### PR TITLE
Enable CPU and heap profiling based on command line flags.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210702192150-009c95f6b1e4 h1:a38qVp
 github.com/akitasoftware/akita-libs v0.0.0-20210702192150-009c95f6b1e4/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
 github.com/akitasoftware/akita-libs v0.0.0-20210707204046-8388976a7962 h1:SUIqjDVdoxtJAnOzxcPqbkdguwSp+1Trq4imqnSaTkw=
 github.com/akitasoftware/akita-libs v0.0.0-20210707204046-8388976a7962/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
+github.com/akitasoftware/akita-libs v0.0.0-20210713070204-b8e04881be61 h1:q2KFounSz1bJ5x9SN9eHRlJUP9zc/eF861UGGqf0tUI=
+github.com/akitasoftware/akita-libs v0.0.0-20210713070204-b8e04881be61/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPBv9mohlLY3EzstN6ds8kxcc0lwq1F541115FP7xY=


### PR DESCRIPTION
Example usage:

```
bin/akita apidump --out foo --heap-profile heap.prof --cpu-profile cpu.prof --live-profile localhost:6060
...
go tool pprof http://localhost:6060/debug/pprof/heap
```

