### PR TITLE
Use Aurora through printer package. Disable based on --no-color flag.

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
@@ -408,9 +407,9 @@ func Run(args Args) error {
 		printer.Stderr.Infof("Running learn mode on interfaces %s\n", strings.Join(iNames, ", "))
 	}
 	if len(outboundFilters) == 0 {
-		printer.Stderr.Warningf("%s\n", aurora.Yellow("--filter flag is not set, this means that:"))
-		printer.Stderr.Warningf("%s\n", aurora.Yellow("  - all network traffic is treated as your API traffic"))
-		printer.Stderr.Warningf("%s\n", aurora.Yellow("  - outbound witness collection is disabled"))
+		printer.Stderr.Warningf("%s\n", printer.Color.Yellow("--filter flag is not set, this means that:"))
+		printer.Stderr.Warningf("%s\n", printer.Color.Yellow("  - all network traffic is treated as your API traffic"))
+		printer.Stderr.Warningf("%s\n", printer.Color.Yellow("  - outbound witness collection is disabled"))
 	}
 
 	var stopErr error
@@ -502,16 +501,16 @@ func Run(args Args) error {
 		if totalCount.TCPPackets == 0 {
 			if outboundSummary.Total().TCPPackets == 0 {
 				printer.Stderr.Infof("Did not capture any TCP packets during the trace.\n")
-				printer.Stderr.Infof("%s\n", aurora.Yellow("This may mean the traffic is on a different interface, or that"))
-				printer.Stderr.Infof("%s\n", aurora.Yellow("there is a problem sending traffic to the API."))
+				printer.Stderr.Infof("%s\n", printer.Color.Yellow("This may mean the traffic is on a different interface, or that"))
+				printer.Stderr.Infof("%s\n", printer.Color.Yellow("there is a problem sending traffic to the API."))
 			} else {
 				printer.Stderr.Infof("Did not capture any TCP packets matching the filter.\n")
-				printer.Stderr.Infof("%s\n", aurora.Yellow("This may mean your filter is incorrect, such as the wrong TCP port."))
+				printer.Stderr.Infof("%s\n", printer.Color.Yellow("This may mean your filter is incorrect, such as the wrong TCP port."))
 			}
 		} else if totalCount.Unparsed > 0 {
 			printer.Stderr.Infof("Captured %d TCP packets total; %d unparsed TCP segments.\n",
 				totalCount.TCPPackets, totalCount.Unparsed)
-			printer.Stderr.Infof("%s\n", aurora.Yellow("This may mean you are trying to capture HTTPS traffic."))
+			printer.Stderr.Infof("%s\n", printer.Color.Yellow("This may mean you are trying to capture HTTPS traffic."))
 			printer.Stderr.Infof("See https://docs.akita.software/docs/proxy-for-encrypted-traffic\n")
 			printer.Stderr.Infof("for instructions on using a proxy, or generate a HAR file with\n")
 			printer.Stderr.Infof("your browser as described in\n")
@@ -520,19 +519,19 @@ func Run(args Args) error {
 			printer.Stderr.Infof("Captured %d HTTP requests before allow and exclude rules, but all were filtered.\n",
 				inboundPrefilter.Total().HTTPRequests)
 		}
-		printer.Stderr.Errorf("%s 🛑\n\n", aurora.Red("No inbound HTTP calls captured!"))
+		printer.Stderr.Errorf("%s 🛑\n\n", printer.Color.Red("No inbound HTTP calls captured!"))
 		return errors.New("incoming API trace is empty")
 	}
 	if totalCount.HTTPRequests == 0 {
-		printer.Stderr.Warningf("%s ⚠\n\n", aurora.Yellow("Saw HTTP responses, but not requests."))
+		printer.Stderr.Warningf("%s ⚠\n\n", printer.Color.Yellow("Saw HTTP responses, but not requests."))
 		return nil
 	}
 	if totalCount.HTTPResponses == 0 {
-		printer.Stderr.Warningf("%s ⚠\n\n", aurora.Yellow("Saw HTTP requests, but not responses."))
+		printer.Stderr.Warningf("%s ⚠\n\n", printer.Color.Yellow("Saw HTTP requests, but not responses."))
 		return nil
 	}
 
-	printer.Stderr.Infof("%s 🎉\n\n", aurora.Green("Success!"))
+	printer.Stderr.Infof("%s 🎉\n\n", printer.Color.Green("Success!"))
 	return nil
 }
 

