### PR TITLE
Disable config file reloading

### DIFF
--- a/cfg/credentials.go
+++ b/cfg/credentials.go
@@ -36,9 +36,6 @@ func initCreds() {
 	creds.AddConfigPath(cfgDir)
 	creds.SetConfigName(credsFileName)
 
-	// Reload config file on change.
-	creds.WatchConfig()
-
 	// Allow credentials to be set via the environment.
 	// API keys from env are implicitly in the "default" profile.
 	creds.AutomaticEnv()


### PR DESCRIPTION
This PR removes a feature that reloads the Akita configuration file on file
change.  There are two reasons to remove this:

1. The config file holds security creds, and the Akita CLI immediately fails
with bad creds.  There's no benefit to reloading on change.

2. The feature -- part of the Viper library -- prints a spurious error message
when the config file is missing but the config values are present in
environment variables.