### PR TITLE
Retain the final timestamp for each request

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210211235551-a548c32e7fbe
-	github.com/akitasoftware/akita-libs v0.0.0-20210223181725-01dbb1695042
+	github.com/akitasoftware/akita-libs v0.0.0-20210407224000-012a0baea6d8
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0
 	github.com/gdamore/tcell/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210218235336-ec78331a03e6 h1:IYCK6O
 github.com/akitasoftware/akita-libs v0.0.0-20210218235336-ec78331a03e6/go.mod h1:mVUHeMwkPLko0KJY9+8Mym0JILJxN8bqLq/hI0a9veo=
 github.com/akitasoftware/akita-libs v0.0.0-20210223181725-01dbb1695042 h1:Z2CIf11Ff0Ohgq+if3QHnHEKQyD4D+SAXC1W9MV0UOk=
 github.com/akitasoftware/akita-libs v0.0.0-20210223181725-01dbb1695042/go.mod h1:mVUHeMwkPLko0KJY9+8Mym0JILJxN8bqLq/hI0a9veo=
+github.com/akitasoftware/akita-libs v0.0.0-20210407224000-012a0baea6d8 h1:kjGWOffRBlI2hZRe7c3HhSIYDJkkZFHqAjDD1lSHvVw=
+github.com/akitasoftware/akita-libs v0.0.0-20210407224000-012a0baea6d8/go.mod h1:mVUHeMwkPLko0KJY9+8Mym0JILJxN8bqLq/hI0a9veo=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPBv9mohlLY3EzstN6ds8kxcc0lwq1F541115FP7xY=

--- a/pcap/http_timing_test.go
+++ b/pcap/http_timing_test.go
@@ -1,0 +1,48 @@
+package pcap
+
+import (
+	"testing"
+	"time"
+
+	"github.com/akitasoftware/akita-libs/akinet"
+	akihttp "github.com/akitasoftware/akita-libs/akinet/http"
+	"github.com/google/gopacket"
+)
+
+func TestHTTPRequestTimes(t *testing.T) {
+	// create an abnormal trace with one byte every 100ms
+	startTime := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	input := "POST /foo HTTP/1.1\r\nHost: example.com\r\nContent-Length: 9\r\n\r\nfoobarbaz"
+
+	pkts := make([]gopacket.Packet, len(input))
+	for i, _ := range pkts {
+		pkts[i] = CreatePacketWithSeq(ip1, ip2, port1, port2, []byte{input[i]}, uint32(i))
+		pkts[i].Metadata().CaptureInfo.Timestamp = startTime.Add(time.Duration(i*100) * time.Millisecond)
+	}
+
+	closeChan := make(chan struct{})
+	defer close(closeChan)
+	out, err := setupParseFromInterface(fakePcap(pkts), closeChan, akihttp.NewHTTPRequestParserFactory())
+	if err != nil {
+		t.Errorf("unexpected error setting up listener: %v", err)
+		return
+	}
+
+	var actual []akinet.ParsedNetworkTraffic
+	for pnt := range out {
+		actual = append(actual, pnt)
+	}
+
+	if len(actual) != 1 {
+		t.Fatalf("Expected 1 parsed object, got %v", len(actual))
+	}
+
+	if actual[0].ObservationTime != startTime {
+		t.Fatalf("Observation time %v does not match %v", actual[0].ObservationTime, startTime)
+	}
+
+	endTime := startTime.Add(time.Duration((len(input)-1)*100) * time.Millisecond)
+	if actual[0].FinalPacketTime != endTime {
+		t.Fatalf("Final time %v does not match %v", actual[0].FinalPacketTime, endTime)
+	}
+}

--- a/pcap/pcap_replay_test.go
+++ b/pcap/pcap_replay_test.go
@@ -131,6 +131,7 @@ func readFileOrDie(path string) []byte {
 
 func removeNonDeterministicField(p *akinet.ParsedNetworkTraffic) {
 	p.ObservationTime = time.Time{}
+	p.FinalPacketTime = time.Time{}
 	switch c := p.Content.(type) {
 	case akinet.HTTPRequest:
 		c.StreamID = uuid.Nil
@@ -221,6 +222,7 @@ func TestPcapHTTP(t *testing.T) {
 	}
 
 	for _, c := range testCases {
+		t.Logf("testing %q", c.pcapFile)
 		collected, err := readFromPcapFile(c.pcapFile)
 		if err != nil {
 			t.Errorf("[%s] got unexpected error: %v", c.name, err)

--- a/pcap/stream_test.go
+++ b/pcap/stream_test.go
@@ -31,6 +31,7 @@ func dummyPNT(c akinet.ParsedNetworkContent) akinet.ParsedNetworkTraffic {
 		DstPort:         81,
 		Content:         c,
 		ObservationTime: testTime,
+		FinalPacketTime: testTime,
 	}
 }
 
@@ -92,7 +93,7 @@ func runTCPFlowTestCase(c tcpFlowTestCase) error {
 		sg.keepFrom = -1
 		sg.isEnd = i == len(c.inputs)-1
 
-		f.reassembled(sg)
+		f.reassembled(sg, sg.AssemblerContext(0))
 
 		// ScatterGather bookkeeping
 		if sg.keepFrom >= 0 {


### PR DESCRIPTION
Depends on https://github.com/akitasoftware/akita-libs/pull/12

Previously if a ParsedNetworkTraffic object spanned multiple packets, the timestamp on the first packet was recorded in ObservationTime. This change records the timestamp on the final packet in the sequence as well, which corresponds to the time when a request has completely arrived at a server.

Method signatures have changed to pass the reassembly.AssemblerContext through, which was previously ignored.
