### PR TITLE
Resolve race conditions in BackendCollector.

### DIFF
--- a/learn/learn_test.go
+++ b/learn/learn_test.go
@@ -194,7 +194,7 @@ func TestPairPartialWitness(t *testing.T) {
 			inputs: []akinet.ParsedNetworkTraffic{helloResp},
 			expected: []*pb.Witness{
 				&pb.Witness{
-					Method: newMethod(nil, []*pb.Data{helloRespData}, unknownHTTPMethodMeta),
+					Method: newMethod(nil, []*pb.Data{helloRespData}, UnknownHTTPMethodMeta()),
 				},
 			},
 		},
@@ -206,7 +206,7 @@ func TestPairPartialWitness(t *testing.T) {
 			inputs: []akinet.ParsedNetworkTraffic{largeIntResp},
 			expected: []*pb.Witness{
 				&pb.Witness{
-					Method: newMethod(nil, []*pb.Data{largeIntRespData}, unknownHTTPMethodMeta),
+					Method: newMethod(nil, []*pb.Data{largeIntRespData}, UnknownHTTPMethodMeta()),
 				},
 			},
 		},

--- a/learn/parse_http_test.go
+++ b/learn/parse_http_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	as "github.com/akitasoftware/akita-ir/go/api_spec"
 	"github.com/akitasoftware/akita-libs/akinet"
 	"github.com/akitasoftware/akita-libs/spec_util"
-	as "github.com/akitasoftware/akita-ir/go/api_spec"
 )
 
 const (
@@ -58,9 +58,9 @@ var testMultipartFormData = strings.Join([]string{
 
 func newTestBodySpec(statusCode int) *as.Data {
 	return newTestBodySpecFromStruct(statusCode, as.HTTPBody_JSON, map[string]*as.Data{
-		"name":         dataFromPrimitive(spec_util.NewPrimitiveString("prince")),
-		"number_teeth": dataFromPrimitive(spec_util.NewPrimitiveInt64(9000)),
-		"dog":          dataFromPrimitive(spec_util.NewPrimitiveBool(true)),
+		"name":                             dataFromPrimitive(spec_util.NewPrimitiveString("prince")),
+		"number_teeth":                     dataFromPrimitive(spec_util.NewPrimitiveInt64(9000)),
+		"dog":                              dataFromPrimitive(spec_util.NewPrimitiveBool(true)),
 		"canadian_social_insurance_number": dataFromPrimitive(annotateIfSensitiveForTest(true, spec_util.NewPrimitiveInt64(378734493671000))),
 		"homes": dataFromList(
 			dataFromPrimitive(spec_util.NewPrimitiveString("burbank, ca")),
@@ -238,7 +238,7 @@ func TestParseHTTPRequest(t *testing.T) {
 			expectedMethod: newMethod(
 				nil,
 				[]*as.Data{newTestBodySpec(200)},
-				unknownHTTPMethodMeta,
+				UnknownHTTPMethodMeta(),
 			),
 		},
 		&parseTest{
@@ -262,7 +262,7 @@ func TestParseHTTPRequest(t *testing.T) {
 					newDataHeader("X-Codename", 500, spec_util.NewPrimitiveString("Operation Paperclip"), false),
 					newDataHeader("X-FullOfLampreys", 500, spec_util.NewPrimitiveString(fakePassword), true),
 				},
-				unknownHTTPMethodMeta,
+				UnknownHTTPMethodMeta(),
 			),
 		},
 		&parseTest{
@@ -287,7 +287,7 @@ func TestParseHTTPRequest(t *testing.T) {
 					newDataCookie("manufacture", 404, false, "high pressure extrusion"),
 					newDataCookie("concave", 404, true, fakePassword),
 				},
-				unknownHTTPMethodMeta,
+				UnknownHTTPMethodMeta(),
 			),
 		},
 		&parseTest{
@@ -314,7 +314,7 @@ func TestParseHTTPRequest(t *testing.T) {
 						},
 					),
 				},
-				unknownHTTPMethodMeta,
+				UnknownHTTPMethodMeta(),
 			),
 		},
 		&parseTest{
@@ -335,7 +335,7 @@ func TestParseHTTPRequest(t *testing.T) {
 						dataFromPrimitive(spec_util.NewPrimitiveBytes([]byte("prince is a good boy"))),
 					),
 				},
-				unknownHTTPMethodMeta,
+				UnknownHTTPMethodMeta(),
 			),
 		},
 		&parseTest{
@@ -365,7 +365,7 @@ prince:
 						},
 					),
 				},
