### PR TITLE
Add time-bounds options to `apispec`

### DIFF
--- a/apispec/run.go
+++ b/apispec/run.go
@@ -34,6 +34,7 @@ import (
 	"github.com/akitasoftware/akita-libs/gitlab"
 	pp "github.com/akitasoftware/akita-libs/path_pattern"
 	"github.com/akitasoftware/akita-libs/tags"
+	"github.com/akitasoftware/akita-libs/time_span"
 
 	"github.com/akitasoftware/akita-cli/plugin"
 )
@@ -56,6 +57,7 @@ type Args struct {
 	IncludeTrackers            bool
 	PathParams                 []string
 	PathExclusions             []string
+	TimeRange                  *time_span.TimeSpan
 
 	GitHubBranch string
 	GitHubCommit string
@@ -245,6 +247,7 @@ func Run(args Args) error {
 		PathExclusions: pathExclusions,
 		GitHubPR:       githubPR,
 		GitLabMR:       args.GitLabMR,
+		TimeRange:      args.TimeRange,
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to create new spec")

--- a/cmd/internal/apispec/flags.go
+++ b/cmd/internal/apispec/flags.go
@@ -1,6 +1,9 @@
 package apispec
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/akitasoftware/akita-cli/location"
 )
 
@@ -27,6 +30,9 @@ var (
 	tagsFlag                       []string
 	getSpecEnableRelatedFieldsFlag bool
 	includeTrackersFlag            bool
+
+	fromTimeFlag string
+	toTimeFlag   string
 
 	pathParamsFlag     []string
 	pathExclusionsFlag []string
@@ -123,6 +129,28 @@ func init() {
 		"include-trackers",
 		false,
 		"If set to true, disables automatic filtering of requests to third-party trackers that are recorded in traces.")
+
+	// Figure out the local time zone.
+	now := time.Now()
+	timeZone, offsetSecs := now.Zone()
+	offsetDir := "+"
+	if offsetSecs < 0 {
+		offsetDir = "-"
+		offsetSecs = -offsetSecs
+	}
+	offsetHours := offsetSecs / 3600
+	offsetMinutes := (offsetSecs / 60) % 60
+
+	Cmd.Flags().StringVar(
+		&fromTimeFlag,
+		"from-time",
+		"",
+		fmt.Sprintf("If provided, only trace events occurring at or after this time will be used to build the spec. Expected format is 'YYYY-MM-DD hh:mm:ss'. If desired, the 'hh:mm:ss' or the ':ss' can be omitted, in which case the start of the day or minute is used. The client's local time zone is assumed: %s (%s%02d:%02d). If the given time occurs during a transition to or from daylight saving time, then one side of the transition is arbitrarily chosen.", timeZone, offsetDir, offsetHours, offsetMinutes))
+	Cmd.Flags().StringVar(
+		&toTimeFlag,
+		"to-time",
+		"",
+		fmt.Sprintf("If provided, only trace events occurring at or before this time will be used to build the spec. Expected format is 'YYYY-MM-DD hh:mm:ss'. If desired, the 'hh:mm:ss' or the ':ss' can be omitted, in which case the start of the day or minute is used. The client's local time zone is assumed: %s (%s%02d:%02d). If the given time occurs during a transition to or from daylight saving time, then one side of the transition is arbitrarily chosen.", timeZone, offsetDir, offsetHours, offsetMinutes))
 
 	// GitLab integration
 	Cmd.Flags().StringVar(

--- a/cmd/internal/man/apispec_page.go
+++ b/cmd/internal/man/apispec_page.go
@@ -51,6 +51,11 @@ Output format for the OpenAPI 3 specification. Supports 'yaml' and 'json'.
 
 Default is 'yaml'.
 
+## --from-time string
+## --to-time string
+
+If provided, only trace events occurring in the given time range will be used to build the spec. Expected format is 'YYYY-MM-DD hh:mm:ss'. If desired, the 'hh:mm:ss' or the ':ss' can be omitted, in which case the start of the day or minute is used. The client's local time is assumed. If a given time occurs during a transition to or from daylight saving time, then one side of the transition is arbitrarily chosen.
+
 ## --tags []string
 
 Add tags to the spec.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210406221235-f036dc848087
-	github.com/akitasoftware/akita-libs v0.0.0-20210707163109-e531702e5a81
+	github.com/akitasoftware/akita-libs v0.0.0-20210707204046-8388976a7962
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0
 	github.com/gdamore/tcell/v2 v2.1.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210406221235-f036dc848087
-	github.com/akitasoftware/akita-libs v0.0.0-20210630213053-52fdc82e38a9
+	github.com/akitasoftware/akita-libs v0.0.0-20210707163109-e531702e5a81
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0
 	github.com/gdamore/tcell/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210624194008-afbe15b4e3f3 h1:TscDbm
 github.com/akitasoftware/akita-libs v0.0.0-20210624194008-afbe15b4e3f3/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
 github.com/akitasoftware/akita-libs v0.0.0-20210630213053-52fdc82e38a9 h1:ZfFrkyo3Py6BO+or3ABT+hL6T1xoYigtN+pcc3pSYaQ=
 github.com/akitasoftware/akita-libs v0.0.0-20210630213053-52fdc82e38a9/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
+github.com/akitasoftware/akita-libs v0.0.0-20210707163109-e531702e5a81 h1:0KINjgf3owBk3QbIGCyW3/BQz+TOraWzqFf4eM1ZQ9o=
+github.com/akitasoftware/akita-libs v0.0.0-20210707163109-e531702e5a81/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPBv9mohlLY3EzstN6ds8kxcc0lwq1F541115FP7xY=

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210624194008-afbe15b4e3f3 h1:TscDbm
 github.com/akitasoftware/akita-libs v0.0.0-20210624194008-afbe15b4e3f3/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
 github.com/akitasoftware/akita-libs v0.0.0-20210630213053-52fdc82e38a9 h1:ZfFrkyo3Py6BO+or3ABT+hL6T1xoYigtN+pcc3pSYaQ=
 github.com/akitasoftware/akita-libs v0.0.0-20210630213053-52fdc82e38a9/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
-github.com/akitasoftware/akita-libs v0.0.0-20210707163109-e531702e5a81 h1:0KINjgf3owBk3QbIGCyW3/BQz+TOraWzqFf4eM1ZQ9o=
-github.com/akitasoftware/akita-libs v0.0.0-20210707163109-e531702e5a81/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
+github.com/akitasoftware/akita-libs v0.0.0-20210707204046-8388976a7962 h1:SUIqjDVdoxtJAnOzxcPqbkdguwSp+1Trq4imqnSaTkw=
+github.com/akitasoftware/akita-libs v0.0.0-20210707204046-8388976a7962/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPBv9mohlLY3EzstN6ds8kxcc0lwq1F541115FP7xY=

--- a/rest/interface.go
+++ b/rest/interface.go
@@ -12,6 +12,7 @@ import (
 	pp "github.com/akitasoftware/akita-libs/path_pattern"
 	"github.com/akitasoftware/akita-libs/path_trie"
 	"github.com/akitasoftware/akita-libs/tags"
+	"github.com/akitasoftware/akita-libs/time_span"
 )
 
 type GetSpecOptions struct {
@@ -24,6 +25,7 @@ type CreateSpecOptions struct {
 	PathExclusions []*regexp.Regexp
 	GitHubPR       *github.PRInfo
 	GitLabMR       *gitlab.MRInfo
+	TimeRange      *time_span.TimeSpan
 }
 
 type LearnClient interface {

--- a/rest/learn_client.go
+++ b/rest/learn_client.go
@@ -107,6 +107,9 @@ func (c *learnClientImpl) CreateSpec(ctx context.Context, name string, lrns []ak
 	if opts.GitLabMR != nil {
 		req["gitlab_mr"] = opts.GitLabMR
 	}
+	if opts.TimeRange != nil {
+		req["time_range"] = opts.TimeRange
+	}
 
 	p := path.Join("/v1/services", akid.String(c.serviceID), "specs")
 	var resp kgxapi.CreateSpecResponse


### PR DESCRIPTION
This adds `--from-time` and `--to-time` options to `apispec` for filtering which witnesses are included in the generated spec. The intent is for this to filter by the witnesses' observation time. However due to limitations in the current database schema, for witnesses that are observed multiple times, this currently filters on the first time each witness was observed in a learn session. Future back-end improvements will bring these options closer to the intended semantics.