### PR TITLE
Fix success message for akita upload cmd

### DIFF
--- a/upload/run.go
+++ b/upload/run.go
@@ -70,8 +70,6 @@ func Run(args Args) error {
 		ObjectName:  objectName,
 	}
 	printer.Stderr.Infof("%s 🎉\n", aurora.Green("Success!"))
-
-	// print URI to stdout for easy scripting
 	printer.Stderr.Infof(fmt.Sprintf("Your upload is available as: %s\n", uri.String()))
 
 	return nil

--- a/upload/run.go
+++ b/upload/run.go
@@ -70,8 +70,9 @@ func Run(args Args) error {
 		ObjectName:  objectName,
 	}
 	printer.Stderr.Infof("%s 🎉\n", aurora.Green("Success!"))
-	printer.Stderr.Infof("Your upload is available as: ")
-	fmt.Println(uri.String()) // print URI to stdout for easy scripting
+
+	// print URI to stdout for easy scripting
+	printer.Stderr.Infof(fmt.Sprintf("Your upload is available as: %s\n", uri.String()))
 
 	return nil
 }


### PR DESCRIPTION
The CLI output for `akita upload` mixed `info` output on `stderr` and `stdout`, which occasionally caused the formatting to break.  This PR switches to use `stderr` exclusively.