### PR TITLE
Listen to all local addresses, not just 127.0.0.1

### DIFF
--- a/daemon/run.go
+++ b/daemon/run.go
@@ -67,7 +67,7 @@ func Run(args Args) error {
 		router.Handle("/v1/services/{serviceName}/traces/{traceName}/events", httpHandler(addEvents)).Methods("POST")
 	}
 
-	listenSocket := fmt.Sprintf("127.0.0.1:%d", cmdArgs.PortNumber)
+	listenSocket := fmt.Sprintf(":%d", cmdArgs.PortNumber)
 	log.Fatal(http.ListenAndServe(listenSocket, router))
 	return nil
 }


### PR DESCRIPTION
The daemon cannot be run in a Docker container (even for same-host traffic) if it only listens to address 127.0.0.1.  The traffic from outside the container is destined to the container's address, like 172.17.0.2, so the connection is reset if there is an address mismatch.  e.g., 

```
mark@ubuntu:~/akibox-tutorial$ curl -X POST http://localhost:50080/v1/services/mgg-test/middleware -H "Content-type: application/json" -d '{"client_name" : "mgg_test", "active_trace_ids" : [] }'
curl: (56) Recv failure: Connection reset by peer
```

See https://stackoverflow.com/questions/57773604/connection-reset-by-peer-when-when-hitting-docker-container