### PR TITLE
Convert environment variables to Kubernetes deployment tags

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
+	"github.com/akitasoftware/akita-cli/deployment"
 	"github.com/akitasoftware/akita-cli/location"
 	"github.com/akitasoftware/akita-cli/plugin"
 	"github.com/akitasoftware/akita-cli/printer"
@@ -173,6 +174,23 @@ func Run(args Args) error {
 	}
 	if args.Filter != "" {
 		traceTags[tags.XAkitaDumpFilterFlag] = args.Filter
+	}
+
+	// Import information about production or staging environment
+	// FIXME: this is performed in apispec as well; does that cause problems if the same
+	// args.Tags map is re-used?
+	{
+		deploymentType, deploymentTags := deployment.GetDeploymentInfo()
+
+		// Override user type, but not CI.
+		if deploymentType != deployment.None &&
+			args.Tags[tags.XAkitaSource] == tags.UserSource || args.Tags[tags.XAkitaSource] == tags.Source("") {
+			args.Tags[tags.XAkitaSource] = tags.DeploymentSource
+		}
+
+		for k, v := range deploymentTags {
+			args.Tags[k] = v
+		}
 	}
 
 	// Build path filters.

--- a/apispec/run.go
+++ b/apispec/run.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/akitasoftware/akita-cli/ci"
+	"github.com/akitasoftware/akita-cli/deployment"
 	"github.com/akitasoftware/akita-cli/location"
 	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-cli/rest"
@@ -96,6 +97,21 @@ func Run(args Args) error {
 					args.GitHubPR = pr.Num
 				}
 			}
+		}
+	}
+
+	// Import information about production or staging environment
+	{
+		deploymentType, deploymentTags := deployment.GetDeploymentInfo()
+
+		// Override user type, but not CI.
+		if deploymentType != deployment.None &&
+			args.Tags[tags.XAkitaSource] == tags.UserSource {
+			args.Tags[tags.XAkitaSource] = tags.DeploymentSource
+		}
+
+		for k, v := range deploymentTags {
+			args.Tags[k] = v
 		}
 	}
 

