### PR TITLE
Fix repeated trace event overriding others in batch

### DIFF
--- a/daemon/internal/cloud_client/trace_event_request.go
+++ b/daemon/internal/cloud_client/trace_event_request.go
@@ -21,7 +21,7 @@ type traceEventRequest struct {
 	traceID akid.LearnSessionID
 
 	// The set of trace events received.
-	traceEvents []TraceEvent
+	traceEvents []*TraceEvent
 
 	// Indicates whether this is the last trace-event request for the trace.
 	noMoreEvents bool
@@ -30,7 +30,7 @@ type traceEventRequest struct {
 	responseChannel chan<- TraceEventResponse
 }
 
-func NewTraceEventRequest(clientName string, serviceID akid.ServiceID, traceID akid.LearnSessionID, traceEvents []TraceEvent, noMoreEvents bool, responseChannel chan<- TraceEventResponse) traceEventRequest {
+func NewTraceEventRequest(clientName string, serviceID akid.ServiceID, traceID akid.LearnSessionID, traceEvents []*TraceEvent, noMoreEvents bool, responseChannel chan<- TraceEventResponse) traceEventRequest {
 	return traceEventRequest{
 		clientName:      clientName,
 		serviceID:       serviceID,
@@ -121,7 +121,7 @@ func uploadTraceEvents(client *cloudClient, req traceEventRequest, traceEventCha
 	for _, traceEvent := range req.traceEvents {
 		// Attempt to enqueue the trace event.
 		select {
-		case traceEventChannel <- &traceEvent:
+		case traceEventChannel <- traceEvent:
 		default:
 			numTraceEventsDropped++
 		}

--- a/daemon/run.go
+++ b/daemon/run.go
@@ -163,9 +163,9 @@ func addEvents(request *http.Request) HTTPResponse {
 
 	// Parse the request body.
 	var requestBody struct {
-		ClientName   string       `json:"client_name"`
-		TraceEvents  []TraceEvent `json:"trace_events"`
-		NoMoreEvents bool         `json:"no_more_events"`
+		ClientName   string        `json:"client_name"`
+		TraceEvents  []*TraceEvent `json:"trace_events"`
+		NoMoreEvents bool          `json:"no_more_events"`
 	}
 	jsonDecoder := json.NewDecoder(request.Body)
 	if err := jsonDecoder.Decode(&requestBody); err != nil {


### PR DESCRIPTION
Switch to a *TraceEvent everywhere from demarshaling the incoming message
up to putting it in the channel to send to the cloud.

The problem (and I run into this all the time trying to modify a Go slice) is that

```
for _, traceEvent := range req.traceEvents {
```

does not bind traceEvent to each of the slice elements in turn (like a C++ reference.)  It's just a copy, and moreover a copy in a local variable, so its address is the same each time.
