### PR TITLE
Diagnostic information when trace is empty

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -76,6 +76,9 @@ type Args struct {
 	Plugins []plugin.AkitaPlugin
 }
 
+// DumpPacketCounters prints the accumulated packet counts per interface and per port,
+// at Debug level, to stderr.  The first argument should be the keyed by interface names (as created
+// in the Run function below); all we really need are those names.
 func DumpPacketCounters(interfaces map[string]interfaceInfo, inboundSummary *trace.PacketCountSummary, outboundSummary *trace.PacketCountSummary) {
 	// Using a map gives inconsistent order when iterating (even on the same run!)
 	directions := []kgxapi.NetworkDirection{kgxapi.Inbound, kgxapi.Outbound}
@@ -84,8 +87,7 @@ func DumpPacketCounters(interfaces map[string]interfaceInfo, inboundSummary *tra
 		toReport = append(toReport, outboundSummary)
 	}
 
-	// Debugging info: packets per interface and prot
-	printer.Stderr.Debugf("==================================\n")
+	printer.Stderr.Debugf("===============================================\n")
 	printer.Stderr.Debugf("Packets per interface:\n")
 	printer.Stderr.Debugf("%15v %8v %7v %5v %5v %5v\n", "interface", "dir", "packets", "req", "resp", "unk")
 	for n := range interfaces {
@@ -102,7 +104,7 @@ func DumpPacketCounters(interfaces map[string]interfaceInfo, inboundSummary *tra
 		}
 	}
 
-	printer.Stderr.Debugf("==================================\n")
+	printer.Stderr.Debugf("===============================================\n")
 	printer.Stderr.Debugf("Packets per port:\n")
 	printer.Stderr.Debugf("%8v %7v %5v %5v %5v\n", "port", "packets", "req", "resp", "unk")
 	for i, summary := range toReport {
@@ -128,7 +130,8 @@ func DumpPacketCounters(interfaces map[string]interfaceInfo, inboundSummary *tra
 		}
 	}
 
-	printer.Stderr.Debugf("==================================\n")
+	printer.Stderr.Debugf("===============================================\n")
+
 }
 
 func Run(args Args) error {

--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -400,7 +400,7 @@ func Run(args Args) error {
 			printer.Stderr.Infof( "https://docs.akita.software/docs/collect-client-side-traffic-2\n" )
 		}
 		printer.Stderr.Errorf("%s 🛑\n\n", aurora.Red("No inbound HTTP calls captured!"))
-		return errors.New( "incomping API trace is empty" )		
+		return errors.New( "incoming API trace is empty" )		
 	}
 	if totalCount.HTTPRequests == 0 {
 		printer.Stderr.Warningf("%s ⚠\n\n", aurora.Yellow("Saw HTTP requests, but not responses."))

--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -76,6 +76,58 @@ type Args struct {
 	Plugins []plugin.AkitaPlugin
 }
 
+func DumpPacketCounters( interfaces map[string]interfaceInfo, inboundSummary *trace.PacketCountSummary, outboundSummary *trace.PacketCountSummary ) {
+	// Using a map gives inconsistent order when iterating (even on the same run!)
+	directions := []kgxapi.NetworkDirection{ kgxapi.Inbound, kgxapi.Outbound }
+	toReport := []*trace.PacketCountSummary{ inboundSummary }
+	if outboundSummary != nil {
+		toReport = append( toReport, outboundSummary )
+	}
+	
+	// Debugging info: packets per interface and prot
+	printer.Stderr.Debugf("==================================\n" )
+	printer.Stderr.Debugf("Packets per interface:\n")
+	printer.Stderr.Debugf("%15v %8v %7v %5v %5v %5v\n", "interface", "dir", "packets", "req", "resp", "unk")
+	for n := range interfaces {
+		for i, summary := range toReport {
+			count := summary.TotalOnInterface(n)
+			printer.Stderr.Debugf("%15s %8s %7d %5d %5d %5d\n",
+				n,
+				directions[i],
+				count.TCPPackets,
+				count.HTTPRequests,
+				count.HTTPResponses,
+				count.Unparsed,
+			)
+		}
+	}
+
+	printer.Stderr.Debugf("==================================\n" )
+	printer.Stderr.Debugf("Packets per port:\n")
+	printer.Stderr.Debugf("%8v %7v %5v %5v %5v\n", "port", "packets", "req", "resp", "unk")
+	for i, summary := range toReport {
+		if directions[i] == kgxapi.Inbound {
+			printer.Stderr.Debugf( "--------- matching filter --------\n" )
+		} else {
+			printer.Stderr.Debugf( "------- not matching filter ------\n" )
+		}
+		byPort := summary.AllPorts()
+		// We don't really know what's in the BPF filter; we know every packet in inbound
+		// must have matched, but that could be multiple ports, or some other criteria.
+		for _, count := range byPort {
+			printer.Stderr.Debugf("%8d %7d %5d %5d %5d\n",
+				count.SrcPort,
+				count.TCPPackets,
+				count.HTTPRequests,
+				count.HTTPResponses,
+				count.Unparsed,
+			)
+		}
+	}
+	
+	printer.Stderr.Debugf("==================================\n")	
+}
+
 func Run(args Args) error {
 	// Get the interfaces to listen on.
 	interfaces, err := getEligibleInterfaces(args.Interfaces)
@@ -170,7 +222,8 @@ func Run(args Args) error {
 	}
 
 	// Initialize packet counts
-	summary := trace.NewPacketCountSummary()
+	inboundSummary := trace.NewPacketCountSummary()
+	outboundSummary := trace.NewPacketCountSummary()
 
 	// Start collecting
 	var doneWG sync.WaitGroup
@@ -178,11 +231,14 @@ func Run(args Args) error {
 	errChan := make(chan error, len(inboundFilters)+len(outboundFilters)) // buffered enough so it never blocks
 	stop := make(chan struct{})
 	for _, dir := range []kgxapi.NetworkDirection{kgxapi.Inbound, kgxapi.Outbound} {
+		var summary *trace.PacketCountSummary
 		var filters map[string]string
 		if dir == kgxapi.Inbound {
 			filters = inboundFilters
+			summary = inboundSummary
 		} else {
 			filters = outboundFilters
+			summary = outboundSummary
 		}
 
 		for interfaceName, filter := range filters {
@@ -310,20 +366,34 @@ func Run(args Args) error {
 		return errors.Wrap(stopErr, "trace collection failed")
 	}
 
-	printer.Stderr.Infof("%15v %7v %5v %5v %5v\n", "interface", "packets", "req", "resp", "unk")
-	for n := range interfaces {
-		count := summary.TotalOnInterface(n)
-		printer.Stderr.Infof("%15s %7d %5d %5d %5d\n",
-			n,
-			count.TCPPackets,
-			count.HTTPRequests,
-			count.HTTPResponses,
-			count.Unparsed,
-		)
+	if len( outboundFilters ) == 0 {
+		DumpPacketCounters(interfaces, inboundSummary, nil)
+	} else {
+		DumpPacketCounters(interfaces, inboundSummary, outboundSummary)
 	}
-
+	
+	// Check summary to see if the inbound trace will have anything in it.
+	totalCount := inboundSummary.Total()
+	if totalCount.HTTPRequests == 0 && totalCount.HTTPResponses == 0 {
+		// TODO: recognize TLS handshakes and count them separately!
+		if totalCount.Unparsed > 0 {
+			printer.Stderr.Infof("Captured %d TCP packets total; %d unparsed TCP segments.\n",
+				totalCount.TCPPackets, totalCount.Unparsed )
+			printer.Stderr.Infof( "%s\n", aurora.Yellow( "This may mean you are trying to capture HTTPS traffic." ) )
+		}
+		printer.Stderr.Errorf("%s 🛑\n\n", aurora.Red("No inbound HTTP calls captured!"))
+		return errors.New( "inbound trace is empty" )		
+	}
+	if totalCount.HTTPRequests == 0 {
+		printer.Stderr.Warningf("%s ⚠\n\n", aurora.Yellow("Saw HTTP requests, but not responses."))
+		return nil
+	}
+	if totalCount.HTTPResponses == 0 {
+		printer.Stderr.Warningf("%s ⚠\n\n", aurora.Yellow("Saw HTTP responses, but not requests."))
+		return nil
+	}
+		
 	printer.Stderr.Infof("%s 🎉\n\n", aurora.Green("Success!"))
-
 	return nil
 }
 

--- a/apispec/run.go
+++ b/apispec/run.go
@@ -411,8 +411,8 @@ func uploadLocalTraces(domain string, clientID akid.ClientID, svc akid.ServiceID
 			return nil, errors.Wrap(err, "failed to create backend learn session")
 		}
 
-		inboundCol := trace.NewBackendCollector(svc, lrn, learnClient, kgxapi.Inbound, plugins)
-		outboundCol := trace.NewBackendCollector(svc, lrn, learnClient, kgxapi.Outbound, plugins)
+		inboundCol := trace.NewBackendCollector(svc, lrn, learnClient, kgxapi.Inbound, plugins, nil)
+		outboundCol := trace.NewBackendCollector(svc, lrn, learnClient, kgxapi.Outbound, plugins, nil)
 		if !includeTrackers {
 			inboundCol = trace.New3PTrackerFilterCollector(inboundCol)
 			outboundCol = trace.New3PTrackerFilterCollector(outboundCol)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210406221235-f036dc848087
-	github.com/akitasoftware/akita-libs v0.0.0-20210419190609-cf503a9eef00
+	github.com/akitasoftware/akita-libs v0.0.0-20210427004255-e904ace9dd90
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0
 	github.com/gdamore/tcell/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210419184625-30233652df5e h1:iH6Lyy
 github.com/akitasoftware/akita-libs v0.0.0-20210419184625-30233652df5e/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
 github.com/akitasoftware/akita-libs v0.0.0-20210419190609-cf503a9eef00 h1:+Xnb5afqK0wYCzaRcoXXWH4QD5b2qQMsRPpfGDqhwCA=
 github.com/akitasoftware/akita-libs v0.0.0-20210419190609-cf503a9eef00/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
+github.com/akitasoftware/akita-libs v0.0.0-20210427004255-e904ace9dd90 h1:n4JWjbTdcjKeZmJV025GVc9t+z6wjdgNe1wm9WFDbhM=
+github.com/akitasoftware/akita-libs v0.0.0-20210427004255-e904ace9dd90/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPBv9mohlLY3EzstN6ds8kxcc0lwq1F541115FP7xY=

--- a/pcap/net_parse.go
+++ b/pcap/net_parse.go
@@ -20,6 +20,7 @@ const (
 
 // Internal implementation of reassembly.AssemblerContext that include TCP
 // seq and ack numbers.
+
 type assemblerCtxWithSeq struct {
 	ci       gopacket.CaptureInfo
 	seq, ack reassembly.Sequence
@@ -48,13 +49,14 @@ func (fact *tcpStreamFactory) New(netFlow, tcpFlow gopacket.Flow, _ *layers.TCP,
 	return newTCPStream(fact.clock, netFlow, fact.outChan, fact.fs)
 }
 
+// NetworkTrafficObserver is the callback function type for observing
+// packets as they come in to a NetworkTrafficParser.
 type NetworkTrafficObserver func(gopacket.Packet)
 
 type NetworkTrafficParser struct {
-	pcap  pcapWrapper
-	clock clockWrapper
-
-	observer NetworkTrafficObserver
+	pcap     pcapWrapper
+	clock    clockWrapper
+	observer NetworkTrafficObserver // This function is called for every packet.
 }
 
 func NewNetworkTrafficParser() *NetworkTrafficParser {
@@ -65,6 +67,8 @@ func NewNetworkTrafficParser() *NetworkTrafficParser {
 	}
 }
 
+// Replace the current per-packet callback. Should be called before starting
+// ParseFromInterface.
 func (p *NetworkTrafficParser) InstallObserver(observer NetworkTrafficObserver) {
 	p.observer = observer
 }

--- a/trace/stats.go
+++ b/trace/stats.go
@@ -35,9 +35,6 @@ func (c *PacketCounters) Add(d PacketCounters) {
 type PacketCountConsumer interface {
 	// Add an additional measurement to the current count
 	Update(delta PacketCounters)
-
-	// Signal the end of the measurement interval
-	Close()
 }
 
 // Discard the count
@@ -45,9 +42,6 @@ type PacketCountDiscard struct {
 }
 
 func (d *PacketCountDiscard) Update(_ PacketCounters) {
-}
-
-func (d *PacketCountDiscard) Close() {
 }
 
 // A consumer that sums the count by (interface, port) pairs.
@@ -112,9 +106,6 @@ func (s *PacketCountSummary) Update(c PacketCounters) {
 	}
 
 	s.total.Add(c)
-}
-
-func (s *PacketCountSummary) Close() {
 }
 
 func (s *PacketCountSummary) Total() PacketCounters {

--- a/trace/stats.go
+++ b/trace/stats.go
@@ -1,0 +1,172 @@
+package trace
+
+import (
+	"sync"
+
+	"github.com/akitasoftware/akita-cli/pcap"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+// We produce a set of packet counters indexed by interface and
+// port number (*either* source or destination.)
+type PacketCounters struct {
+	// Flow
+	Interface string
+	SrcPort   int
+	DstPort   int
+
+	// Number of events
+	TCPPackets    int
+	HTTPRequests  int
+	HTTPResponses int
+	Unparsed      int
+}
+
+func (c *PacketCounters) Add(d PacketCounters) {
+	c.TCPPackets += d.TCPPackets
+	c.HTTPRequests += d.HTTPRequests
+	c.HTTPResponses += d.HTTPResponses
+	c.Unparsed += d.Unparsed
+}
+
+// A consumer accepts incremental updates in the form
+// of PacketCounters.
+type PacketCountConsumer interface {
+	// Add an additional measurement to the current count
+	Update(delta PacketCounters)
+
+	// Signal the end of the measurement interval
+	Close()
+}
+
+// Discard the count
+type PacketCountDiscard struct {
+}
+
+func (d *PacketCountDiscard) Update(_ PacketCounters) {
+}
+
+func (d *PacketCountDiscard) Close() {
+}
+
+// A consumer that sums the count by (interface, port) pairs.
+// In the future, this could put counters on a pipe and do the increments
+// in a separate goroutine, but we would *still* need a mutex to read the
+// totals out.
+// TODO: limit maximum size
+type PacketCountSummary struct {
+	total       PacketCounters
+	byPort      map[int]*PacketCounters
+	byInterface map[string]*PacketCounters
+	mutex       sync.RWMutex
+}
+
+func NewPacketCountSummary() *PacketCountSummary {
+	return &PacketCountSummary{
+		byPort:      make(map[int]*PacketCounters),
+		byInterface: make(map[string]*PacketCounters),
+	}
+}
+
+func (s *PacketCountSummary) Update(c PacketCounters) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if prev, ok := s.byPort[c.SrcPort]; ok {
+		prev.Add(c)
+	} else {
+		new := &PacketCounters{
+			Interface: "*",
+			SrcPort:   c.SrcPort,
+			DstPort:   0,
+		}
+		new.Add(c)
+		s.byPort[new.SrcPort] = new
+	}
+
+	if prev, ok := s.byPort[c.DstPort]; ok {
+		prev.Add(c)
+	} else {
+		// Use SrcPort as the identifier in the
+		// accumualted counter
+		new := &PacketCounters{
+			Interface: "*",
+			SrcPort:   c.DstPort,
+			DstPort:   0,
+		}
+		new.Add(c)
+		s.byPort[new.SrcPort] = new
+	}
+
+	if prev, ok := s.byInterface[c.Interface]; ok {
+		prev.Add(c)
+	} else {
+		new := &PacketCounters{
+			Interface: c.Interface,
+			SrcPort:   0,
+			DstPort:   0,
+		}
+		new.Add(c)
+		s.byInterface[new.Interface] = new
+	}
+
+	s.total.Add(c)
+}
+
+func (s *PacketCountSummary) Close() {
+}
+
+func (s *PacketCountSummary) Total() PacketCounters {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.total
+}
+
+// Packet counters summed over interface
+func (s *PacketCountSummary) TotalOnInterface(name string) PacketCounters {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	if count, ok := s.byInterface[name]; ok {
+		return *count
+	}
+
+	return PacketCounters{Interface: name}
+}
+
+// Packet counters summed over port
+func (s *PacketCountSummary) TotalOnPort(port int) PacketCounters {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	if count, ok := s.byPort[port]; ok {
+		return *count
+	}
+	return PacketCounters{Interface: "*", SrcPort: port}
+}
+
+// All available port numbers
+func (s *PacketCountSummary) AllPorts() []PacketCounters {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	ret := make([]PacketCounters, 0, len(s.byPort))
+	for _, v := range s.byPort {
+		ret = append(ret, *v)
+	}
+	return ret
+}
+
+// Observe every captured TCP segment here
+func CountTcpPackets(ifc string, packetCount PacketCountConsumer) pcap.NetworkTrafficObserver {
+	observer := func(p gopacket.Packet) {
+		if tcpLayer := p.Layer(layers.LayerTypeTCP); tcpLayer != nil {
+			tcp, _ := tcpLayer.(*layers.TCP)
+			packetCount.Update(PacketCounters{
+				Interface:  ifc,
+				SrcPort:    int(tcp.SrcPort),
+				DstPort:    int(tcp.DstPort),
+				TCPPackets: 1,
+			})
+		}
+	}
+	return pcap.NetworkTrafficObserver(observer)
+}

--- a/trace/stats.go
+++ b/trace/stats.go
@@ -83,7 +83,7 @@ func (s *PacketCountSummary) Update(c PacketCounters) {
 		prev.Add(c)
 	} else {
 		// Use SrcPort as the identifier in the
-		// accumualted counter
+		// accumulated counter
 		new := &PacketCounters{
 			Interface: "*",
 			SrcPort:   c.DstPort,

--- a/upload/run.go
+++ b/upload/run.go
@@ -118,8 +118,8 @@ func uploadTraces(learnClient rest.LearnClient, args Args, serviceID akid.Servic
 	}
 
 	// Create collector for ingesting the trace events.
-	inboundCollector := trace.NewBackendCollector(serviceID, traceID, learnClient, api_schema.Inbound, args.Plugins)
-	outboundCollector := trace.NewBackendCollector(serviceID, traceID, learnClient, api_schema.Outbound, args.Plugins)
+	inboundCollector := trace.NewBackendCollector(serviceID, traceID, learnClient, api_schema.Inbound, args.Plugins, nil)
+	outboundCollector := trace.NewBackendCollector(serviceID, traceID, learnClient, api_schema.Outbound, args.Plugins, nil)
 	if !args.IncludeTrackers {
 		inboundCollector = trace.New3PTrackerFilterCollector(inboundCollector)
 		outboundCollector = trace.New3PTrackerFilterCollector(outboundCollector)


### PR DESCRIPTION
Capture packet counts from pcap and parsing layers.
Display this information in summary form in the debug output.

Example output capturing HTTPS:
```
[INFO] Captured 364 TCP packets total; 182 unparsed TCP segments.
[INFO] This may mean you are trying to capture HTTPS traffic.
[INFO] See https://docs.akita.software/docs/proxy-for-encrypted-traffic
[INFO] for instructions on using a proxy, or generate a HAR file with
[INFO] your browser as described in
[INFO] https://docs.akita.software/docs/collect-client-side-traffic-2
[ERROR] No inbound HTTP calls captured! 🛑

[ERROR] failed to create trace: incomping API trace is empty
```

Example output when no traffic on the desired port:
```
[INFO] Did not capture any TCP packets matching the filter.
[INFO] This may mean your filter is incorrect, such as the wrong TCP port.
[ERROR] No inbound HTTP calls captured! 🛑

[ERROR] failed to create trace: incomping API trace is empty
```

Example debug output:
```
[DEBUG] ==================================
[DEBUG] Packets per interface:
[DEBUG]       interface      dir packets   req  resp   unk
[DEBUG]              lo  INBOUND       0     0     0     0
[DEBUG]              lo OUTBOUND       0     0     0     4
[DEBUG]           ens33  INBOUND       0     0     0     0
[DEBUG]           ens33 OUTBOUND       1     0     0    12
[DEBUG]         docker0  INBOUND       0     0     0     0
[DEBUG]         docker0 OUTBOUND       0     0     0     0
[DEBUG] br-25f3702c5d47  INBOUND       0     0     0     0
[DEBUG] br-25f3702c5d47 OUTBOUND       0     0     0     0
[DEBUG]     veth78430a1  INBOUND       0     0     0     0
[DEBUG]     veth78430a1 OUTBOUND       0     0     0     0
[DEBUG] ==================================
[DEBUG] Packets per port:
[DEBUG]     port packets   req  resp   unk
[DEBUG] --------- matching filter --------
[DEBUG]        no packets captured        
[DEBUG] ------- not matching filter ------
[DEBUG]    40005       0     0     0     2
[DEBUG]    44790       1     0     0     0
[DEBUG]    49513       0     0     0     2
[DEBUG]       53       0     0     0    12
[DEBUG]    44854       0     0     0     2
[DEBUG]    54092       0     0     0     4
[DEBUG]     1900       0     0     0     4
[DEBUG]      443       1     0     0     0
[DEBUG]    53897       0     0     0     2
[DEBUG]    37949       0     0     0     4
[DEBUG] ==================================
```
