### PR TITLE
Assign versions on model creation

### DIFF
--- a/apispec/run.go
+++ b/apispec/run.go
@@ -53,6 +53,7 @@ type Args struct {
 	Service                    string
 	Format                     string
 	Tags                       map[tags.Key]string
+	Versions                   []string
 	GetSpecEnableRelatedFields bool
 	IncludeTrackers            bool
 	PathParams                 []string
@@ -243,6 +244,7 @@ func Run(args Args) error {
 	defer cancel()
 	outSpecID, err := learnClient.CreateSpec(ctx, outSpecName, learnSessions, rest.CreateSpecOptions{
 		Tags:           specTags,
+		Versions:       args.Versions,
 		PathPatterns:   pathPatternsFromStrings(args.PathParams),
 		PathExclusions: pathExclusions,
 		GitHubPR:       githubPR,

--- a/cmd/internal/apispec/cmd.go
+++ b/cmd/internal/apispec/cmd.go
@@ -15,6 +15,7 @@ import (
 	"github.com/akitasoftware/akita-libs/gitlab"
 	"github.com/akitasoftware/akita-libs/tags"
 	"github.com/akitasoftware/akita-libs/time_span"
+	"github.com/akitasoftware/akita-libs/version_names"
 )
 
 func parseTime(s string) (time.Time, error) {
@@ -44,6 +45,13 @@ var Cmd = &cobra.Command{
 		traceTags, err := tags.FromPairs(tracesByTagFlag)
 		if err != nil {
 			return err
+		}
+
+		// Check for reserved versions.
+		for _, version := range versionsFlag {
+			if version_names.IsReservedVersionName(version) {
+				return errors.Errorf("'%s' is an Akita-reserved version", version)
+			}
 		}
 
 		var timeRange *time_span.TimeSpan
@@ -116,6 +124,7 @@ var Cmd = &cobra.Command{
 			Service:        serviceFlag,
 			Format:         formatFlag,
 			Tags:           tags,
+			Versions:       versionsFlag,
 			PathParams:     pathParamsFlag,
 			PathExclusions: pathExclusionsFlag,
 			TimeRange:      timeRange,

--- a/cmd/internal/apispec/flags.go
+++ b/cmd/internal/apispec/flags.go
@@ -28,6 +28,7 @@ var (
 
 	formatFlag                     string
 	tagsFlag                       []string
+	versionsFlag                   []string
 	getSpecEnableRelatedFieldsFlag bool
 	includeTrackersFlag            bool
 
@@ -103,6 +104,12 @@ func init() {
 		"tags",
 		nil,
 		`Adds tags to the spec. Specified as a comma separated list of "key=value" pairs.`,
+	)
+	Cmd.Flags().StringSliceVar(
+		&versionsFlag,
+		"versions",
+		nil,
+		`Assigns versions to the spec.  Versions are similar to tags, but a version may only be assigned to one spec within a service. Specified as a comma separated list of strings.`,
 	)
 	Cmd.Flags().StringSliceVar(
 		&pathParamsFlag,

--- a/cmd/internal/learn/cmd.go
+++ b/cmd/internal/learn/cmd.go
@@ -14,6 +14,12 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/akitasoftware/akita-libs/akid"
+	"github.com/akitasoftware/akita-libs/akiuri"
+	"github.com/akitasoftware/akita-libs/gitlab"
+	"github.com/akitasoftware/akita-libs/tags"
+	"github.com/akitasoftware/akita-libs/version_names"
+
 	"github.com/akitasoftware/akita-cli/apidump"
 	"github.com/akitasoftware/akita-cli/apispec"
 	"github.com/akitasoftware/akita-cli/cmd/internal/akiflag"
@@ -23,10 +29,6 @@ import (
 	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-cli/rest"
 	"github.com/akitasoftware/akita-cli/util"
-	"github.com/akitasoftware/akita-libs/akid"
-	"github.com/akitasoftware/akita-libs/akiuri"
-	"github.com/akitasoftware/akita-libs/gitlab"
-	"github.com/akitasoftware/akita-libs/tags"
 
 	"github.com/akitasoftware/akita-cli/plugin"
 )
@@ -148,6 +150,13 @@ func runLearnMode() error {
 	tagsMap, err := tags.FromPairs(tagsFlag)
 	if err != nil {
 		return err
+	}
+
+	// Check for reserved versions.
+	for _, version := range versionsFlag {
+		if version_names.IsReservedVersionName(version) {
+			return errors.Errorf("'%s' is an Akita-reserved version", version)
+		}
 	}
 
 	// Populate legacy github integration tag.
@@ -318,6 +327,7 @@ func runAPISpec(clientID akid.ClientID, serviceName string, traceURI *akiuri.URI
 		Service:        serviceName,
 		Format:         "yaml",
 		Tags:           tagsMap,
+		Versions:       versionsFlag,
 		PathParams:     pathParamsFlag,
 		PathExclusions: pathExclusionsFlag,
 

--- a/cmd/internal/learn/flags.go
+++ b/cmd/internal/learn/flags.go
@@ -14,6 +14,7 @@ var (
 	filterFlag     string
 	interfacesFlag []string
 	tagsFlag       []string
+	versionsFlag   []string
 	sampleRateFlag float64
 	rateLimitFlag  float64
 
@@ -85,6 +86,16 @@ func registerOptionalFlags() {
 		"tags",
 		nil,
 		`Adds tags to the new learn session. Specified as a comma separated list of "key=value" pairs.
+
+Ignored if --session is used to attach to an existing learn session.
+`,
+	)
+
+	Cmd.Flags().StringSliceVar(
+		&versionsFlag,
+		"versions",
+		nil,
+		`Assigns versions to the spec.  Versions are similar to tags, but a version may only be assigned to one spec within a service. Specified as a comma separated list of strings.
 
 Ignored if --session is used to attach to an existing learn session.
 `,

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210406221235-f036dc848087
-	github.com/akitasoftware/akita-libs v0.0.0-20210716010522-1ebc58f1676a
+	github.com/akitasoftware/akita-libs v0.0.0-20210716030952-24dfd2b177a1
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0
 	github.com/gdamore/tcell/v2 v2.1.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210406221235-f036dc848087
-	github.com/akitasoftware/akita-libs v0.0.0-20210713070204-b8e04881be61
+	github.com/akitasoftware/akita-libs v0.0.0-20210716010522-1ebc58f1676a
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0
 	github.com/gdamore/tcell/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210713070204-b8e04881be61 h1:q2KFou
 github.com/akitasoftware/akita-libs v0.0.0-20210713070204-b8e04881be61/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
 github.com/akitasoftware/akita-libs v0.0.0-20210716010522-1ebc58f1676a h1:CPiBU7R0TZkk1n15lriyayFz2H0RZ1lNmNOUxbDSrUw=
 github.com/akitasoftware/akita-libs v0.0.0-20210716010522-1ebc58f1676a/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
+github.com/akitasoftware/akita-libs v0.0.0-20210716030952-24dfd2b177a1 h1:aPTRT7Jwd9Eq8uGdH3vTTWE0DFHs/rKXCkstpimjAzE=
+github.com/akitasoftware/akita-libs v0.0.0-20210716030952-24dfd2b177a1/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPBv9mohlLY3EzstN6ds8kxcc0lwq1F541115FP7xY=

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210707204046-8388976a7962 h1:SUIqjD
 github.com/akitasoftware/akita-libs v0.0.0-20210707204046-8388976a7962/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
 github.com/akitasoftware/akita-libs v0.0.0-20210713070204-b8e04881be61 h1:q2KFounSz1bJ5x9SN9eHRlJUP9zc/eF861UGGqf0tUI=
 github.com/akitasoftware/akita-libs v0.0.0-20210713070204-b8e04881be61/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
+github.com/akitasoftware/akita-libs v0.0.0-20210716010522-1ebc58f1676a h1:CPiBU7R0TZkk1n15lriyayFz2H0RZ1lNmNOUxbDSrUw=
+github.com/akitasoftware/akita-libs v0.0.0-20210716010522-1ebc58f1676a/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPBv9mohlLY3EzstN6ds8kxcc0lwq1F541115FP7xY=

--- a/rest/interface.go
+++ b/rest/interface.go
@@ -21,6 +21,7 @@ type GetSpecOptions struct {
 
 type CreateSpecOptions struct {
 	Tags           map[tags.Key]string
+	Versions       []string
 	PathPatterns   []pp.Pattern
 	PathExclusions []*regexp.Regexp
 	GitHubPR       *github.PRInfo

--- a/rest/learn_client.go
+++ b/rest/learn_client.go
@@ -100,6 +100,7 @@ func (c *learnClientImpl) CreateSpec(ctx context.Context, name string, lrns []ak
 		"path_patterns":     opts.PathPatterns,
 		"path_exclusions":   pathExclusions,
 		"tags":              opts.Tags,
+		"versions":          opts.Versions,
 	}
 	if opts.GitHubPR != nil {
 		req["github_pr"] = opts.GitHubPR


### PR DESCRIPTION
This PR adds a `--versions` flag to the `apispec` and `learn` commands, which
allows users to assign versions to models at creation time.

Example usage:

* `akita apispec --traces akita://akibox:trace:t1 --versions stable`
* `akita learn --service akibox --versions stable,demo`