### PR TITLE
More tags

### DIFF
--- a/ci/circleci.go
+++ b/ci/circleci.go
@@ -17,6 +17,10 @@ func circleCIInfo() (*github.PullRequest, map[tags.Key]string) {
 
 	tags := map[tags.Key]string{
 		tags.XAkitaCI:               CircleCI.String(),
+		tags.XAkitaGitRepoURL:       os.Getenv("CIRCLE_REPOSITORY_URL"),
+		tags.XAkitaGitBranch:        os.Getenv("CIRCLE_BRANCH"),
+		tags.XAkitaGitCommit:        os.Getenv("CIRCLE_SHA1"),
+		tags.XAkitaGitHubPRURL:      os.Getenv("CIRCLE_PULL_REQUEST"),
 		tags.XAkitaCircleCIBuildURL: os.Getenv("CIRCLE_BUILD_URL"),
 	}
 	return pr, tags

--- a/ci/travis.go
+++ b/ci/travis.go
@@ -14,6 +14,11 @@ import (
 // GitHub.
 // https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
 func travisCIInfo() (*github.PullRequest, map[tags.Key]string) {
+	repoURL := url.URL{
+		Scheme: "https",
+		Host:   "github.com",
+		Path:   os.Getenv("TRAVIS_REPO_SLUG"),
+	}
 	prURL := url.URL{
 		Scheme: "https",
 		Host:   "github.com",
@@ -28,6 +33,10 @@ func travisCIInfo() (*github.PullRequest, map[tags.Key]string) {
 
 	return pr, map[tags.Key]string{
 		tags.XAkitaCI:                Travis.String(),
+		tags.XAkitaGitRepoURL:        repoURL.String(),
+		tags.XAkitaGitBranch:         os.Getenv("TRAVIS_BRANCH"),
+		tags.XAkitaGitCommit:         os.Getenv("TRAVIS_COMMIT"),
+		tags.XAkitaGitHubPRURL:       prURL.String(),
 		tags.XAkitaTravisBuildWebURL: os.Getenv("TRAVIS_BUILD_WEB_URL"),
 		tags.XAkitaTravisJobWebURL:   os.Getenv("TRAVIS_JOB_WEB_URL"),
 	}


### PR DESCRIPTION
We apparently have two copies of our CI-processing code. One copy was adding more tags than the other.

For posterity, here are the two copies:
  - https://github.com/akitasoftware/akita-cli/blob/39bc8eca6da4cad65350e4bd171a9c620b530b8d/env/ci.go
  - https://github.com/akitasoftware/akita-cli/blob/39bc8eca6da4cad65350e4bd171a9c620b530b8d/ci/ci.go