### PR TITLE
Add `--tags` to `upload` command

### DIFF
--- a/cmd/internal/upload/cmd.go
+++ b/cmd/internal/upload/cmd.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/akitasoftware/akita-libs/akiuri"
+	"github.com/akitasoftware/akita-libs/tags"
 
 	"github.com/akitasoftware/akita-cli/cmd/internal/akiflag"
 	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
@@ -71,11 +72,24 @@ var Cmd = &cobra.Command{
 			return errors.New("\"plugins\" can only be used with trace objects")
 		}
 
+		// The flags --append and --tags cannot be used together.
+		// TODO: add support for this.
+		if appendFlag && len(tagsFlag) > 0 {
+			return errors.New("\"append\" and \"tags\" cannot be used together")
+		}
+
+		// Parse tags.
+		tags, err := tags.FromPairs(tagsFlag)
+		if err != nil {
+			return err
+		}
+
 		uploadArgs := upload.Args{
 			ClientID:      akiflag.GetClientID(),
 			Domain:        akiflag.Domain,
 			DestURI:       destURI,
 			FilePaths:     args,
+			Tags:          tags,
 			Append:        appendFlag,
 			UploadTimeout: uploadTimeoutFlag,
 		}

--- a/cmd/internal/upload/flags.go
+++ b/cmd/internal/upload/flags.go
@@ -12,9 +12,10 @@ var (
 	// Optional flags
 	specNameFlag string // deprecated
 
+	tagsFlag []string
+
 	appendFlag          bool
 	includeTrackersFlag bool
-	overwriteFlag       bool
 	uploadTimeoutFlag   time.Duration
 
 	pluginsFlag []string
@@ -52,6 +53,13 @@ func init() {
 		"",
 		"A custom name for the spec.")
 	Cmd.Flags().MarkDeprecated("name", "use --dest instead.")
+
+	Cmd.Flags().StringSliceVar(
+		&tagsFlag,
+		"tags",
+		nil,
+		`Adds tags to the uploaded object. Specified as a comma-seprated list of "key=value" pairs.`,
+	)
 
 	Cmd.Flags().BoolVar(
 		&appendFlag,

--- a/upload/args.go
+++ b/upload/args.go
@@ -6,6 +6,7 @@ import (
 	"github.com/akitasoftware/akita-cli/plugin"
 	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/akita-libs/akiuri"
+	"github.com/akitasoftware/akita-libs/tags"
 )
 
 type Args struct {
@@ -17,6 +18,7 @@ type Args struct {
 	FilePaths []string
 
 	// Optional args
+	Tags            map[tags.Key]string
 	Append          bool
 	IncludeTrackers bool
 	UploadTimeout   time.Duration


### PR DESCRIPTION
Allow users to specify tags when uploading specs and traces.