### PR TITLE
Tweaks to daemon–middleware API.

### DIFF
--- a/daemon/internal/cloud_client/change_active_traces_event.go
+++ b/daemon/internal/cloud_client/change_active_traces_event.go
@@ -42,6 +42,7 @@ func (event changedActiveTracesEvent) handle(client *cloudClient) {
 
 	// Add activated traces.
 	for _, loggingOption := range event.activeTraceDiff.ActivatedTraces {
+		printer.Infof("Activating trace %s (%s)\n", loggingOption.TraceName, akid.String(loggingOption.TraceID))
 		client.startTraceEventCollector(event.serviceID, loggingOption)
 	}
 
@@ -52,6 +53,8 @@ func (event changedActiveTracesEvent) handle(client *cloudClient) {
 			printer.Debugf("Ignoring deactivation of unknown trace: %s\n", akid.String(deactivatedTraceID))
 			continue
 		}
+
+		printer.Infof("Deactivating trace %s (%s)\n", traceInfo.loggingOptions.TraceName, akid.String(traceInfo.loggingOptions.TraceID))
 
 		traceInfo.active = false
 

--- a/daemon/internal/cloud_client/cloud_client.go
+++ b/daemon/internal/cloud_client/cloud_client.go
@@ -192,6 +192,7 @@ func collectTraces(traceEventChannel <-chan *TraceEvent, learnClient rest.LearnC
 // This should only be called from within the main goroutine for the cloud
 // client.
 func (client *cloudClient) unregisterTrace(serviceID akid.ServiceID, traceID akid.LearnSessionID) {
+	printer.Debugf("Unregistering trace %q\n", akid.String(traceID))
 	serviceInfo, traceInfo := client.getInfo(serviceID, traceID)
 	if serviceInfo == nil {
 		printer.Debugf("Tried to unregister a trace from an unknown service %q\n", akid.String(serviceID))

--- a/daemon/internal/cloud_client/registration_request.go
+++ b/daemon/internal/cloud_client/registration_request.go
@@ -9,7 +9,7 @@ import (
 // A request for registering a client (middleware) to the daemon.
 type registrationRequest struct {
 	// The name of the client.
-	name string
+	clientName string
 
 	// The service with which the client is associated.
 	serviceID akid.ServiceID
@@ -21,9 +21,9 @@ type registrationRequest struct {
 	responseChannel chan<- daemon.ActiveTraceDiff
 }
 
-func NewRegistrationRequest(name string, serviceID akid.ServiceID, activeTraces []akid.LearnSessionID, responseChannel chan<- daemon.ActiveTraceDiff) registrationRequest {
+func NewRegistrationRequest(clientName string, serviceID akid.ServiceID, activeTraces []akid.LearnSessionID, responseChannel chan<- daemon.ActiveTraceDiff) registrationRequest {
 	return registrationRequest{
-		name:            name,
+		clientName:      clientName,
 		serviceID:       serviceID,
 		activeTraces:    activeTraces,
 		responseChannel: responseChannel,

--- a/daemon/internal/cloud_client/trace_event_request.go
+++ b/daemon/internal/cloud_client/trace_event_request.go
@@ -1,9 +1,7 @@
 package cloud_client
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/akitasoftware/akita-cli/har_loader"
@@ -22,19 +20,23 @@ type traceEventRequest struct {
 	// The trace to which events are to be added.
 	traceID akid.LearnSessionID
 
-	// The input stream on which to receive trace events.
-	traceEvents *json.Decoder
+	// The set of trace events received.
+	traceEvents []TraceEvent
+
+	// Indicates whether this is the last trace-event request for the trace.
+	noMoreEvents bool
 
 	// The channel on which to send the response to this request.
 	responseChannel chan<- TraceEventResponse
 }
 
-func NewTraceEventRequest(clientName string, serviceID akid.ServiceID, traceID akid.LearnSessionID, traceEvents *json.Decoder, responseChannel chan<- TraceEventResponse) traceEventRequest {
+func NewTraceEventRequest(clientName string, serviceID akid.ServiceID, traceID akid.LearnSessionID, traceEvents []TraceEvent, noMoreEvents bool, responseChannel chan<- TraceEventResponse) traceEventRequest {
 	return traceEventRequest{
 		clientName:      clientName,
 		serviceID:       serviceID,
 		traceID:         traceID,
 		traceEvents:     traceEvents,
+		noMoreEvents:    noMoreEvents,
 		responseChannel: responseChannel,
 	}
 }
@@ -69,11 +71,6 @@ type TraceEvent = har_loader.CustomHAREntry
 
 // Provides details on the processing status of trace events.
 type TraceEventDetails struct {
-	// How many were parsed as valid trace events. Currently, we assume that a
-	// JSON object is a valid trace event if it has either a "request" or a
-	// "response" field.
-	Parsed int `json:"parsed"`
-
 	// How many were dropped because the queue was full.
 	Drops int `json:"drops"`
 }
@@ -81,6 +78,11 @@ type TraceEventDetails struct {
 // This should only be called from within the main goroutine for the cloud
 // client.
 func (req traceEventRequest) handle(client *cloudClient) {
+	printer.Debugf("Handling incoming %d events for trace %q of service %q\n", len(req.traceEvents), akid.String(req.traceID), akid.String(req.serviceID))
+	if req.noMoreEvents {
+		printer.Debugf("  Client has signalled no more events\n")
+	}
+
 	// See if the service and trace are known by the daemon. If the daemon
 	// doesn't know about the service or the trace yet, either the client is
 	// misbehaving or the daemon has restarted and lost its state. Either way,
@@ -108,75 +110,52 @@ func (req traceEventRequest) handle(client *cloudClient) {
 	traceInfo.clientNames[req.clientName] = struct{}{}
 
 	// Start a goroutine for relaying the incoming trace events to the collector.
-	traceEventChannel := traceInfo.traceEventChannel
-	go func() {
-		noMoreEvents := false
-		numTraceEventsParsed := 0
-		numTraceEventsDropped := 0
+	go uploadTraceEvents(client, req, traceInfo.traceEventChannel)
+}
 
-		var err error = nil
-		for {
-			// Deserialize the next trace event.
-			var traceEvent TraceEvent
-			if err = req.traceEvents.Decode(&traceEvent); err != nil {
-				if err == io.EOF {
-					// We've reached the end of the stream, which isn't really an error.
-					// However, until we receive an empty JSON object from the client, we
-					// expect to receive more trace events from the client in a
-					// subsequent connection.
-					err = nil
-				}
-				break
-			}
+// Sends trace events to the cloud.
+func uploadTraceEvents(client *cloudClient, req traceEventRequest, traceEventChannel chan<- *TraceEvent) {
+	numTraceEventsDropped := 0
 
-			// If the deserialized object has neither a request nor a response, treat
-			// it as signalling the end of the trace from this client.
-			if traceEvent.Request == nil && traceEvent.Response == nil {
-				noMoreEvents = true
-				break
-			}
+	var err error = nil
+	for _, traceEvent := range req.traceEvents {
+		// Attempt to enqueue the trace event.
+		select {
+		case traceEventChannel <- &traceEvent:
+		default:
+			numTraceEventsDropped++
+		}
+	}
 
-			numTraceEventsParsed++
+	// Log any errors that we encountered while processing the trace events.
+	eventDetails := TraceEventDetails{
+		Drops: numTraceEventsDropped,
+	}
 
-			// Attempt to enqueue the trace event.
-			select {
-			case traceEventChannel <- &traceEvent:
-			default:
-				numTraceEventsDropped++
-			}
+	// Send the result to the client.
+	{
+		defer close(req.responseChannel)
+
+		status := http.StatusAccepted
+		message := ""
+
+		if err != nil {
+			// We encountered malformed trace events. Return a "Bad Request"
+			// status.
+			status = http.StatusBadRequest
+			message = "Malformed trace event encountered"
+		} else if numTraceEventsDropped > 0 {
+			status = http.StatusUnprocessableEntity
+			message = "Not all trace events were processed"
 		}
 
-		// Log any errors that we encountered while processing the trace events.
-		eventDetails := TraceEventDetails{
-			Parsed: numTraceEventsParsed,
-			Drops:  numTraceEventsDropped,
-		}
+		req.responseChannel <- newTraceEventResponse(status, message, &eventDetails)
+	}
 
-		// Send the result to the client.
-		{
-			defer close(req.responseChannel)
-
-			status := http.StatusAccepted
-			message := ""
-
-			if err != nil {
-				// We encountered malformed trace events. Return a "Bad Request"
-				// status.
-				status = http.StatusBadRequest
-				message = "Malformed trace event encountered"
-			} else if numTraceEventsDropped > 0 {
-				status = http.StatusUnprocessableEntity
-				message = "Not all trace events were processed"
-			}
-
-			req.responseChannel <- newTraceEventResponse(status, message, &eventDetails)
-		}
-
-		// Unregister the client if it's signalled the end of the event stream.
-		if noMoreEvents {
-			client.eventChannel <- newUnregisterClientFromTrace(req.clientName, req.serviceID, req.traceID)
-		}
-	}()
+	// Unregister the client if it's signalled the end of the event stream.
+	if req.noMoreEvents {
+		client.eventChannel <- newUnregisterClientFromTrace(req.clientName, req.serviceID, req.traceID)
+	}
 }
 
 type unregisterClientFromTrace struct {
@@ -196,14 +175,15 @@ func newUnregisterClientFromTrace(clientName string, serviceID akid.ServiceID, t
 // This should only be called from within the main goroutine for the cloud
 // client.
 func (event unregisterClientFromTrace) handle(client *cloudClient) {
+	printer.Debugf("Unregistering client %s from trace %s\n", event.clientName, akid.String(event.traceID))
 	serviceInfo, traceInfo := client.getInfo(event.serviceID, event.traceID)
 	if serviceInfo == nil {
-		printer.Debugf("Attempted to unregister client from unknown service %q\n", akid.String(event.serviceID))
+		printer.Debugf("Attempted to unregister client %s from unknown service %q\n", event.clientName, akid.String(event.serviceID))
 		return
 	}
 
 	if traceInfo == nil {
-		printer.Debugf("Attempted to unregister client from unknown trace %q\n", akid.String(event.traceID))
+		printer.Debugf("Attempted to unregister client %s from unknown trace %q\n", event.clientName, akid.String(event.traceID))
 		return
 	}
 


### PR DESCRIPTION
Bodies of registration requests from middleware now contain just a single JSON object. Previously, it was a stream of objects, which some frameworks (e.g., Express.js) don't appear to support very well.

When sending trace events, middleware now indicate whether to expect more events in future requests.

Wait for middleware to finish sending their events before shutting down a trace.

Instrumented backend collector with a packet count summary. We now report the number of requests and responses uploaded when shutting down a trace.

Added a missing channel flush.

Added more logging.