### PR TITLE
Add daemon_name to long poll request

### DIFF
--- a/daemon/internal/cloud_client/long_poll_service_event.go
+++ b/daemon/internal/cloud_client/long_poll_service_event.go
@@ -29,7 +29,7 @@ func (event longPollServiceEvent) handle(client *cloudClient) {
 		// Send a request to the cloud containing a list of the traces currently
 		// being logged. The response will be a list of new traces to log and a
 		// list of traces that should finish logging.
-		activeTraceDiff, err := util.LongPollActiveTracesForService(frontClient, event.serviceID, currentTraces)
+		activeTraceDiff, err := util.LongPollActiveTracesForService(frontClient, client.daemonName, event.serviceID, currentTraces)
 		if err != nil {
 			// Log the error, wait a bit, and try again.
 			printer.Warningf("Error while polling service ID %s: %v\n", akid.String(event.serviceID), err)

--- a/rest/front_client.go
+++ b/rest/front_client.go
@@ -36,10 +36,12 @@ func (c *frontClientImpl) DaemonHeartbeat(ctx context.Context, daemonName string
 	return c.post(ctx, "/v1/daemon/heartbeat", body, &resp)
 }
 
-func (c *frontClientImpl) LongPollActiveTracesForService(ctx context.Context, serviceID akid.ServiceID, activeTraces []akid.LearnSessionID) (daemon.ActiveTraceDiff, error) {
+func (c *frontClientImpl) LongPollActiveTracesForService(ctx context.Context, daemonName string, serviceID akid.ServiceID, activeTraces []akid.LearnSessionID) (daemon.ActiveTraceDiff, error) {
 	body := struct {
+		DaemonName     string                `json:"daemon_name"`
 		ActiveTraceIDs []akid.LearnSessionID `json:"active_trace_ids"`
 	}{
+		DaemonName:     daemonName,
 		ActiveTraceIDs: activeTraces,
 	}
 	var resp daemon.ActiveTraceDiff

--- a/rest/interface.go
+++ b/rest/interface.go
@@ -58,5 +58,5 @@ type FrontClient interface {
 	// the cloud has a different set, this method returns options for capturing
 	// new traces and a set of deactivated traces. An error is returned if the
 	// connection is dropped (e.g., due to timing out).
-	LongPollActiveTracesForService(context context.Context, serviceID akid.ServiceID, currentTraces []akid.LearnSessionID) (daemon.ActiveTraceDiff, error)
+	LongPollActiveTracesForService(context context.Context, dameonName string, serviceID akid.ServiceID, currentTraces []akid.LearnSessionID) (daemon.ActiveTraceDiff, error)
 }

--- a/rest/interface.go
+++ b/rest/interface.go
@@ -58,5 +58,5 @@ type FrontClient interface {
 	// the cloud has a different set, this method returns options for capturing
 	// new traces and a set of deactivated traces. An error is returned if the
 	// connection is dropped (e.g., due to timing out).
-	LongPollActiveTracesForService(context context.Context, dameonName string, serviceID akid.ServiceID, currentTraces []akid.LearnSessionID) (daemon.ActiveTraceDiff, error)
+	LongPollActiveTracesForService(context context.Context, daemonName string, serviceID akid.ServiceID, currentTraces []akid.LearnSessionID) (daemon.ActiveTraceDiff, error)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -77,10 +77,10 @@ func DaemonHeartbeat(c rest.FrontClient, daemonName string) error {
 }
 
 // Long-polls the cloud for changes to the set of active traces for a service.
-func LongPollActiveTracesForService(c rest.FrontClient, serviceID akid.ServiceID, currentTraces []akid.LearnSessionID) (daemon.ActiveTraceDiff, error) {
+func LongPollActiveTracesForService(c rest.FrontClient, daemonName string, serviceID akid.ServiceID, currentTraces []akid.LearnSessionID) (daemon.ActiveTraceDiff, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
 	defer cancel()
-	return c.LongPollActiveTracesForService(ctx, serviceID, currentTraces)
+	return c.LongPollActiveTracesForService(ctx, daemonName, serviceID, currentTraces)
 }
 
 func GetLearnSessionIDByName(c rest.LearnClient, name string) (akid.LearnSessionID, error) {


### PR DESCRIPTION
This allows us to more easily tell which daemon instances are querying for a particular service, so we can show their names to the user in the UI.