### PR TITLE
Add hidden flag (and config file entry) for max HTTP length

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,7 +81,7 @@ func init() {
 	rootCmd.PersistentFlags().MarkHidden("domain")
 
 	// Semi-secret somewhat-safe flags
-	rootCmd.PersistentFlags().Int64Var(&http.MaximumHTTPLength, "max-http-length", 1024*1024, "Maximum size of HTTP body to capture")
+	rootCmd.PersistentFlags().Int64Var(&http.MaximumHTTPLength, "max-http-length", 10*1024*1024, "Maximum size of HTTP body to capture")
 	rootCmd.PersistentFlags().MarkHidden("max-http-length")
 	viper.BindPFlag("max-http-length", rootCmd.PersistentFlags().Lookup("max-http-length"))
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-cli/util"
 	"github.com/akitasoftware/akita-cli/version"
+	"github.com/akitasoftware/akita-libs/akinet/http"
 )
 
 var (
@@ -77,6 +78,11 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().StringVar(&akiflag.Domain, "domain", defaultDomain, "Your assigned Akita domain (e.g. company.akita.software)")
 	rootCmd.PersistentFlags().MarkHidden("domain")
+
+	// Semi-secret somewhat-safe flags
+	rootCmd.PersistentFlags().Int64Var(&http.MaximumHTTPLength, "max-http-length", 1024*1024, "Maximum size of HTTP body to capture")
+	rootCmd.PersistentFlags().MarkHidden("max-http-length")
+	viper.BindPFlag("max-http-length", rootCmd.PersistentFlags().Lookup("max-http-length"))
 
 	// Super secret unsafe test only flags
 	rootCmd.PersistentFlags().BoolVar(&testOnlyUseHTTPSFlag, "test_only_disable_https", false, "TEST ONLY - whether to use HTTPS when communicating with backend")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/akitasoftware/akita-cli/cmd/internal/man"
 	"github.com/akitasoftware/akita-cli/cmd/internal/setversion"
 	"github.com/akitasoftware/akita-cli/cmd/internal/upload"
+	"github.com/akitasoftware/akita-cli/pcap"
 	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-cli/util"
 	"github.com/akitasoftware/akita-cli/version"
@@ -83,6 +84,10 @@ func init() {
 	rootCmd.PersistentFlags().Int64Var(&http.MaximumHTTPLength, "max-http-length", 1024*1024, "Maximum size of HTTP body to capture")
 	rootCmd.PersistentFlags().MarkHidden("max-http-length")
 	viper.BindPFlag("max-http-length", rootCmd.PersistentFlags().Lookup("max-http-length"))
+
+	rootCmd.PersistentFlags().Int64Var(&pcap.StreamTimeoutSeconds, "stream-timeout-seconds", 10, "Maximum time to wait for missing TCP data")
+	rootCmd.PersistentFlags().MarkHidden("stream-timeout-seconds")
+	viper.BindPFlag("stream-timeout-seconds", rootCmd.PersistentFlags().Lookup("stream-timeout-seconds"))
 
 	// Super secret unsafe test only flags
 	rootCmd.PersistentFlags().BoolVar(&testOnlyUseHTTPSFlag, "test_only_disable_https", false, "TEST ONLY - whether to use HTTPS when communicating with backend")

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210406221235-f036dc848087
-	github.com/akitasoftware/akita-libs v0.0.0-20210707204046-8388976a7962
+	github.com/akitasoftware/akita-libs v0.0.0-20210713070204-b8e04881be61
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0
 	github.com/gdamore/tcell/v2 v2.1.0


### PR DESCRIPTION
Depends on https://github.com/akitasoftware/akita-libs/pull/58

Also lowers the stream timeout to 10 seconds, with a flag for configuring it.