### PR TITLE
Add support for uploading HAR files to `upload`

### DIFF
--- a/apispec/har.go
+++ b/apispec/har.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Extract witnesses from a local HAR file and send them to the collector.
-func processHAR(inboundCol, outboundCol trace.Collector, p string) error {
+func ProcessHAR(inboundCol, outboundCol trace.Collector, p string) error {
 	harContent, err := hl.LoadCustomHARFromFile(p)
 	if err != nil {
 		return errors.Wrapf(err, "failed to load HAR file %s", p)

--- a/apispec/run.go
+++ b/apispec/run.go
@@ -421,7 +421,7 @@ func uploadLocalTraces(domain string, clientID akid.ClientID, svc akid.ServiceID
 		defer inboundCol.Close()
 		defer outboundCol.Close()
 
-		if err := processHAR(inboundCol, outboundCol, p); err != nil {
+		if err := ProcessHAR(inboundCol, outboundCol, p); err != nil {
 			return nil, errors.Wrapf(err, "failed to process HAR file %s", p)
 		} else {
 			lrns = append(lrns, lrn)

--- a/cmd/internal/man/upload_page.go
+++ b/cmd/internal/man/upload_page.go
@@ -1,31 +1,51 @@
 package man
 
+import "github.com/akitasoftware/akita-cli/cmd/internal/upload"
+
 var uploadPage = `
 # === upload ===
 
 # Description
 
-Uploads an OpenAPI 3 spec to Akita Cloud.
-
-Once uploaded, the command prints the uploaded spec's Akita URI to stdout.
+Uploads an OpenAPI 3 spec or a HAR file to Akita Cloud. When the upload completes, the command prints the uploaded object's Akita URI to stdout.
 
 # Examples
 
-## akita upload --service my-service /path/to/spec.yaml
+## akita upload --dest akita://my-service:spec: /path/to/spec.yaml
+
+Upload the given file as a spec for my-service. A new name is generated for the spec.
+
+## akita upload --dest akita://my-service:spec:spec1 /path/to/spec.yaml
+
+Upload the given file as a spec for my-service. The uploaded spec will be called "spec1".
+
+## akita upload --dest akita://my-service:trace: /path/to/trace1.har /path/to/trace2.har
+
+Upload the given files as a trace for my-service. A new name is generated for the trace.
+
+## akita upload --dest akita://my-service:trace:trace1 /path/to/trace1.har /path/to/trace2.har
+
+Upload the given files as a trace for my-service. The uploaded trace will be called "trace1".
 
 # Required Flags
 
-## --service string
+## --dest akita_uri
 
-The Akita service where you want to upload this spec to.
+The Akita URI where you want to upload to, specifying the Akita service, the type of the upload, and optionally, the name of the upload.
+
+If a name is provided and an object already exists with that name, an error occurs, unless '--append' or '--overwrite' is also specified.
 
 # Optional Flags
 
-## --name string
+## --append
 
-A unique name to assign to the uploaded spec.
+Add the upload to an existing Akita trace. If a trace with the given name doesn't already exist, it will be created and a warning will be printed to stderr. Only relevant to trace uploads.
+
+## --include-trackers
+
+By default, Akita automatically filters out requests to common third-party trackers in the trace. Use this flag to include them. Only relevant to trace uploads.
 
 ## --timeout duration
 
-Timeout for uploading and processing the spec.
+Timeout for transferring and processing the upload. Defaults to ` + upload.DEFAULT_TIMEOUT.String() + `.
 `

--- a/cmd/internal/man/upload_page.go
+++ b/cmd/internal/man/upload_page.go
@@ -11,7 +11,7 @@ Uploads an OpenAPI 3 spec or a HAR file to Akita Cloud. When the upload complete
 
 # Examples
 
-## akita upload --dest akita://my-service:spec: /path/to/spec.yaml
+## akita upload --dest akita://my-service:spec /path/to/spec.yaml
 
 Upload the given file as a spec for my-service. A new name is generated for the spec.
 
@@ -19,7 +19,7 @@ Upload the given file as a spec for my-service. A new name is generated for the 
 
 Upload the given file as a spec for my-service. The uploaded spec will be called "spec1".
 
-## akita upload --dest akita://my-service:trace: /path/to/trace1.har /path/to/trace2.har
+## akita upload --dest akita://my-service:trace /path/to/trace1.har /path/to/trace2.har
 
 Upload the given files as a trace for my-service. A new name is generated for the trace.
 

--- a/cmd/internal/man/upload_page.go
+++ b/cmd/internal/man/upload_page.go
@@ -33,7 +33,7 @@ Upload the given files as a trace for my-service. The uploaded trace will be cal
 
 The Akita URI where you want to upload to, specifying the Akita service, the type of the upload, and optionally, the name of the upload.
 
-If a name is provided and an object already exists with that name, an error occurs, unless '--append' or '--overwrite' is also specified.
+If a name is provided and an object already exists with that name, an error occurs, unless '--append' is also specified.
 
 # Optional Flags
 

--- a/cmd/internal/upload/flags.go
+++ b/cmd/internal/upload/flags.go
@@ -2,29 +2,46 @@ package upload
 
 import (
 	"time"
-
-	"github.com/spf13/cobra"
 )
 
 var (
-	// Required flags
-	serviceFlag string
+	// Required flags – exactly one of these must be specified.
+	destFlag    string
+	serviceFlag string // deprecated
 
 	// Optional flags
-	specNameFlag      string
-	uploadTimeoutFlag time.Duration
+	specNameFlag string // deprecated
+
+	appendFlag          bool
+	includeTrackersFlag bool
+	overwriteFlag       bool
+	uploadTimeoutFlag   time.Duration
+
+	pluginsFlag []string
 )
+
+const DEFAULT_TIMEOUT = 3 * time.Minute
 
 func init() {
 	//
 	// Required Flags
 	//
 	Cmd.Flags().StringVar(
+		&destFlag,
+		"dest",
+		"",
+		"The Akita URI to upload to. The URI must specify at least the service name and the object type for the upload.")
+	// Not marked as required because users can still fall back on the deprecated
+	// --service flag.
+	//
+	//cobra.MarkFlagRequired(Cmd.Flags(), "dest")
+
+	Cmd.Flags().StringVar(
 		&serviceFlag,
 		"service",
 		"",
-		"Serivce that the spec belongs to.")
-	cobra.MarkFlagRequired(Cmd.Flags(), "service")
+		"Service that the spec belongs to.")
+	Cmd.Flags().MarkDeprecated("service", "use --dest instead.")
 
 	//
 	// Optional Flags
@@ -34,10 +51,32 @@ func init() {
 		"name",
 		"",
 		"A custom name for the spec.")
+	Cmd.Flags().MarkDeprecated("name", "use --dest instead.")
+
+	Cmd.Flags().BoolVar(
+		&appendFlag,
+		"append",
+		false,
+		"Add the upload to an existing Akita trace.")
+
+	Cmd.Flags().BoolVar(
+		&includeTrackersFlag,
+		"include-trackers",
+		false,
+		"If set to true, disables automatic filtering of requests to third-party trackers that are recorded in traces.",
+	)
 
 	Cmd.Flags().DurationVar(
 		&uploadTimeoutFlag,
 		"timeout",
-		3*time.Minute,
+		DEFAULT_TIMEOUT,
 		"Timeout for spec upload.")
+
+	Cmd.Flags().StringSliceVar(
+		&pluginsFlag,
+		"plugins",
+		nil,
+		"Paths of third-party Akita plugins. These are executed in the order given.",
+	)
+	Cmd.Flags().MarkHidden("plugins")
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210211235551-a548c32e7fbe
-	github.com/akitasoftware/akita-libs v0.0.0-20210407224000-012a0baea6d8
+	github.com/akitasoftware/akita-libs v0.0.0-20210415202933-9e282d2a5e2d
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0
 	github.com/gdamore/tcell/v2 v2.1.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210211235551-a548c32e7fbe
-	github.com/akitasoftware/akita-libs v0.0.0-20210415202933-9e282d2a5e2d
+	github.com/akitasoftware/akita-libs v0.0.0-20210415205549-9ebef731e49b
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0
 	github.com/gdamore/tcell/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210223181725-01dbb1695042 h1:Z2CIf1
 github.com/akitasoftware/akita-libs v0.0.0-20210223181725-01dbb1695042/go.mod h1:mVUHeMwkPLko0KJY9+8Mym0JILJxN8bqLq/hI0a9veo=
 github.com/akitasoftware/akita-libs v0.0.0-20210407224000-012a0baea6d8 h1:kjGWOffRBlI2hZRe7c3HhSIYDJkkZFHqAjDD1lSHvVw=
 github.com/akitasoftware/akita-libs v0.0.0-20210407224000-012a0baea6d8/go.mod h1:mVUHeMwkPLko0KJY9+8Mym0JILJxN8bqLq/hI0a9veo=
+github.com/akitasoftware/akita-libs v0.0.0-20210415202933-9e282d2a5e2d h1:dIwPFN+rezQvlGAD449Dtu1Eg21sYJRVfMFr1PUcvNk=
+github.com/akitasoftware/akita-libs v0.0.0-20210415202933-9e282d2a5e2d/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPBv9mohlLY3EzstN6ds8kxcc0lwq1F541115FP7xY=

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210407224000-012a0baea6d8 h1:kjGWOf
 github.com/akitasoftware/akita-libs v0.0.0-20210407224000-012a0baea6d8/go.mod h1:mVUHeMwkPLko0KJY9+8Mym0JILJxN8bqLq/hI0a9veo=
 github.com/akitasoftware/akita-libs v0.0.0-20210415202933-9e282d2a5e2d h1:dIwPFN+rezQvlGAD449Dtu1Eg21sYJRVfMFr1PUcvNk=
 github.com/akitasoftware/akita-libs v0.0.0-20210415202933-9e282d2a5e2d/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
+github.com/akitasoftware/akita-libs v0.0.0-20210415205549-9ebef731e49b h1:ZOriqpiMUznsmdu+nDZcz+TUwvmvBjtPQfzTFlLpzNk=
+github.com/akitasoftware/akita-libs v0.0.0-20210415205549-9ebef731e49b/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPBv9mohlLY3EzstN6ds8kxcc0lwq1F541115FP7xY=

--- a/upload/args.go
+++ b/upload/args.go
@@ -3,7 +3,9 @@ package upload
 import (
 	"time"
 
+	"github.com/akitasoftware/akita-cli/plugin"
 	"github.com/akitasoftware/akita-libs/akid"
+	"github.com/akitasoftware/akita-libs/akiuri"
 )
 
 type Args struct {
@@ -11,10 +13,12 @@ type Args struct {
 	ClientID akid.ClientID
 	Domain   string
 
-	Service  string
-	SpecPath string
+	DestURI   akiuri.URI
+	FilePaths []string
 
 	// Optional args
-	SpecName      string
-	UploadTimeout time.Duration
+	Append          bool
+	IncludeTrackers bool
+	UploadTimeout   time.Duration
+	Plugins         []plugin.AkitaPlugin
 }

--- a/upload/run.go
+++ b/upload/run.go
@@ -4,64 +4,133 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"strings"
 
-	randomdata "github.com/Pallinder/go-randomdata"
-	"github.com/google/uuid"
 	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 
+	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/akita-libs/akiuri"
 	"github.com/akitasoftware/akita-libs/api_schema"
 
+	"github.com/akitasoftware/akita-cli/apispec"
 	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-cli/rest"
+	"github.com/akitasoftware/akita-cli/trace"
 	"github.com/akitasoftware/akita-cli/util"
 )
 
 func Run(args Args) error {
 	// Resolve ServiceID
 	frontClient := rest.NewFrontClient(args.Domain, args.ClientID)
-	svc, err := util.GetServiceIDByName(frontClient, args.Service)
+	svc, err := util.GetServiceIDByName(frontClient, args.DestURI.ServiceName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to resolve service name %q", args.Service)
+		return errors.Wrapf(err, "failed to resolve service name %q", args.DestURI.ServiceName)
 	}
 
-	// Read spec content.
-	content, err := ioutil.ReadFile(args.SpecPath)
-	if err != nil {
-		return errors.Wrapf(err, "failed to read spec from %q", args.SpecPath)
+	// Determine the object's name.
+	objectName := args.DestURI.ObjectName
+	if objectName == "" {
+		switch args.DestURI.ObjectType {
+		case akiuri.SPEC:
+			objectName = util.RandomAPIModelName()
+		case akiuri.TRACE:
+			objectName = util.RandomLearnSessionName()
+		default:
+			return errors.Errorf("unknown object type: %q", args.DestURI.ObjectType)
+		}
 	}
 
-	// Upload
+	// Do the upload.
+	learnClient := rest.NewLearnClient(args.Domain, args.ClientID, svc)
+	switch args.DestURI.ObjectType {
+	case akiuri.SPEC:
+		if err := uploadSpec(learnClient, args, objectName); err != nil {
+			return err
+		}
+
+	case akiuri.TRACE:
+		if err := uploadTraces(learnClient, args, svc, objectName); err != nil {
+			return err
+		}
+
+	default:
+		return errors.Errorf("unknown object type: %q", args.DestURI.ObjectType)
+	}
+
+	// Display the resulting URI to the user.
+	uri := akiuri.URI{
+		ServiceName: args.DestURI.ServiceName,
+		ObjectType:  args.DestURI.ObjectType,
+		ObjectName:  objectName,
+	}
+	printer.Stderr.Infof("%s 🎉\n", aurora.Green("Success!"))
+	printer.Stderr.Infof("Your upload is available as: ")
+	fmt.Println(uri.String()) // print URI to stdout for easy scripting
+
+	return nil
+}
+
+func uploadSpec(learnClient rest.LearnClient, args Args, specName string) error {
+	// Read file content.
+	fileContent, err := ioutil.ReadFile(args.FilePaths[0])
+	if err != nil {
+		return errors.Wrapf(err, "failed to read %q", args.FilePaths[0])
+	}
+
 	printer.Stderr.Infof("Uploading...\n")
-	specName := args.SpecName
-	if specName == "" {
-		specName = strings.Join([]string{
-			randomdata.Adjective(),
-			randomdata.Noun(),
-			uuid.New().String()[0:8],
-		}, "-")
-	}
 	req := api_schema.UploadSpecRequest{
 		Name:    specName,
-		Content: string(content),
+		Content: string(fileContent),
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), args.UploadTimeout)
 	defer cancel()
-	learnClient := rest.NewLearnClient(args.Domain, args.ClientID, svc)
 	if _, err := learnClient.UploadSpec(ctx, req); err != nil {
 		return errors.Wrap(err, "upload failed")
 	}
 
-	uri := akiuri.URI{
-		ServiceName: args.Service,
-		ObjectType:  akiuri.SPEC,
-		ObjectName:  specName,
+	return nil
+}
+
+func uploadTraces(learnClient rest.LearnClient, args Args, serviceID akid.ServiceID, traceName string) error {
+	// Attempt to get the trace ID. First, see if the trace already exists.
+	traceID, err := util.GetLearnSessionIDByName(learnClient, traceName)
+	if err != nil {
+		// XXX Assume the error means that the session doesn't already exist. We
+		// XXX should check this assumption, but errors appear to be too opaque to
+		// XXX do this easily.
+
+		// If we are supposed to be appending to an existing trace, warn that the
+		// trace doesn't yet exist.
+		if args.Append {
+			printer.Stderr.Warningf("trace %q doesn't yet exist; creating it\n", traceName)
+		}
+
+		// Attempt to create the trace.
+		printer.Stderr.Infof("Creating trace...\n")
+		tags := map[string]string{}
+		traceID, err = util.NewLearnSession(args.Domain, args.ClientID, serviceID, traceName, tags, nil)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create trace %q", traceName)
+		}
+	} else if !args.Append {
+		// The trace already exists, but the user has not asked to append to it. Cowardly avoid accidentally modifying the trace.
+		return errors.Errorf("trace %q already exists. Use \"--append\" if you wish to add events to the trace", traceName)
 	}
-	printer.Stderr.Infof("%s 🎉\n", aurora.Green("Success!"))
-	printer.Stderr.Infof("Your API spec is available as: ")
-	fmt.Println(uri.String()) // print URI to stdout for easy scripting
+
+	// Create collector for ingesting the trace events.
+	inboundCollector := trace.NewBackendCollector(serviceID, traceID, learnClient, api_schema.Inbound, args.Plugins)
+	outboundCollector := trace.NewBackendCollector(serviceID, traceID, learnClient, api_schema.Outbound, args.Plugins)
+	if !args.IncludeTrackers {
+		inboundCollector = trace.New3PTrackerFilterCollector(inboundCollector)
+		outboundCollector = trace.New3PTrackerFilterCollector(outboundCollector)
+	}
+
+	for _, harFileName := range args.FilePaths {
+		printer.Stderr.Infof("Uploading %q...\n", harFileName)
+		if err := apispec.ProcessHAR(inboundCollector, outboundCollector, harFileName); err != nil {
+			return errors.Wrapf(err, "failed to process HAR file %q", harFileName)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
This adds support for uploading HAR files to the `upload` command. The old `--service` and `--name` options are now deprecated in favour of `--dest`, which takes in Akita URIs.

When uploading traces, the user may provide multiple files to upload to a single trace. Plugins and removal of third-party trackers is supported. If the specified trace already exists, the user must specify `--append` to modify the trace. If `--append` is used when the trace doesn't yet exist, the trace is created and a warning is printed to stderr.