### PR TITLE
Add log format argument and JSON log format compatible with DataDog

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -1,7 +1,6 @@
 package apidump
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -420,11 +419,12 @@ func Run(args Args) error {
 
 		// Print delimiter so it's easier to differentiate subcommand output from
 		// Akita output.
-		fmt.Fprintln(os.Stdout, subcommandOutputDelimiter)
-		fmt.Fprintln(os.Stderr, subcommandOutputDelimiter)
+		// It won't appear in JSON-formatted output.
+		printer.Stdout.RawOutput(subcommandOutputDelimiter)
+		printer.Stderr.RawOutput(subcommandOutputDelimiter)
 		cmdErr := runCommand(args.ExecCommandUser, args.ExecCommand)
-		fmt.Fprintln(os.Stdout, subcommandOutputDelimiter)
-		fmt.Fprintln(os.Stderr, subcommandOutputDelimiter)
+		printer.Stdout.RawOutput(subcommandOutputDelimiter)
+		printer.Stderr.RawOutput(subcommandOutputDelimiter)
 
 		if cmdErr != nil {
 			stopErr = errors.Wrap(cmdErr, "failed to run subcommand")

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -11,7 +11,6 @@ import (
 	"github.com/akitasoftware/akita-cli/location"
 	"github.com/akitasoftware/akita-cli/util"
 	"github.com/akitasoftware/akita-libs/akiuri"
-	"github.com/akitasoftware/akita-libs/tags"
 )
 
 var (
@@ -39,9 +38,9 @@ var Cmd = &cobra.Command{
 	Long:         "Capture and store a sequence of requests/responses to a service by observing network traffic.",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		traceTags, err := tags.FromPairs(tagsFlag)
+		traceTags, err := util.ParseTagsAndWarn(tagsFlag)
 		if err != nil {
-			return errors.Wrap(err, "failed to parse tags")
+			return err
 		}
 
 		plugins, err := pluginloader.Load(pluginsFlag)

--- a/cmd/internal/apispec/cmd.go
+++ b/cmd/internal/apispec/cmd.go
@@ -13,7 +13,6 @@ import (
 	"github.com/akitasoftware/akita-cli/location"
 	"github.com/akitasoftware/akita-cli/util"
 	"github.com/akitasoftware/akita-libs/gitlab"
-	"github.com/akitasoftware/akita-libs/tags"
 	"github.com/akitasoftware/akita-libs/time_span"
 	"github.com/akitasoftware/akita-libs/version_names"
 )
@@ -42,7 +41,8 @@ var Cmd = &cobra.Command{
 			return err
 		}
 
-		traceTags, err := tags.FromPairs(tracesByTagFlag)
+		// No need to warn here, matching on reserved tags is OK
+		traceTags, err := util.ParseTags(tracesByTagFlag)
 		if err != nil {
 			return err
 		}
@@ -96,7 +96,7 @@ var Cmd = &cobra.Command{
 			traces = append(traces, location.Location{AkitaURI: &destURI})
 		}
 
-		tags, err := tags.FromPairs(tagsFlag)
+		tags, err := util.ParseTagsAndWarn(tagsFlag)
 		if err != nil {
 			return err
 		}

--- a/cmd/internal/get/specs.go
+++ b/cmd/internal/get/specs.go
@@ -193,7 +193,7 @@ func getSpecs(cmd *cobra.Command, args []string) error {
 		return errors.New("Only one source and one destination supported.")
 	}
 
-	tags, err := tags.FromPairs(tagsFlag)
+	tags, err := util.ParseTags(tagsFlag)
 	if err != nil {
 		return err
 	}

--- a/cmd/internal/get/traces.go
+++ b/cmd/internal/get/traces.go
@@ -15,7 +15,6 @@ import (
 	"github.com/akitasoftware/akita-cli/util"
 	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/akita-libs/akiuri"
-	"github.com/akitasoftware/akita-libs/tags"
 )
 
 var GetTracesCmd = &cobra.Command{
@@ -95,7 +94,7 @@ func getTraces(cmd *cobra.Command, args []string) error {
 	}
 
 	learnClient := rest.NewLearnClient(akiflag.Domain, clientID, serviceID)
-	tags, err := tags.FromPairs(tagsFlag)
+	tags, err := util.ParseTags(tagsFlag)
 	if err != nil {
 		return err
 	}

--- a/cmd/internal/learn/cmd.go
+++ b/cmd/internal/learn/cmd.go
@@ -147,7 +147,7 @@ func runLearnMode() error {
 		}
 	}
 
-	tagsMap, err := tags.FromPairs(tagsFlag)
+	tagsMap, err := util.ParseTagsAndWarn(tagsFlag)
 	if err != nil {
 		return err
 	}

--- a/cmd/internal/upload/cmd.go
+++ b/cmd/internal/upload/cmd.go
@@ -5,7 +5,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/akitasoftware/akita-libs/akiuri"
-	"github.com/akitasoftware/akita-libs/tags"
 
 	"github.com/akitasoftware/akita-cli/cmd/internal/akiflag"
 	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
@@ -80,7 +79,7 @@ var Cmd = &cobra.Command{
 		}
 
 		// Parse tags.
-		tags, err := tags.FromPairs(tagsFlag)
+		tags, err := util.ParseTagsAndWarn(tagsFlag)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210406221235-f036dc848087
-	github.com/akitasoftware/akita-libs v0.0.0-20210728062013-8bfc8c89bbdc
+	github.com/akitasoftware/akita-libs v0.0.0-20210729224535-6dad693e4176
 	github.com/akitasoftware/objecthash-proto v0.0.0-20210728061301-b7904b31cc09 // indirect
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210716030952-24dfd2b177a1 h1:aPTRT7
 github.com/akitasoftware/akita-libs v0.0.0-20210716030952-24dfd2b177a1/go.mod h1:S5p43bBkmlcUa+2JqDZgBzmSHUDKB64k+2gQtIx4Ps0=
 github.com/akitasoftware/akita-libs v0.0.0-20210728062013-8bfc8c89bbdc h1:KcOoP7ReEnqqYhuMpvzhoAM8Z4Y9S7Gd6q+w503P0kA=
 github.com/akitasoftware/akita-libs v0.0.0-20210728062013-8bfc8c89bbdc/go.mod h1:vJ075NqOkCGEJLjrQEY2D66huv0igrNmzpWVnzmKyBc=
+github.com/akitasoftware/akita-libs v0.0.0-20210729224535-6dad693e4176 h1:Tua4K65RITfJEpsPm5zBf6rELxRZQbbMoOOxklzrEfE=
+github.com/akitasoftware/akita-libs v0.0.0-20210729224535-6dad693e4176/go.mod h1:vJ075NqOkCGEJLjrQEY2D66huv0igrNmzpWVnzmKyBc=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210108221002-22c39e10ccd2 h1:sBPBv9mohlLY3EzstN6ds8kxcc0lwq1F541115FP7xY=

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -2,9 +2,12 @@
 package printer
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/logrusorgru/aurora"
 	"github.com/spf13/viper"
@@ -12,6 +15,7 @@ import (
 
 var (
 	Stderr = NewP(os.Stderr)
+	Stdout = NewP(os.Stdout)
 	Color  = aurora.NewAurora(true)
 )
 
@@ -29,6 +33,10 @@ func Errorln(args ...interface{}) {
 
 func Debugln(args ...interface{}) {
 	Stderr.Debugln(args...)
+}
+
+func RawOutput(args ...interface{}) {
+	Stderr.RawOutput(args...)
 }
 
 func Infof(fmtString string, args ...interface{}) {
@@ -63,6 +71,9 @@ type P interface {
 	Errorf(f string, args ...interface{})
 	Debugf(f string, args ...interface{})
 	V(level int) P
+
+	// Output with no header
+	RawOutput(args ...interface{})
 }
 
 type impl struct {
@@ -130,14 +141,106 @@ func (p impl) V(level int) P {
 	}
 }
 
+func (p impl) RawOutput(args ...interface{}) {
+	fmt.Fprintln(p.out, args...)
+}
+
 type noopPrinter struct{}
 
 func (noopPrinter) Infoln(args ...interface{})             {}
 func (noopPrinter) Warningln(args ...interface{})          {}
 func (noopPrinter) Errorln(args ...interface{})            {}
 func (noopPrinter) Debugln(args ...interface{})            {}
+func (noopPrinter) RawOutput(args ...interface{})          {}
 func (noopPrinter) Infof(f string, args ...interface{})    {}
 func (noopPrinter) Warningf(f string, args ...interface{}) {}
 func (noopPrinter) Errorf(f string, args ...interface{})   {}
 func (noopPrinter) Debugf(f string, args ...interface{})   {}
 func (p noopPrinter) V(level int) P                        { return p }
+
+type jsonImpl struct {
+	encoder *json.Encoder
+}
+
+func SwitchToJSON() {
+	// No ANSI escapes
+	Color = aurora.NewAurora(false)
+	Stderr = &jsonImpl{
+		encoder: json.NewEncoder(os.Stderr),
+	}
+	Stdout = &jsonImpl{
+		encoder: json.NewEncoder(os.Stdout),
+	}
+}
+
+func SwitchToPlain() {
+	// No ANSI escapes
+	Color = aurora.NewAurora(false)
+}
+
+// A JSON log entry using the reserved fields that DataDog expects
+// to find.  We assume that "host", "service", and "env" will
+// be filled in by the collector.
+type jsonLog struct {
+	Date    time.Time `json:"date"`
+	Status  string    `json:"status"`
+	Message string    `json:"message"`
+}
+
+func (j *jsonImpl) writeJSON(status string, message string) {
+	message = strings.Trim(message, "\n")
+	logEntry := jsonLog{
+		Date:    time.Now(),
+		Status:  status,
+		Message: message,
+	}
+	j.encoder.Encode(logEntry) // includes newline!
+}
+
+func (j *jsonImpl) Infoln(args ...interface{}) {
+	j.writeJSON("info", fmt.Sprint(args...))
+}
+
+func (j *jsonImpl) Warningln(args ...interface{}) {
+	j.writeJSON("warning", fmt.Sprint(args...))
+}
+
+func (j *jsonImpl) Errorln(args ...interface{}) {
+	j.writeJSON("error", fmt.Sprint(args...))
+}
+
+func (j *jsonImpl) Debugln(args ...interface{}) {
+	if viper.GetBool("debug") {
+		j.writeJSON("debug", fmt.Sprint(args...))
+	}
+}
+
+func (j *jsonImpl) RawOutput(args ...interface{}) {
+	// omit
+}
+
+func (j *jsonImpl) Infof(f string, args ...interface{}) {
+	j.writeJSON("info", fmt.Sprintf(f, args...))
+}
+
+func (j *jsonImpl) Warningf(f string, args ...interface{}) {
+	j.writeJSON("warning", fmt.Sprintf(f, args...))
+}
+
+func (j *jsonImpl) Errorf(f string, args ...interface{}) {
+	j.writeJSON("error", fmt.Sprintf(f, args...))
+}
+
+func (j *jsonImpl) Debugf(f string, args ...interface{}) {
+	if viper.GetBool("debug") {
+		j.writeJSON("debug", fmt.Sprintf(f, args...))
+	}
+}
+
+func (j *jsonImpl) V(level int) P {
+	if l := viper.GetInt("verbose-level"); l > 0 && level >= l {
+		return j
+	} else {
+		return noopPrinter{}
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -229,3 +229,28 @@ func ContainsCLITraffic(t akinet.ParsedNetworkTraffic) bool {
 	}
 	return false
 }
+
+func ParseTags(tagsArg []string) (map[tags.Key]string, error) {
+	tagSet, err := tags.FromPairs(tagsArg)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse tags")
+	}
+	return tagSet, nil
+}
+
+func ParseTagsAndWarn(tagsArg []string) (map[tags.Key]string, error) {
+	tagSet, err := tags.FromPairs(tagsArg)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse tags")
+	}
+	WarnOnReservedTags(tagSet)
+	return tagSet, nil
+}
+
+func WarnOnReservedTags(tagSet map[tags.Key]string) {
+	for t, _ := range tagSet {
+		if tags.IsReservedKey(t) {
+			printer.Warningf("%s is an Akita-reserved key. Its value may be overwritten internally\n", t)
+		}
+	}
+}


### PR DESCRIPTION
Depends on https://github.com/akitasoftware/akita-libs/pull/64 so that the warning message about reserved tags is consistently formatted.

Also, took the opportunity to not log warnings in a couple places where using a reserved tag to filter objects would be OK.

Example output:

```
{"date":"2021-07-29T17:26:26.598170266-05:00","status":"warning","message":"x-akita-source is an Akita-reserved key. Its value may be overwritten internally."}
{"date":"2021-07-29T17:26:26.67969592-05:00","status":"info","message":"Running learn mode on interfaces br-a3f4bbff3da2, lo, ens33, br-1d38328ca3be, docker0, br-75a0084d9170"}
{"date":"2021-07-29T17:26:26.679761692-05:00","status":"warning","message":"--filter flag is not set, this means that:"}
{"date":"2021-07-29T17:26:26.679769255-05:00","status":"warning","message":"  - all network traffic is treated as your API traffic"}
{"date":"2021-07-29T17:26:26.679772303-05:00","status":"warning","message":"  - outbound witness collection is disabled"}
{"date":"2021-07-29T17:26:26.679775188-05:00","status":"info","message":"Running subcommand..."}
```