-				unknownHTTPMethodMeta,
+				UnknownHTTPMethodMeta(),
 			),
 		},
 		&parseTest{
@@ -388,7 +388,7 @@ prince:
 						},
 					),
 				},
-				unknownHTTPMethodMeta,
+				UnknownHTTPMethodMeta(),
 			),
 		},
 		&parseTest{
@@ -412,7 +412,7 @@ prince:
 						},
 					),
 				},
-				unknownHTTPMethodMeta,
+				UnknownHTTPMethodMeta(),
 			),
 		},
 		&parseTest{
@@ -437,7 +437,7 @@ prince:
 						},
 					),
 				},
-				unknownHTTPMethodMeta,
+				UnknownHTTPMethodMeta(),
 			),
 		},
 		&parseTest{
@@ -459,7 +459,7 @@ prince:
 				[]*as.Data{
 					newDataHeader("X-Charming-Level", 200, spec_util.NewPrimitiveString("extreme"), false),
 				},
-				unknownHTTPMethodMeta,
+				UnknownHTTPMethodMeta(),
 			),
 		},
 		&parseTest{

--- a/learn/util_test.go
+++ b/learn/util_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
+	as "github.com/akitasoftware/akita-ir/go/api_spec"
+	pb "github.com/akitasoftware/akita-ir/go/api_spec"
 	"github.com/akitasoftware/akita-libs/akinet"
 	"github.com/akitasoftware/akita-libs/pbhash"
 	"github.com/akitasoftware/akita-libs/spec_util"
-	as "github.com/akitasoftware/akita-ir/go/api_spec"
-	pb "github.com/akitasoftware/akita-ir/go/api_spec"
 )
 
 const (
@@ -99,7 +99,7 @@ func newTestHTTPResponse(
 }
 
 func newMethod(argsData []*pb.Data, responsesData []*pb.Data, meta *pb.MethodMeta) *pb.Method {
-	m := &pb.Method{Meta: meta, Id: unassignedHTTPID}
+	m := &pb.Method{Meta: meta, Id: UnassignedHTTPID()}
 	if argsData != nil {
 		m.Args = map[string]*pb.Data{}
 		for _, v := range argsData {

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -117,13 +118,14 @@ type BackendCollector struct {
 	dir            kgxapi.NetworkDirection
 
 	// Cache un-paired partial witnesses by pair key.
-	pairCache map[akid.WitnessID]*witnessWithInfo
+	// akid.WitnessID -> *witnessWithInfo
+	pairCache sync.Map
 
 	// Batch of witnesses pending upload.
 	uploadBatch *batcher.InMemory
 
-	// Time when last process call was made.
-	lastProcessTime time.Time
+	// Channel controlling periodic cache flush
+	flushDone chan struct{}
 
 	plugins []plugin.AkitaPlugin
 }
@@ -136,7 +138,7 @@ func NewBackendCollector(svc akid.ServiceID,
 		learnSessionID: lrn,
 		learnClient:    lc,
 		dir:            dir,
-		pairCache:      map[akid.WitnessID]*witnessWithInfo{},
+		flushDone:      make(chan struct{}),
 		plugins:        plugins,
 	}
 
@@ -148,15 +150,6 @@ func NewBackendCollector(svc akid.ServiceID,
 }
 
 func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
-	defer func() {
-		// Lazily flush pair cache.
-		now := time.Now()
-		if !c.lastProcessTime.IsZero() && now.Sub(c.lastProcessTime) > pairCacheCleanupInterval {
-			c.flushPairCache(now.Add(-1 * pairCacheExpiration))
-		}
-		c.lastProcessTime = now
-	}()
-
 	var isRequest bool
 	var partial *learn.PartialWitness
 	var parseHTTPErr error
@@ -176,12 +169,14 @@ func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
 		return nil
 	}
 
-	if pair, ok := c.pairCache[partial.PairKey]; ok {
+	if val, ok := c.pairCache.Load(partial.PairKey); ok {
+		pair := val.(*witnessWithInfo)
+
 		// Combine the pair, merging the result into the existing item
 		// rather than the new partial.
 		learn.MergeWitness(pair.witness, partial.Witness)
 		pair.computeProcessingLatency(isRequest, t)
-		delete(c.pairCache, partial.PairKey)
+		c.pairCache.Delete(partial.PairKey)
 
 		// If partial is the request, flip the src/dst in the pair before
 		// reporting.
@@ -205,7 +200,7 @@ func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
 		}
 		// Store whichever timestamp brackets the processing interval.
 		w.recordTimestamp(isRequest, t)
-		c.pairCache[partial.PairKey] = w
+		c.pairCache.Store(partial.PairKey, w)
 
 	}
 	return nil
@@ -227,6 +222,7 @@ func (c *BackendCollector) queueUpload(w *witnessWithInfo) {
 }
 
 func (c *BackendCollector) Close() error {
+	close(c.flushDone)
 	c.flushPairCache(time.Now())
 	c.uploadBatch.Close()
 	return nil
@@ -252,11 +248,27 @@ func (c *BackendCollector) uploadWitnesses(in []interface{}) {
 	}
 }
 
-func (c *BackendCollector) flushPairCache(cutoffTime time.Time) {
-	for k, e := range c.pairCache {
-		if e.observationTime.Before(cutoffTime) {
-			c.queueUpload(e)
-			delete(c.pairCache, k)
+func (c *BackendCollector) periodicFlush() {
+	ticker := time.NewTicker(pairCacheCleanupInterval)
+
+	for true {
+		select {
+		case <-ticker.C:
+			c.flushPairCache(time.Now().Add(-1 * pairCacheExpiration))
+		case <-c.flushDone:
+			ticker.Stop()
+			break
 		}
 	}
+}
+
+func (c *BackendCollector) flushPairCache(cutoffTime time.Time) {
+	c.pairCache.Range(func(k, v interface{}) bool {
+		e := v.(*witnessWithInfo)
+		if e.observationTime.Before(cutoffTime) {
+			c.queueUpload(e)
+			c.pairCache.Delete(k)
+		}
+		return true
+	})
 }

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -169,14 +169,13 @@ func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
 		return nil
 	}
 
-	if val, ok := c.pairCache.Load(partial.PairKey); ok {
+	if val, ok := c.pairCache.LoadAndDelete(partial.PairKey); ok {
 		pair := val.(*witnessWithInfo)
 
 		// Combine the pair, merging the result into the existing item
 		// rather than the new partial.
 		learn.MergeWitness(pair.witness, partial.Witness)
 		pair.computeProcessingLatency(isRequest, t)
-		c.pairCache.Delete(partial.PairKey)
 
 		// If partial is the request, flip the src/dst in the pair before
 		// reporting.

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -146,6 +146,7 @@ func NewBackendCollector(svc akid.ServiceID,
 		col.uploadWitnesses,
 		uploadBatchMaxSize,
 		uploadBatchFlushDuration)
+	go col.periodicFlush()
 	return col
 }
 

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -249,14 +249,14 @@ func TestMultipleInterfaces(t *testing.T) {
 	bc := NewBackendCollector(fakeSvc, fakeLrn, mockClient, kgxapi.Inbound, nil)
 
 	var wg sync.WaitGroup
-	fakeTrace := func(count int) {
+	fakeTrace := func(count int, start_seq int) {
 		for i := 0; i < count; i++ {
 			streamID := uuid.New()
 			// Re-using the example above
 			req := akinet.ParsedNetworkTraffic{
 				Content: akinet.HTTPRequest{
 					StreamID: streamID,
-					Seq:      1203,
+					Seq:      start_seq + count,
 					Method:   "POST",
 					URL: &url.URL{
 						Path: "/v1/doggos",
@@ -272,7 +272,7 @@ func TestMultipleInterfaces(t *testing.T) {
 			resp := akinet.ParsedNetworkTraffic{
 				Content: akinet.HTTPResponse{
 					StreamID:   streamID,
-					Seq:        1203,
+					Seq:        start_seq + count,
 					StatusCode: 200,
 					Header: map[string][]string{
 						"Content-Type": {"application/json"},
@@ -286,8 +286,8 @@ func TestMultipleInterfaces(t *testing.T) {
 	}
 
 	wg.Add(2)
-	go fakeTrace(100)
-	go fakeTrace(200)
+	go fakeTrace(100, 1000)
+	go fakeTrace(200, 2000)
 
 	wg.Wait()
 }


### PR DESCRIPTION
Replace map[] with a sync.Map.
Move periodic flush to its own goroutine.

The unit test is not too impressive right now but I intend to use it to test packet count per interface, when that goes in.