### PR TITLE
Signal rate limit collectors in a nonblocking fashion

### DIFF
--- a/trace/rate_limit.go
+++ b/trace/rate_limit.go
@@ -128,6 +128,8 @@ func (r *SharedRateLimit) startNewEpoch(epochStart time.Time) {
 	printer.Debugln("New collection epoch:", epochStart)
 
 	r.lock.Lock()
+	defer r.lock.Unlock()
+
 	r.CurrentEpochStart = time.Now()
 
 	// Ensure timer is stopped before reset
@@ -145,9 +147,7 @@ func (r *SharedRateLimit) startNewEpoch(epochStart time.Time) {
 		r.intervalTimer.Reset(randomOffset)
 	}
 
-	r.lock.Unlock()
-
-	// Trigger request expiration for all collectors
+	// Trigger request expiration for all collectors.
 	// If they never have Process() called, then their channel will fill up,
 	// so do this in a nonblocking fashion (with buffer size 1).
 	threshold := epochStart.Add(-1 * viper.GetDuration(RateLimitMaxDuration))


### PR DESCRIPTION
The bug here is that the other side of this channel is read in rateLimitCollector.Process().  It is used to signal the start of a new epoch, so that the collectors have a chance to expire unmatched requests.

But, if there is no traffic on a particular interface for 10 minutes, then that collector's Process() method would never be called and so not clear the channel.  Then startNewEpoch() would block with the lock held.

The fix here is to send to the rate-limited collectors in a nonblocking fashion.  If they aren't receiving packets, then it's not particularly important to expire their request map.  I also decided to do the channel writes without the mutex held.

Verified by letting the CLI run that the new code path is used:

```
[INFO] Running learn mode on interfaces lo, ens33, docker0, br-a3f4bbff3da2, br-75a0084d9170, br-1d38328ca3be
[DEBUG]  New sample interval started: 2021-06-26 13:12:28.745940687 -0500 CDT m=+0.118943721
...
[DEBUG] Time to first packet on ens33: 28.259088598s
[DEBUG] Time to first packet on lo: 41.491297473s
[DEBUG]  New collection epoch: 2021-06-26 13:17:28.747852096 -0500 CDT m=+300.120855128
[DEBUG]  New sample interval started: 2021-06-26 13:17:28.747937013 -0500 CDT m=+300.120940045
[DEBUG] Expired 0 old requests
[DEBUG] Expired 0 old requests
[DEBUG]  New collection epoch: 2021-06-26 13:22:28.747025092 -0500 CDT m=+600.120028125
[DEBUG] child collector 0xc0004f9140 not accepting epoch start
[DEBUG] child collector 0xc0004f9a40 not accepting epoch start
[DEBUG] child collector 0xc0004f9cb0 not accepting epoch start
[DEBUG] child collector 0xc0001f1560 not accepting epoch start
[DEBUG]  New sample interval started: 2021-06-26 13:22:28.747151508 -0500 CDT m=+600.120154542
[DEBUG] Expired 0 old requests
[DEBUG] Expired 0 old requests
```


