### PR TITLE
Ensure periodicFlush exits

### DIFF
--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -285,7 +285,7 @@ func (c *BackendCollector) periodicFlush() {
 			c.flushPairCache(time.Now().Add(-1 * pairCacheExpiration))
 		case <-c.flushDone:
 			ticker.Stop()
-			break
+			return
 		}
 	}
 }


### PR DESCRIPTION
"break" only exits the "select" statement, not the loop.

The loop ran forever busy-waiting because flushDone was always triggered once closed. 