--- a/apispec/run.go
+++ b/apispec/run.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/jpillora/backoff"
-	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
@@ -271,11 +270,11 @@ func Run(args Args) error {
 	if args.Out.LocalPath == nil {
 		// No LocalPath means either AkitaURI is set or Out is not set - both mean
 		// backend output only.
-		successMsg := aurora.Green(fmt.Sprintf("🔎 View your spec at: %s", specURL.String()))
-		printer.Infof("%s 🎉\n\n%s\n\n", aurora.Green("Success!"), successMsg)
+		successMsg := printer.Color.Green(fmt.Sprintf("🔎 View your spec at: %s", specURL.String()))
+		printer.Infof("%s 🎉\n\n%s\n\n", printer.Color.Green("Success!"), successMsg)
 	} else {
 		printer.Infof("Waiting for your spec to generate...\n")
-		printer.Infof("%s\n", aurora.Green(fmt.Sprintf("🔎 Preview your spec at: %s", specURL.String())))
+		printer.Infof("%s\n", printer.Color.Green(fmt.Sprintf("🔎 Preview your spec at: %s", specURL.String())))
 
 		specContent, err := pollSpecUntilReady(learnClient, outSpecID, args.GetSpecEnableRelatedFields)
 		if err != nil {
@@ -307,7 +306,7 @@ func Run(args Args) error {
 			return errors.Wrap(err, "failed to write spec")
 		}
 
-		printer.Infof("%s 🎉\n\n", aurora.Green("Success!"))
+		printer.Infof("%s 🎉\n\n", printer.Color.Green("Success!"))
 	}
 
 	return nil

--- a/cmd/internal/legacy/util.go
+++ b/cmd/internal/legacy/util.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
@@ -36,8 +35,8 @@ func printViewSpecMessage(svc akid.ServiceID, spec akid.APISpecID) {
 	printer.Stderr.Infof("Your API spec ID is: ")
 	fmt.Println(akid.String(spec))
 
-	successMsg := aurora.Green(fmt.Sprintf("🔎 View your spec at: %s", editorURL.String()))
-	printer.Stderr.Infof("%s 🎉\n\n%s\n\n", aurora.Green("Success!"), successMsg)
+	successMsg := printer.Color.Green(fmt.Sprintf("🔎 View your spec at: %s", editorURL.String()))
+	printer.Stderr.Infof("%s 🎉\n\n%s\n\n", printer.Color.Green("Success!"), successMsg)
 }
 
 func getAppHost() string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 
+	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
@@ -44,6 +45,7 @@ var (
 	cpuProfileOut                       *os.File
 	heapProfile                         string
 	liveProfileAddress                  string
+	noColorFlag                         bool
 )
 
 const (
@@ -63,10 +65,17 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
-		PersistentPreRun:  startProfiling,
+		PersistentPreRun:  preRun,
 		PersistentPostRun: stopProfiling,
 	}
 )
+
+func preRun(cmd *cobra.Command, args []string) {
+	if noColorFlag {
+		printer.Color = aurora.NewAurora(false)
+	}
+	startProfiling(cmd, args)
+}
 
 func startProfiling(cmd *cobra.Command, args []string) {
 	var err error
@@ -172,6 +181,9 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&debugFlag, "debug", false, "If set, outputs detailed information for debugging.")
 	rootCmd.PersistentFlags().MarkHidden("debug")
 	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
+
+	rootCmd.PersistentFlags().BoolVar(&noColorFlag, "no-color", false, "If set, disables color highlighting.")
+	rootCmd.PersistentFlags().MarkHidden("no-color")
 
 	// Include flags from go libraries that we're using. We hand-pick the flags to
 	// include to avoid polluting the flag set of the CLI.

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	Stderr = NewP(os.Stderr)
+	Color  = aurora.NewAurora(true)
 )
 
 func Infoln(args ...interface{}) {
@@ -82,41 +83,41 @@ func (p impl) ln(t string, args ...interface{}) {
 }
 
 func (p impl) Infoln(args ...interface{}) {
-	p.ln(aurora.Blue("[INFO] ").String(), args...)
+	p.ln(Color.Blue("[INFO] ").String(), args...)
 }
 
 func (p impl) Warningln(args ...interface{}) {
-	p.ln(aurora.Yellow("[WARNING] ").String(), args...)
+	p.ln(Color.Yellow("[WARNING] ").String(), args...)
 }
 
 func (p impl) Errorln(args ...interface{}) {
-	p.ln(aurora.Red("[ERROR] ").String(), args...)
+	p.ln(Color.Red("[ERROR] ").String(), args...)
 }
 
 func (p impl) Debugln(args ...interface{}) {
 	if viper.GetBool("debug") {
-		p.ln(aurora.Magenta("[DEBUG] ").String(), args...)
+		p.ln(Color.Magenta("[DEBUG] ").String(), args...)
 	}
 }
 
 func (p impl) Infof(fmtString string, args ...interface{}) {
-	fmt.Fprintf(p.out, aurora.Blue("[INFO] ").String())
+	fmt.Fprintf(p.out, Color.Blue("[INFO] ").String())
 	fmt.Fprintf(p.out, fmtString, args...)
 }
 
 func (p impl) Warningf(fmtString string, args ...interface{}) {
-	fmt.Fprintf(p.out, aurora.Yellow("[WARNING] ").String())
+	fmt.Fprintf(p.out, Color.Yellow("[WARNING] ").String())
 	fmt.Fprintf(p.out, fmtString, args...)
 }
 
 func (p impl) Errorf(fmtString string, args ...interface{}) {
-	fmt.Fprintf(p.out, aurora.Red("[ERROR] ").String())
+	fmt.Fprintf(p.out, Color.Red("[ERROR] ").String())
 	fmt.Fprintf(p.out, fmtString, args...)
 }
 
 func (p impl) Debugf(fmtString string, args ...interface{}) {
 	if viper.GetBool("debug") {
-		fmt.Fprintf(p.out, aurora.Magenta("[DEBUG] ").String())
+		fmt.Fprintf(p.out, Color.Magenta("[DEBUG] ").String())
 		fmt.Fprintf(p.out, fmtString, args...)
 	}
 }

--- a/upload/run.go
+++ b/upload/run.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 
 	"github.com/akitasoftware/akita-libs/akid"
@@ -69,7 +68,7 @@ func Run(args Args) error {
 		ObjectType:  args.DestURI.ObjectType,
 		ObjectName:  objectName,
 	}
-	printer.Stderr.Infof("%s 🎉\n", aurora.Green("Success!"))
+	printer.Stderr.Infof("%s 🎉\n", printer.Color.Green("Success!"))
 	printer.Stderr.Infof(fmt.Sprintf("Your upload is available as: %s\n", uri.String()))
 
 	return nil


### PR DESCRIPTION
This isn't a complete solution for DataDog, but I've decided it's worth keeping so we don't wrap ANSI color codes in JSON.