### PR TITLE
BackendCollectors should send all requests to server

### DIFF
--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -273,6 +273,7 @@ func (c *BackendCollector) uploadWitnesses(in []interface{}) {
 	if err != nil {
 		printer.Warningf("Failed to upload witnesses: %v\n", err)
 	}
+	printer.Debugf("Uploaded %d witnesses\n", len(in))
 }
 
 func (c *BackendCollector) periodicFlush() {


### PR DESCRIPTION
In-memory buffer is flushed on Close(), or periodically, so < 10 packets
wouldn't have been sent at all-- and larger traces would probably be truncated.

Added debugging information about flushes, and a count of uploaded HTTP packets.