### PR TITLE
Add --allow-host and --allow-path flags

### DIFF
--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -24,6 +24,8 @@ var (
 	tagsFlag            []string
 	pathExclusionsFlag  []string
 	hostExclusionsFlag  []string
+	pathAllowlistFlag   []string
+	hostAllowlistFlag   []string
 	execCommandFlag     string
 	execCommandUserFlag string
 	pluginsFlag         []string
@@ -70,6 +72,8 @@ var Cmd = &cobra.Command{
 			Filter:             filterFlag,
 			PathExclusions:     pathExclusionsFlag,
 			HostExclusions:     hostExclusionsFlag,
+			PathAllowlist:      pathAllowlistFlag,
+			HostAllowlist:      hostAllowlistFlag,
 			ExecCommand:        execCommandFlag,
 			ExecCommandUser:    execCommandUserFlag,
 			Plugins:            plugins,
@@ -138,6 +142,20 @@ func init() {
 		"host-exclusions",
 		nil,
 		"Removes HTTP hosts matching regular expressions.",
+	)
+
+	Cmd.Flags().StringSliceVar(
+		&pathAllowlistFlag,
+		"path-allow",
+		nil,
+		"Allows only HTTP paths matching regular expressions.",
+	)
+
+	Cmd.Flags().StringSliceVar(
+		&hostAllowlistFlag,
+		"host-allow",
+		nil,
+		"Allows only HTTP hosts matching regular expressions.",
 	)
 
 	Cmd.Flags().StringVarP(

--- a/cmd/internal/learn/cmd.go
+++ b/cmd/internal/learn/cmd.go
@@ -279,6 +279,8 @@ func runAPIDump(clientID akid.ClientID, serviceName string, tagsMap map[tags.Key
 		WitnessesPerMinute: rateLimitFlag,
 		PathExclusions:     pathExclusionsFlag,
 		HostExclusions:     hostExclusionsFlag,
+		PathAllowlist:      pathAllowlistFlag,
+		HostAllowlist:      hostAllowlistFlag,
 		ExecCommand:        execCommandFlag,
 		ExecCommandUser:    execCommandUserFlag,
 		Plugins:            plugins,

--- a/cmd/internal/learn/flags.go
+++ b/cmd/internal/learn/flags.go
@@ -20,6 +20,8 @@ var (
 	pathParamsFlag     []string
 	pathExclusionsFlag []string
 	hostExclusionsFlag []string
+	pathAllowlistFlag  []string
+	hostAllowlistFlag  []string
 
 	execCommandFlag     string
 	execCommandUserFlag string
@@ -137,6 +139,20 @@ You may specify multiple interfaces by using a comma-separated list (e.g.
 		"host-exclusions",
 		nil,
 		"Removes HTTP hosts matching regular expressions.",
+	)
+
+	Cmd.Flags().StringSliceVar(
+		&pathAllowlistFlag,
+		"path-allow",
+		nil,
+		"Allows only HTTP paths matching regular expressions.",
+	)
+
+	Cmd.Flags().StringSliceVar(
+		&hostAllowlistFlag,
+		"host-allow",
+		nil,
+		"Allows only HTTP hosts matching regular expressions.",
 	)
 
 	// GitHub integration flags.

--- a/trace/filters.go
+++ b/trace/filters.go
@@ -10,6 +10,7 @@ import (
 )
 
 // Filters out HTTP paths.
+// TODO: compile the N regular expressions into one for efficiency.
 func NewHTTPPathFilterCollector(matchers []*regexp.Regexp, col Collector) Collector {
 	return &genericRequestFilter{
 		Collector: col,
@@ -26,6 +27,7 @@ func NewHTTPPathFilterCollector(matchers []*regexp.Regexp, col Collector) Collec
 	}
 }
 
+// Filter out matching HTTP hosts
 func NewHTTPHostFilterCollector(matchers []*regexp.Regexp, col Collector) Collector {
 	return &genericRequestFilter{
 		Collector: col,
@@ -36,6 +38,39 @@ func NewHTTPHostFilterCollector(matchers []*regexp.Regexp, col Collector) Collec
 				}
 			}
 			return true
+		},
+	}
+}
+
+// Allows only matching paths
+// TODO: compile the N regular expressions into one for efficiency.
+func NewHTTPPathAllowlistCollector(matchers []*regexp.Regexp, col Collector) Collector {
+	return &genericRequestFilter{
+		Collector: col,
+		filterFunc: func(r akinet.HTTPRequest) bool {
+			if r.URL != nil {
+				for _, m := range matchers {
+					if m.MatchString(r.URL.Path) {
+						return true
+					}
+				}
+			}
+			return false
+		},
+	}
+}
+
+// Allows only matching hosts
+func NewHTTPHostAllowlistCollector(matchers []*regexp.Regexp, col Collector) Collector {
+	return &genericRequestFilter{
+		Collector: col,
+		filterFunc: func(r akinet.HTTPRequest) bool {
+			for _, m := range matchers {
+				if m.MatchString(r.Host) {
+					return true
+				}
+			}
+			return false
 		},
 	}
 }


### PR DESCRIPTION
Only add filters that are enabled to the stack of collectors.
Add a pre-filter packet count so that we can compare and warn if all
packets we eliminated due to filters.

```
[INFO] Captured 8 HTTP requests before allow and exclude rules, but all were filtered.
[ERROR] No inbound HTTP calls captured! 🛑
```

