### PR TITLE
Add ability to set API-model version names

### DIFF
--- a/cmd/internal/man/cmd.go
+++ b/cmd/internal/man/cmd.go
@@ -54,6 +54,10 @@ var (
 			content: addBackticks(learnPage),
 		},
 		{
+			command: "setversion",
+			content: addBackticks(setversionPage),
+		},
+		{
 			command: "upload",
 			content: addBackticks(uploadPage),
 		},

--- a/cmd/internal/man/setversion_page.go
+++ b/cmd/internal/man/setversion_page.go
@@ -5,7 +5,7 @@ var setversionPage = `
 
 # Description
 
-Sets the version name of an API spec.
+Sets the version name of an API spec. Version names are unique within a service. For example, "latest" is a version name automatically assigned to the most recent API spec.
 
 # Examples
 
@@ -13,7 +13,7 @@ Sets the version name of an API spec.
 
 Marks the spec identified by <bt>akita://myservice:spec:beta<bt> as "v1.0.0" for <bt>my-service<bt>. Any spec in <bt>my-service<bt> that was previously marked with "v1.0.0" will no longer be associated with that version name.
 
-## akita setversion stable akita://my-service:spec:latest
+## akita setversion stable akita://my-service:spec:public
 
-Marks the spec identified by <bt>akita://myservice:spec:latest<bt> as "stable" for <bt>my-service<bt>. This removes the "stable" designation from all other specs in <bt>my-service<bt>.
+Marks the spec identified by <bt>akita://myservice:spec:public<bt> as "stable" for <bt>my-service<bt>. This removes the "stable" designation from all other specs in <bt>my-service<bt>.
 `

--- a/cmd/internal/man/setversion_page.go
+++ b/cmd/internal/man/setversion_page.go
@@ -1,0 +1,19 @@
+package man
+
+var setversionPage = `
+# === setversion ===
+
+# Description
+
+Sets the version name of an API spec.
+
+# Examples
+
+## akita setversion v1.0.0 akita://my-service:spec:beta
+
+Marks the spec identified by <bt>akita://myservice:spec:beta<bt> as "v1.0.0" for <bt>my-service<bt>. Any spec in <bt>my-service<bt> that was previously marked with "v1.0.0" will no longer be associated with that version name.
+
+## akita setversion stable akita://my-service:spec:latest
+
+Marks the spec identified by <bt>akita://myservice:spec:latest<bt> as "stable" for <bt>my-service<bt>. This removes the "stable" designation from all other specs in <bt>my-service<bt>.
+`

