### PR TITLE
Move packet-counting logic into a shim Collector

### DIFF
--- a/apispec/run.go
+++ b/apispec/run.go
@@ -411,8 +411,8 @@ func uploadLocalTraces(domain string, clientID akid.ClientID, svc akid.ServiceID
 			return nil, errors.Wrap(err, "failed to create backend learn session")
 		}
 
-		inboundCol := trace.NewBackendCollector(svc, lrn, learnClient, kgxapi.Inbound, plugins, nil)
-		outboundCol := trace.NewBackendCollector(svc, lrn, learnClient, kgxapi.Outbound, plugins, nil)
+		inboundCol := trace.NewBackendCollector(svc, lrn, learnClient, kgxapi.Inbound, plugins)
+		outboundCol := trace.NewBackendCollector(svc, lrn, learnClient, kgxapi.Outbound, plugins)
 		if !includeTrackers {
 			inboundCol = trace.New3PTrackerFilterCollector(inboundCol)
 			outboundCol = trace.New3PTrackerFilterCollector(outboundCol)

--- a/daemon/internal/cloud_client/cloud_client.go
+++ b/daemon/internal/cloud_client/cloud_client.go
@@ -154,7 +154,11 @@ func (client *cloudClient) startTraceEventCollector(serviceID akid.ServiceID, lo
 func collectTraces(traceEventChannel <-chan *TraceEvent, learnClient rest.LearnClient, serviceID akid.ServiceID, loggingOptions daemon.LoggingOptions, plugins []plugin.AkitaPlugin) {
 	// Create the collector.
 	packetCountSummary := trace.NewPacketCountSummary()
-	collector := trace.NewBackendCollector(serviceID, loggingOptions.TraceID, learnClient, api_schema.Inbound, plugins, packetCountSummary)
+	collector := trace.NewBackendCollector(serviceID, loggingOptions.TraceID, learnClient, api_schema.Inbound, plugins)
+	collector = &trace.PacketCountCollector{
+		PacketCounts: packetCountSummary,
+		Collector:    collector,
+	}
 	if loggingOptions.FilterThirdPartyTrackers {
 		collector = trace.New3PTrackerFilterCollector(collector)
 	}

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -127,16 +127,12 @@ type BackendCollector struct {
 	// Channel controlling periodic cache flush
 	flushDone chan struct{}
 
-	// Consumer for packet counts
-	packetCounts PacketCountConsumer
-
 	plugins []plugin.AkitaPlugin
 }
 
 func NewBackendCollector(svc akid.ServiceID,
 	lrn akid.LearnSessionID, lc rest.LearnClient, dir kgxapi.NetworkDirection,
-	plugins []plugin.AkitaPlugin,
-	packetCounts PacketCountConsumer) Collector {
+	plugins []plugin.AkitaPlugin) Collector {
 	col := &BackendCollector{
 		serviceID:      svc,
 		learnSessionID: lrn,
@@ -144,11 +140,6 @@ func NewBackendCollector(svc akid.ServiceID,
 		dir:            dir,
 		flushDone:      make(chan struct{}),
 		plugins:        plugins,
-		packetCounts:   packetCounts,
-	}
-
-	if packetCounts == nil {
-		col.packetCounts = &PacketCountDiscard{}
 	}
 
 	col.uploadBatch = batcher.NewInMemory(
@@ -167,28 +158,10 @@ func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
 	case akinet.HTTPRequest:
 		isRequest = true
 		partial, parseHTTPErr = learn.ParseHTTP(content)
-		c.packetCounts.Update(PacketCounters{
-			Interface:    t.Interface,
-			SrcPort:      t.SrcPort,
-			DstPort:      t.DstPort,
-			HTTPRequests: 1,
-		})
 	case akinet.HTTPResponse:
 		partial, parseHTTPErr = learn.ParseHTTP(content)
-		c.packetCounts.Update(PacketCounters{
-			Interface:     t.Interface,
-			SrcPort:       t.SrcPort,
-			DstPort:       t.DstPort,
-			HTTPResponses: 1,
-		})
 	default:
 		// Non-HTTP traffic not handled
-		c.packetCounts.Update(PacketCounters{
-			Interface: t.Interface,
-			SrcPort:   t.SrcPort,
-			DstPort:   t.DstPort,
-			Unparsed:  1,
-		})
 		return nil
 	}
 

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -90,7 +90,7 @@ func TestObfuscate(t *testing.T) {
 		},
 	}
 
-	col := NewBackendCollector(fakeSvc, fakeLrn, mockClient, kgxapi.Inbound, nil, nil)
+	col := NewBackendCollector(fakeSvc, fakeLrn, mockClient, kgxapi.Inbound, nil)
 	assert.NoError(t, col.Process(req))
 	assert.NoError(t, col.Process(resp))
 	assert.NoError(t, col.Close())
@@ -225,7 +225,7 @@ func TestTiming(t *testing.T) {
 		FinalPacketTime: startTime.Add(13 * time.Millisecond),
 	}
 
-	col := NewBackendCollector(fakeSvc, fakeLrn, mockClient, kgxapi.Inbound, nil, nil)
+	col := NewBackendCollector(fakeSvc, fakeLrn, mockClient, kgxapi.Inbound, nil)
 	assert.NoError(t, col.Process(req))
 	assert.NoError(t, col.Process(resp))
 	assert.NoError(t, col.Close())
@@ -247,7 +247,7 @@ func TestMultipleInterfaces(t *testing.T) {
 		AnyTimes().
 		Return(nil)
 
-	bc := NewBackendCollector(fakeSvc, fakeLrn, mockClient, kgxapi.Inbound, nil, nil)
+	bc := NewBackendCollector(fakeSvc, fakeLrn, mockClient, kgxapi.Inbound, nil)
 
 	var wg sync.WaitGroup
 	fakeTrace := func(count int, start_seq int) {

--- a/upload/run.go
+++ b/upload/run.go
@@ -121,10 +121,20 @@ func uploadTraces(learnClient rest.LearnClient, args Args, serviceID akid.Servic
 	outboundCount := trace.NewPacketCountSummary()
 
 	// Create collector for ingesting the trace events.
-	inboundCollector := trace.NewBackendCollector(serviceID, traceID, learnClient, api_schema.Inbound, args.Plugins, inboundCount)
-	outboundCollector := trace.NewBackendCollector(serviceID, traceID, learnClient, api_schema.Outbound, args.Plugins, outboundCount)
+	inboundCollector := trace.NewBackendCollector(serviceID, traceID, learnClient, api_schema.Inbound, args.Plugins)
+	outboundCollector := trace.NewBackendCollector(serviceID, traceID, learnClient, api_schema.Outbound, args.Plugins)
 	defer inboundCollector.Close()
 	defer outboundCollector.Close()
+
+	inboundCollector = &trace.PacketCountCollector{
+		PacketCounts: inboundCount,
+		Collector:    inboundCollector,
+	}
+
+	outboundCollector = &trace.PacketCountCollector{
+		PacketCounts: outboundCount,
+		Collector:    outboundCollector,
+	}
 
 	if !args.IncludeTrackers {
 		inboundCollector = trace.New3PTrackerFilterCollector(inboundCollector)


### PR DESCRIPTION
This ensures counts are collected whether apidump is using the backend collector or the HAR collector; previously it was giving an error that no packets were detected when writing to a HAR.