--- a/apispec/run.go
+++ b/apispec/run.go
@@ -68,11 +68,6 @@ type Args struct {
 }
 
 func Run(args Args) error {
-	// Set source to user by default.
-	if _, ok := args.Tags[tags.XAkitaSource]; !ok {
-		args.Tags[tags.XAkitaSource] = tags.UserSource
-	}
-
 	// Auto detect CI environment.
 	{
 		ciType, pr, ciTags := ci.GetCIInfo()
@@ -101,18 +96,12 @@ func Run(args Args) error {
 	}
 
 	// Import information about production or staging environment
-	{
-		deploymentType, deploymentTags := deployment.GetDeploymentInfo()
+	// including, possible, XAkitaSource
+	deployment.UpdateTags(args.Tags)
 
-		// Override user type, but not CI.
-		if deploymentType != deployment.None &&
-			args.Tags[tags.XAkitaSource] == tags.UserSource {
-			args.Tags[tags.XAkitaSource] = tags.DeploymentSource
-		}
-
-		for k, v := range deploymentTags {
-			args.Tags[k] = v
-		}
+	// Set source to user by default.
+	if _, ok := args.Tags[tags.XAkitaSource]; !ok {
+		args.Tags[tags.XAkitaSource] = tags.UserSource
 	}
 
 	var serviceName string

--- a/apispec/run.go
+++ b/apispec/run.go
@@ -67,43 +67,82 @@ type Args struct {
 	Plugins []plugin.AkitaPlugin
 }
 
-func Run(args Args) error {
+// Collect the tag set to apply to the specification.
+// May modify the arguments based on CI information, and return a github PR
+func collectSpecTags(args *Args) (map[tags.Key]string, *github.PRInfo, error) {
+	specTags := args.Tags
+	if specTags == nil {
+		specTags = map[tags.Key]string{}
+	}
+
 	// Auto detect CI environment.
-	{
-		ciType, pr, ciTags := ci.GetCIInfo()
-		if ciType != ci.Unknown {
-			for k, v := range ciTags {
-				args.Tags[k] = v
+	ciType, pr, ciTags := ci.GetCIInfo()
+	if ciType != ci.Unknown {
+		for k, v := range ciTags {
+			specTags[k] = v
+		}
+
+		specTags[tags.XAkitaSource] = tags.CISource
+
+		if pr != nil {
+			if args.GitHubBranch == "" {
+				args.GitHubBranch = pr.Branch
 			}
-
-			args.Tags[tags.XAkitaSource] = tags.CISource
-
-			if pr != nil {
-				if args.GitHubBranch == "" {
-					args.GitHubBranch = pr.Branch
-				}
-				if args.GitHubCommit == "" {
-					args.GitHubCommit = pr.Commit
-				}
-				if args.GitHubRepo == "" {
-					args.GitHubRepo = pr.Repo.Owner + "/" + pr.Repo.Name
-				}
-				if args.GitHubPR == 0 {
-					args.GitHubPR = pr.Num
-				}
+			if args.GitHubCommit == "" {
+				args.GitHubCommit = pr.Commit
+			}
+			if args.GitHubRepo == "" {
+				args.GitHubRepo = pr.Repo.Owner + "/" + pr.Repo.Name
+			}
+			if args.GitHubPR == 0 {
+				args.GitHubPR = pr.Num
 			}
 		}
 	}
 
 	// Import information about production or staging environment
-	// including, possible, XAkitaSource
-	deployment.UpdateTags(args.Tags)
+	// including, possibly, XAkitaSource
+	deployment.UpdateTags(specTags)
 
 	// Set source to user by default.
-	if _, ok := args.Tags[tags.XAkitaSource]; !ok {
-		args.Tags[tags.XAkitaSource] = tags.UserSource
+	if _, ok := specTags[tags.XAkitaSource]; !ok {
+		specTags[tags.XAkitaSource] = tags.UserSource
 	}
 
+	// additional github or gitlab tags
+	var githubPR *github.PRInfo
+	if args.GitHubRepo != "" && args.GitHubPR != 0 {
+		parts := strings.Split(args.GitHubRepo, "/")
+		if len(parts) != 2 {
+			return nil, nil, errors.Errorf("github repo name should contain {OWNER}/{NAME}")
+		}
+
+		// Add tags to store commit information.
+		specTags[tags.XAkitaSource] = tags.CISource
+		specTags[tags.XAkitaGitHubRepo] = args.GitHubRepo
+		specTags[tags.XAkitaGitHubPR] = strconv.Itoa(args.GitHubPR)
+		specTags[tags.XAkitaGitBranch] = args.GitHubBranch
+		specTags[tags.XAkitaGitCommit] = args.GitHubCommit
+
+		githubPR = &github.PRInfo{
+			RepoOwner: parts[0],
+			RepoName:  parts[1],
+			Num:       args.GitHubPR,
+		}
+	}
+	if args.GitLabMR != nil {
+		// Add tags to store commit information.
+		specTags[tags.XAkitaSource] = tags.CISource
+		specTags[tags.XAkitaGitLabProject] = args.GitLabMR.Project
+		specTags[tags.XAkitaGitLabMRIID] = args.GitLabMR.IID
+		specTags[tags.XAkitaGitBranch] = args.GitLabMR.Branch
+		specTags[tags.XAkitaGitCommit] = args.GitLabMR.Commit
+	}
+
+	return specTags, githubPR, nil
+}
+
+func Run(args Args) error {
 	var serviceName string
 	if uri := args.Out.AkitaURI; uri != nil {
 		serviceName = uri.ServiceName
@@ -155,38 +194,10 @@ func Run(args Args) error {
 		}
 	}
 
-	specTags := args.Tags
-	if specTags == nil {
-		specTags = map[tags.Key]string{}
-	}
-
-	var githubPR *github.PRInfo
-	if args.GitHubRepo != "" && args.GitHubPR != 0 {
-		parts := strings.Split(args.GitHubRepo, "/")
-		if len(parts) != 2 {
-			return errors.Errorf("github repo name should contain {OWNER}/{NAME}")
-		}
-
-		// Add tags to store commit information.
-		specTags[tags.XAkitaSource] = tags.CISource
-		specTags[tags.XAkitaGitHubRepo] = args.GitHubRepo
-		specTags[tags.XAkitaGitHubPR] = strconv.Itoa(args.GitHubPR)
-		specTags[tags.XAkitaGitBranch] = args.GitHubBranch
-		specTags[tags.XAkitaGitCommit] = args.GitHubCommit
-
-		githubPR = &github.PRInfo{
-			RepoOwner: parts[0],
-			RepoName:  parts[1],
-			Num:       args.GitHubPR,
-		}
-	}
-	if args.GitLabMR != nil {
-		// Add tags to store commit information.
-		specTags[tags.XAkitaSource] = tags.CISource
-		specTags[tags.XAkitaGitLabProject] = args.GitLabMR.Project
-		specTags[tags.XAkitaGitLabMRIID] = args.GitLabMR.IID
-		specTags[tags.XAkitaGitBranch] = args.GitLabMR.Branch
-		specTags[tags.XAkitaGitCommit] = args.GitLabMR.Commit
+	// Build tag set, extract CI or source-control information
+	specTags, githubPR, err := collectSpecTags(&args)
+	if err != nil {
+		return err
 	}
 
 	// Process input.

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -60,9 +60,6 @@ var Cmd = &cobra.Command{
 			outFlag.AkitaURI = &uri
 		}
 
-		// Tag the trace as being manually created by the user.
-		traceTags[tags.XAkitaSource] = tags.UserSource
-
 		args := apidump.Args{
 			ClientID:           akid.GenerateClientID(),
 			Domain:             akiflag.Domain,

--- a/cmd/internal/learn/cmd.go
+++ b/cmd/internal/learn/cmd.go
@@ -161,10 +161,11 @@ func runLearnMode() error {
 
 		// Tag as coming from CI.
 		tagsMap[tags.XAkitaSource] = tags.CISource
-	} else {
-		// Tag as coming from the user.
-		tagsMap[tags.XAkitaSource] = tags.UserSource
 	}
+	// Other tags are set up in apidump and/or apispec
+	// TODO: completely refactor so tags are only set here, or
+	// internal/apidump/cmd, or internal/apispec/cmd, instead
+	// of doing it twice in this case.
 
 	traceURI, err := runAPIDump(clientID, serviceName, tagsMap, plugins)
 	if err != nil {

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -45,7 +45,7 @@ func (d Deployment) String() string {
 }
 
 // Use envToTag map to see if any of the environment variables are present.
-// Return true if so.
+// Return true if so, and update the tagset.
 func (d Deployment) getTagsFromEnvironment(tagset map[tags.Key]string) bool {
 	found := false
 	for envVar, tag := range environmentToTag[d] {

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -1,0 +1,85 @@
+package deployment
+
+import (
+	"os"
+
+	"github.com/akitasoftware/akita-cli/printer"
+	"github.com/akitasoftware/akita-libs/tags"
+)
+
+type Deployment string
+
+const (
+	None       Deployment = ""
+	Unknown               = "unknown"
+	Kubernetes            = "kubernetes"
+)
+
+func (d Deployment) String() string {
+	return string(d)
+}
+
+func GetDeploymentInfo() (Deployment, map[tags.Key]string) {
+	// Allow the user to specify a deployment environment, even
+	// if it's of an unknown type.
+
+	deploymentType := None
+	tagset := make(map[tags.Key]string)
+
+	if d := os.Getenv("AKITA_DEPLOYMENT"); d != "" {
+		deploymentType = Unknown
+		tagset[tags.XAkitaDeployment] = d
+	}
+
+	// If there is a git commit associated with this deployment,
+	// then record it.
+	if c := os.Getenv("AKITA_DEPLOYMENT_COMMIT"); c != "" {
+		tagset[tags.XAkitaGitCommit] = c
+	}
+
+	if GetAWSTags(tagset) {
+		printer.Infof("Found AWS environment variables.\n")
+	}
+
+	if GetKubernetesTags(tagset) {
+		printer.Infof("Found Kubernetes environment variables.\n")
+		deploymentType = Kubernetes
+	}
+
+	return deploymentType, tagset
+}
+
+func GetKubernetesTags(tagset map[tags.Key]string) bool {
+	// Return true if any of these are present.
+	envMapping := []struct {
+		EnvVar string
+		Key    tags.Key
+	}{
+		{"AKITA_K8S_NAMESPACE", tags.XAkitaKubernetesNamespace},
+		{"AKITA_K8S_NODE", tags.XAkitaKubernetesNode},
+		{"AKITA_K8S_HOST_IP", tags.XAkitaKubernetesHostIP},
+		{"AKITA_K8S_POD", tags.XAkitaKubernetesPod},
+		{"AKITA_K8S_POD_IP", tags.XAkitaKubernetesPodIP},
+		{"AKITA_K8S_DAEMONSET", tags.XAkitaKubernetesDaemonset},
+	}
+
+	found := false
+	for _, e := range envMapping {
+		if v := os.Getenv(e.EnvVar); v != "" {
+			tagset[e.Key] = v
+			found = true
+		}
+	}
+
+	return found
+}
+
+func GetAWSTags(tagset map[tags.Key]string) bool {
+	// Only the region for now
+
+	if awsRegion := os.Getenv("AKITA_AWS_REGION"); awsRegion != "" {
+		tagset[tags.XAkitaAWSRegion] = awsRegion
+		return true
+	}
+	return false
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210406221235-f036dc848087
-	github.com/akitasoftware/akita-libs v0.0.0-20210615181930-d19978da466f
+	github.com/akitasoftware/akita-libs v0.0.0-20210616210415-89c2f6efadc8
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0
 	github.com/gdamore/tcell/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210615180249-656a48f41a4b h1:Lh6V+R
 github.com/akitasoftware/akita-libs v0.0.0-20210615180249-656a48f41a4b/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
 github.com/akitasoftware/akita-libs v0.0.0-20210615181930-d19978da466f h1:7dBzDbSPPm4xM83B2TbLajv7Y4GOwuMdjCC9vzJndL4=
 github.com/akitasoftware/akita-libs v0.0.0-20210615181930-d19978da466f/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
+github.com/akitasoftware/akita-libs v0.0.0-20210616210415-89c2f6efadc8 h1:xwhZAS2ouDWNO24g6rjzIxiX6L2Cp6H2yoJjL2AHLfQ=
+github.com/akitasoftware/akita-libs v0.0.0-20210616210415-89c2f6efadc8/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPBv9mohlLY3EzstN6ds8kxcc0lwq1F541115FP7xY=


### PR DESCRIPTION
I discovered while testing that when using 'learn' that the trace did not have the full set of tags; only the spec did.  I fixed this for deployment; should it also be fixed for CI?

Probably, I think, the automatic tags creation should be done by the original command during command line parsing; having "learn" process the tags twice, once in apidump.Run() and once in apispec.Run() and once in  is a little off.