--- a/cmd/internal/setversion/cmd.go
+++ b/cmd/internal/setversion/cmd.go
@@ -1,0 +1,41 @@
+package setversion
+
+import (
+	"github.com/akitasoftware/akita-cli/cmd/internal/akiflag"
+	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
+	"github.com/akitasoftware/akita-cli/setversion"
+	"github.com/akitasoftware/akita-libs/akid"
+	"github.com/akitasoftware/akita-libs/akiuri"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:          "setversion NAME SPEC_AKITA_URI",
+	Short:        "Sets the version name for an API model.",
+	SilenceUsage: true,
+	Args:         cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Second argument must be a model URI.
+		modelURI, err := akiuri.Parse(args[1])
+		if err != nil {
+			return errors.Wrapf(err, "%q is not a well-formed AkitaURI", args[1])
+		}
+		if !modelURI.ObjectType.IsSpec() {
+			return errors.New("Must specify an API model. For example, \"akita://serviceName:spec:specName\"")
+		}
+
+		setversionArgs := setversion.Args{
+			ClientID:    akid.GenerateClientID(),
+			Domain:      akiflag.Domain,
+			ModelURI:    modelURI,
+			VersionName: args[0],
+		}
+
+		if err := setversion.Run(setversionArgs); err != nil {
+			return cmderr.AkitaErr{Err: err}
+		}
+
+		return nil
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/akitasoftware/akita-cli/cmd/internal/legacy"
 	"github.com/akitasoftware/akita-cli/cmd/internal/login"
 	"github.com/akitasoftware/akita-cli/cmd/internal/man"
+	"github.com/akitasoftware/akita-cli/cmd/internal/setversion"
 	"github.com/akitasoftware/akita-cli/cmd/internal/upload"
 	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-cli/util"
@@ -130,6 +131,7 @@ func init() {
 	rootCmd.AddCommand(learn.Cmd)
 	rootCmd.AddCommand(login.Cmd)
 	rootCmd.AddCommand(man.Cmd)
+	rootCmd.AddCommand(setversion.Cmd)
 	rootCmd.AddCommand(upload.Cmd)
 
 	// Legacy commands, included for backward compatibility but are hidden.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210406221235-f036dc848087
-	github.com/akitasoftware/akita-libs v0.0.0-20210522000334-18114ff4754c
+	github.com/akitasoftware/akita-libs v0.0.0-20210601201612-d76a5b4e91fe
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0
 	github.com/gdamore/tcell/v2 v2.1.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210406221235-f036dc848087
-	github.com/akitasoftware/akita-libs v0.0.0-20210601201612-d76a5b4e91fe
+	github.com/akitasoftware/akita-libs v0.0.0-20210602023920-4dd82f7082ad
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0
 	github.com/gdamore/tcell/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210521013525-93e697dfbee3 h1:OPDuaQ
 github.com/akitasoftware/akita-libs v0.0.0-20210521013525-93e697dfbee3/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
 github.com/akitasoftware/akita-libs v0.0.0-20210522000334-18114ff4754c h1:rw7KJm7W5s/OTWVaC5826uibi9ko3Zp5Ud6HPUPDXUg=
 github.com/akitasoftware/akita-libs v0.0.0-20210522000334-18114ff4754c/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
+github.com/akitasoftware/akita-libs v0.0.0-20210601201612-d76a5b4e91fe h1:r9V06aXhH60hzo/omTP83o6s48+I1ARhFTSYZ8N2fxo=
+github.com/akitasoftware/akita-libs v0.0.0-20210601201612-d76a5b4e91fe/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPBv9mohlLY3EzstN6ds8kxcc0lwq1F541115FP7xY=

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210522000334-18114ff4754c h1:rw7KJm
 github.com/akitasoftware/akita-libs v0.0.0-20210522000334-18114ff4754c/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
 github.com/akitasoftware/akita-libs v0.0.0-20210601201612-d76a5b4e91fe h1:r9V06aXhH60hzo/omTP83o6s48+I1ARhFTSYZ8N2fxo=
 github.com/akitasoftware/akita-libs v0.0.0-20210601201612-d76a5b4e91fe/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
+github.com/akitasoftware/akita-libs v0.0.0-20210602023920-4dd82f7082ad h1:mHTr7z1sZUrl3uiUI6BXYpr96zBVw38aj5veIVrWr5E=
+github.com/akitasoftware/akita-libs v0.0.0-20210602023920-4dd82f7082ad/go.mod h1:6YXeZ4GJ1dmzjziWfRDynTVT0kx0Jz+bleiaCuFDgwk=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPBv9mohlLY3EzstN6ds8kxcc0lwq1F541115FP7xY=

--- a/rest/learn_client.go
+++ b/rest/learn_client.go
@@ -167,3 +167,15 @@ func (c *learnClientImpl) GetSpecDiffTrie(ctx context.Context, baseID, newID aki
 	err := c.get(ctx, path, &resp)
 	return &resp, err
 }
+
+func (c *learnClientImpl) SetSpecVersion(ctx context.Context, specID akid.APISpecID, versionName string) error {
+	resp := struct {
+	}{}
+	path := fmt.Sprintf("/v1/services/%s/spec-versions/%s",
+		akid.String(c.serviceID), versionName)
+	req := kgxapi.SetSpecVersionRequest{
+		APISpecID: specID,
+	}
+
+	return c.post(ctx, path, req, &resp)
+}

--- a/setversion/args.go
+++ b/setversion/args.go
@@ -1,0 +1,15 @@
+package setversion
+
+import (
+	"github.com/akitasoftware/akita-libs/akid"
+	"github.com/akitasoftware/akita-libs/akiuri"
+)
+
+type Args struct {
+	// Required args
+	ClientID akid.ClientID
+	Domain   string
+
+	ModelURI    akiuri.URI
+	VersionName string
+}

--- a/setversion/run.go
+++ b/setversion/run.go
@@ -1,0 +1,31 @@
+package setversion
+
+import (
+	"context"
+	"time"
+
+	"github.com/akitasoftware/akita-cli/rest"
+	"github.com/akitasoftware/akita-cli/util"
+)
+
+func Run(args Args) error {
+	// Resolve service ID.
+	frontClient := rest.NewFrontClient(args.Domain, args.ClientID)
+	serviceName := args.ModelURI.ServiceName
+	serviceID, err := util.GetServiceIDByName(frontClient, serviceName)
+	if err != nil {
+		return err
+	}
+
+	// Resolve API model ID.
+	learnClient := rest.NewLearnClient(args.Domain, args.ClientID, serviceID)
+	modelID, err := util.ResolveSpecURI(learnClient, args.ModelURI)
+	if err != nil {
+		return err
+	}
+
+	// Set version name.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return learnClient.SetSpecVersion(ctx, modelID, args.VersionName)
+}


### PR DESCRIPTION
Adds `setversion` for setting version names of API models.
```
Sets the version name for an API model.

Usage:
  akita setversion NAME SPEC_AKITA_URI [flags]

Flags:
  -h, --help   help for setversion
```