### PR TITLE
Convert strings in traces to other types depending on context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210406221235-f036dc848087
-	github.com/akitasoftware/akita-libs v0.0.0-20210520200249-ace6dc8c22c4
+	github.com/akitasoftware/akita-libs v0.0.0-20210520233454-94be75920269
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0
 	github.com/gdamore/tcell/v2 v2.1.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210406221235-f036dc848087
-	github.com/akitasoftware/akita-libs v0.0.0-20210521005746-9ae93ff5dbc1
+	github.com/akitasoftware/akita-libs v0.0.0-20210521013525-93e697dfbee3
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0
 	github.com/gdamore/tcell/v2 v2.1.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210406221235-f036dc848087
-	github.com/akitasoftware/akita-libs v0.0.0-20210520233454-94be75920269
+	github.com/akitasoftware/akita-libs v0.0.0-20210521005746-9ae93ff5dbc1
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0
 	github.com/gdamore/tcell/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210520233454-94be75920269 h1:poKxHe
 github.com/akitasoftware/akita-libs v0.0.0-20210520233454-94be75920269/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
 github.com/akitasoftware/akita-libs v0.0.0-20210521005746-9ae93ff5dbc1 h1:iKmWC8ZSeGXO7tQ6hZ5JZoEyRXwligWfsoyVHX/i4Tg=
 github.com/akitasoftware/akita-libs v0.0.0-20210521005746-9ae93ff5dbc1/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
+github.com/akitasoftware/akita-libs v0.0.0-20210521013525-93e697dfbee3 h1:OPDuaQLYsJ65XUkbx0YFnQdGiURE/YWt0b6q1L3mmaY=
+github.com/akitasoftware/akita-libs v0.0.0-20210521013525-93e697dfbee3/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPBv9mohlLY3EzstN6ds8kxcc0lwq1F541115FP7xY=

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210520200249-ace6dc8c22c4 h1:xjvuXc
 github.com/akitasoftware/akita-libs v0.0.0-20210520200249-ace6dc8c22c4/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
 github.com/akitasoftware/akita-libs v0.0.0-20210520233454-94be75920269 h1:poKxHe0le1iBMv+QLoKd2fvZjrojWGxztzHhA0LP9t8=
 github.com/akitasoftware/akita-libs v0.0.0-20210520233454-94be75920269/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
+github.com/akitasoftware/akita-libs v0.0.0-20210521005746-9ae93ff5dbc1 h1:iKmWC8ZSeGXO7tQ6hZ5JZoEyRXwligWfsoyVHX/i4Tg=
+github.com/akitasoftware/akita-libs v0.0.0-20210521005746-9ae93ff5dbc1/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPBv9mohlLY3EzstN6ds8kxcc0lwq1F541115FP7xY=

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210520023156-8d8801e1930f h1:BszCFk
 github.com/akitasoftware/akita-libs v0.0.0-20210520023156-8d8801e1930f/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
 github.com/akitasoftware/akita-libs v0.0.0-20210520200249-ace6dc8c22c4 h1:xjvuXc79E17MOQ6lSceDacIk8hgpHjnkEq+PejqreT4=
 github.com/akitasoftware/akita-libs v0.0.0-20210520200249-ace6dc8c22c4/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
+github.com/akitasoftware/akita-libs v0.0.0-20210520233454-94be75920269 h1:poKxHe0le1iBMv+QLoKd2fvZjrojWGxztzHhA0LP9t8=
+github.com/akitasoftware/akita-libs v0.0.0-20210520233454-94be75920269/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPBv9mohlLY3EzstN6ds8kxcc0lwq1F541115FP7xY=

--- a/learn/parse_http_test.go
+++ b/learn/parse_http_test.go
@@ -61,7 +61,7 @@ func newTestBodySpec(statusCode int) *as.Data {
 		"name":                             dataFromPrimitive(spec_util.NewPrimitiveString("prince")),
 		"number_teeth":                     dataFromPrimitive(spec_util.NewPrimitiveInt64(9000)),
 		"dog":                              dataFromPrimitive(spec_util.NewPrimitiveBool(true)),
-		"canadian_social_insurance_number": dataFromPrimitive(annotateIfSensitiveForTest(true, spec_util.NewPrimitiveInt64(378734493671000))),
+		"canadian_social_insurance_number": dataFromPrimitive(annotateIfSensitiveForTest(true, spec_util.NewPrimitiveString("378734493671000"))),
 		"homes": dataFromList(
 			dataFromPrimitive(spec_util.NewPrimitiveString("burbank, ca")),
 			dataFromPrimitive(spec_util.NewPrimitiveString("jeuno, ak")),
@@ -89,7 +89,7 @@ func newTestMultipartFormData(statusCode int) *as.Data {
 
 	return &as.Data{
 		Value: &as.Data_Struct{
-			&as.Struct{
+			Struct: &as.Struct{
 				Fields: map[string]*as.Data{
 					"field1": newTestBodySpecFromData(statusCode, as.HTTPBody_TEXT_PLAIN, f1),
 					"field2": newTestBodySpecFromStruct(statusCode, as.HTTPBody_JSON, map[string]*as.Data{


### PR DESCRIPTION
When producing IR from traces, don't auto-convert strings to ints and bools. This was causing us to generate incorrect specs.