### PR TITLE
Increase upload batch size to 120 witnesses

### DIFF
--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -31,7 +31,7 @@ const (
 	pairCacheCleanupInterval = 30 * time.Second
 
 	// Max size per upload batch.
-	uploadBatchMaxSize = 10
+	uploadBatchMaxSize = 120
 
 	// How often to flush the upload batch.
 	uploadBatchFlushDuration = 30 * time.Second


### PR DESCRIPTION
This is just a stopgap. We really should be measuring the size of the accumulated payload, not the number of witnesses.