### PR TITLE
Add command-line flags to refer to a trace by tag

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -56,7 +56,7 @@ type Args struct {
 
 	// If both LocalPath and AkitaURI are set, data is teed to both local traces
 	// and backend trace.
-	// If unset, defaults to a random spec on Akita Cloud.
+	// If unset, defaults to a random spec name on Akita Cloud.
 	Out location.Location
 
 	Interfaces     []string

--- a/cmd/internal/apispec/cmd.go
+++ b/cmd/internal/apispec/cmd.go
@@ -8,6 +8,8 @@ import (
 	"github.com/akitasoftware/akita-cli/cmd/internal/akiflag"
 	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
 	"github.com/akitasoftware/akita-cli/cmd/internal/pluginloader"
+	"github.com/akitasoftware/akita-cli/location"
+	"github.com/akitasoftware/akita-cli/util"
 	"github.com/akitasoftware/akita-libs/gitlab"
 	"github.com/akitasoftware/akita-libs/tags"
 )
@@ -20,6 +22,34 @@ var Cmd = &cobra.Command{
 		traces, err := toLocations(tracesFlag)
 		if err != nil {
 			return err
+		}
+
+		traceTags, err := tags.FromPairs(tracesByTagFlag)
+		if err != nil {
+			return err
+		}
+
+		if len(traces) == 0 && len(traceTags) == 0 {
+			return errors.New("Must specify at least one input via \"traces\" or \"trace-tag\"")
+		}
+
+		if len(traceTags) > 0 {
+			var serviceName string
+			if serviceFlag != "" {
+				serviceName = serviceFlag
+			} else if outFlag.AkitaURI != nil {
+				serviceName = outFlag.AkitaURI.ServiceName
+			} else {
+				return errors.New("Must specify \"service\" or \"out\" to use \"trace-tag\"")
+			}
+			destURI, err := util.GetTraceURIByTags(akiflag.Domain, akiflag.GetClientID(), serviceName, traceTags, "trace-tag")
+			if err != nil {
+				return err
+			}
+			if destURI.ObjectName == "" {
+				return cmderr.AkitaErr{Err: errors.New("No traces matching specified tag, cannot create spec")}
+			}
+			traces = append(traces, location.Location{AkitaURI: &destURI})
 		}
 
 		tags, err := tags.FromPairs(tagsFlag)

--- a/cmd/internal/apispec/flags.go
+++ b/cmd/internal/apispec/flags.go
@@ -1,14 +1,13 @@
 package apispec
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/akitasoftware/akita-cli/location"
 )
 
 var (
 	// Required flags.
-	tracesFlag []string
+	tracesFlag      []string
+	tracesByTagFlag []string
 
 	// Optional flags
 	outFlag     location.Location
@@ -41,7 +40,12 @@ func init() {
 		"traces",
 		nil,
 		"The locations to read traces from. Can be a mix of AkitaURI and local file paths.")
-	cobra.MarkFlagRequired(Cmd.Flags(), "traces")
+
+	Cmd.Flags().StringSliceVar(
+		&tracesByTagFlag,
+		"trace-tag",
+		nil,
+		"Use a the most recent trace in the Akita cloud with a matching tag as input.")
 
 	//
 	// Optional Flags

--- a/cmd/internal/apispec/flags.go
+++ b/cmd/internal/apispec/flags.go
@@ -45,7 +45,7 @@ func init() {
 		&tracesByTagFlag,
 		"trace-tag",
 		nil,
-		"Use a the most recent trace in the Akita cloud with a matching tag as input.")
+		"Use the most recent trace in the Akita cloud with a matching tag as input.")
 
 	//
 	// Optional Flags

--- a/cmd/internal/upload/flags.go
+++ b/cmd/internal/upload/flags.go
@@ -15,6 +15,7 @@ var (
 	tagsFlag []string
 
 	appendFlag          bool
+	appendByTagFlag     bool
 	includeTrackersFlag bool
 	uploadTimeoutFlag   time.Duration
 
@@ -66,6 +67,12 @@ func init() {
 		"append",
 		false,
 		"Add the upload to an existing Akita trace.")
+
+	Cmd.Flags().BoolVar(
+		&appendByTagFlag,
+		"append-by-tag",
+		false,
+		"Add the upload to the most recent Akita trace with matching tag.")
 
 	Cmd.Flags().BoolVar(
 		&includeTrackersFlag,

--- a/util/util.go
+++ b/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	cache "github.com/patrickmn/go-cache"
 	"github.com/pkg/errors"
 
+	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-cli/rest"
 	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/akita-libs/akiuri"
@@ -24,13 +26,16 @@ var (
 
 	// Maps learn session name to ID.
 	learnSessionNameCache = cache.New(30*time.Second, 5*time.Minute)
+
+	// API timeout
+	apiTimeout = 20 * time.Second
 )
 
 func NewLearnSession(domain string, clientID akid.ClientID, svc akid.ServiceID, sessionName string, tags map[tags.Key]string, baseSpecRef *kgxapi.APISpecReference) (akid.LearnSessionID, error) {
 	learnClient := rest.NewLearnClient(domain, clientID, svc)
 
 	// Create a new learn session.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), apiTimeout)
 	defer cancel()
 	lrn, err := learnClient.CreateLearnSession(ctx, baseSpecRef, sessionName, tags)
 	if err != nil {
@@ -46,7 +51,7 @@ func GetServiceIDByName(c rest.FrontClient, name string) (akid.ServiceID, error)
 	}
 
 	// Fill cache.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), apiTimeout)
 	defer cancel()
 	services, err := c.GetServices(ctx)
 	if err != nil {
@@ -68,7 +73,7 @@ func GetServiceIDByName(c rest.FrontClient, name string) (akid.ServiceID, error)
 }
 
 func DaemonHeartbeat(c rest.FrontClient, daemonName string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), apiTimeout)
 	defer cancel()
 	err := c.DaemonHeartbeat(ctx, daemonName)
 	if err != nil {
@@ -90,7 +95,7 @@ func GetLearnSessionIDByName(c rest.LearnClient, name string) (akid.LearnSession
 	}
 
 	// Fill cache.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), apiTimeout)
 	defer cancel()
 	id, err := c.GetLearnSessionIDByName(ctx, name)
 	if err != nil {
@@ -100,11 +105,77 @@ func GetLearnSessionIDByName(c rest.LearnClient, name string) (akid.LearnSession
 	return id, nil
 }
 
+func GetLearnSessionByTags(c rest.LearnClient, serviceID akid.ServiceID, tags map[tags.Key]string) (*kgxapi.ListedLearnSession, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), apiTimeout)
+	defer cancel()
+
+	sessions, err := c.ListLearnSessions(ctx, serviceID, tags)
+	if err != nil {
+		return nil, errors.Wrapf(err, "listing sessions for %v by tag failed", akid.String(serviceID))
+	}
+
+	if len(sessions) == 0 {
+		return nil, nil
+	}
+
+	// TODO: support AND-based matching on the back-end
+	printer.Debugf("Found %d sessions, filtering for most recent match.\n", len(sessions))
+	latest := -1
+	for i, s := range sessions {
+		if latest < 0 || s.CreationTime.After(sessions[latest].CreationTime) {
+			latest = i
+		}
+	}
+
+	return sessions[latest], nil
+}
+
+// Get the most recent trace for a service; helper method for commands to implement the
+// --append-by-tag or --trace-tag flags.
+func GetTraceURIByTags(domain string, clientID akid.ClientID, serviceName string, tags map[tags.Key]string, flagName string) (akiuri.URI, error) {
+	if len(tags) == 0 {
+		return akiuri.URI{}, fmt.Errorf("Must specify a tag to match with %q", flagName)
+	}
+
+	if len(tags) > 1 {
+		return akiuri.URI{}, fmt.Errorf("%q currently supports only a single tag", flagName)
+	}
+
+	// Resolve ServiceID
+	// TODO: find a better way to overlap this with commands that already do the lookup
+	frontClient := rest.NewFrontClient(domain, clientID)
+	serviceID, err := GetServiceIDByName(frontClient, serviceName)
+	if err != nil {
+		return akiuri.URI{}, errors.Wrapf(err, "failed to resolve service name %q", serviceName)
+	}
+
+	learnClient := rest.NewLearnClient(domain, clientID, serviceID)
+	learnSession, err := GetLearnSessionByTags(learnClient, serviceID, tags)
+	if err != nil {
+		return akiuri.URI{}, errors.Wrapf(err, "failed to list traces for %q", serviceName)
+	}
+	if learnSession == nil {
+		printer.Infof("No traces matching specified tag\n")
+		return akiuri.URI{
+			ServiceName: serviceName,
+			ObjectName:  "", // create a new name
+			ObjectType:  akiuri.TRACE.Ptr(),
+		}, nil
+	}
+	uri := akiuri.URI{
+		ServiceName: serviceName,
+		ObjectName:  learnSession.Name,
+		ObjectType:  akiuri.TRACE.Ptr(),
+	}
+	printer.Infof("Trace %v matches tag\n", uri.String())
+	return uri, nil
+}
+
 func ResolveSpecURI(lc rest.LearnClient, uri akiuri.URI) (akid.APISpecID, error) {
 	if !uri.ObjectType.IsSpec() {
 		return akid.APISpecID{}, errors.Errorf("AkitaURI must refer to a spec object")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), apiTimeout)
 	defer cancel()
 	return lc.GetAPISpecIDByName(ctx, uri.ObjectName)
 }


### PR DESCRIPTION
Usage examples

```
akita upload --dest akita://mgg-test:trace --append-by-tag --tags tester=mark foo/akita_lo.har
[INFO] Appending to akita://mgg-test:trace:marsh-wasp-ebb9ec14
[INFO] Uploading "foo/akita_lo.har"...
...

akita apidump --append-by-tag --out akita://mgg-test --filter "port 8000" --tags tester=bob
[INFO] No matching traces found, creating new trace.
[INFO] Created new trace on Akita Cloud: akita://mgg-test:trace:quilt-ape-cddc2f9a
...

akita apidump --service mgg-test --append-by-tag --tags tester=bob
[INFO] Trace akita://mgg-test:trace:quilt-ape-cddc2f9a matches tag
[INFO] Adding to existing trace: akita://mgg-test:trace:quilt-ape-cddc2f9a
...

akita apispec --service mgg-test --trace-tag tester=mark 
[INFO] Trace akita://mgg-test:trace:marsh-wasp-ebb9ec14 matches tag
[INFO] Generating API specification...
```

Limitation for now is that only one tag may be used.  The correct thing to do long-term is to have the server make the create-or-append decision to avoid a race condition between different clients.
