### PR TITLE
Split the maximum page cache size up among each parser.

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -388,10 +388,14 @@ func Run(args Args) error {
 				}
 			}
 
+			// Compute the share of the page cache that each collection process may use.
+			// (gopacket does not currently permit a unified page cache for packet reassembly.)
+			bufferShare := 1.0 / float32(len(outboundFilters)+len(inboundFilters))
+
 			go func(interfaceName, filter string) {
 				defer doneWG.Done()
 				// Collect trace. This blocks until stop is closed or an error occurs.
-				if err := trace.Collect(stop, interfaceName, filter, collector, summary); err != nil {
+				if err := trace.Collect(stop, interfaceName, filter, bufferShare, collector, summary); err != nil {
 					errChan <- errors.Wrapf(err, "failed to collect trace on interface %s", interfaceName)
 				}
 			}(interfaceName, filter)

--- a/learn/learn_runner.go
+++ b/learn/learn_runner.go
@@ -46,7 +46,7 @@ func CollectWitnesses(stop <-chan struct{}, intf, bpfFilter string, proc Witness
 		akihttp.NewHTTPRequestParserFactory(),
 		akihttp.NewHTTPResponseParserFactory(),
 	}
-	parser := col.NewNetworkTrafficParser()
+	parser := col.NewNetworkTrafficParser(1.0)
 	parsedChan, err := parser.ParseFromInterface(intf, bpfFilter, stop, facts...)
 	if err != nil {
 		return errors.Wrap(err, "couldn't start parsing from interface")

--- a/pcap/net_parse_test.go
+++ b/pcap/net_parse_test.go
@@ -94,7 +94,7 @@ func makeUDPPackets(split int, ms ...*testMessage) []gopacket.Packet {
 }
 
 func setupParseFromInterface(pcap pcapWrapper, signalClose <-chan struct{}, facts ...akinet.TCPParserFactory) (<-chan akinet.ParsedNetworkTraffic, error) {
-	p := NewNetworkTrafficParser()
+	p := NewNetworkTrafficParser(1.0)
 	p.pcap = pcap
 	p.clock = &fakeClock{testTime}
 	return p.ParseFromInterface("dummy0", "", signalClose, facts...)

--- a/pcap/pcap_replay_test.go
+++ b/pcap/pcap_replay_test.go
@@ -174,7 +174,7 @@ func (filePcapWrapper) getInterfaceAddrs(interfaceName string) ([]net.IP, error)
 }
 
 func readFromPcapFile(file string) ([]akinet.ParsedNetworkTraffic, error) {
-	p := NewNetworkTrafficParser()
+	p := NewNetworkTrafficParser(1.0)
 	p.pcap = filePcapWrapper(file)
 
 	done := make(chan struct{})

--- a/trace/run.go
+++ b/trace/run.go
@@ -8,7 +8,7 @@ import (
 	akihttp "github.com/akitasoftware/akita-libs/akinet/http"
 )
 
-func Collect(stop <-chan struct{}, intf, bpfFilter string, proc Collector, packetCount PacketCountConsumer) error {
+func Collect(stop <-chan struct{}, intf, bpfFilter string, bufferShare float32, proc Collector, packetCount PacketCountConsumer) error {
 	defer proc.Close()
 
 	facts := []akinet.TCPParserFactory{
@@ -16,7 +16,7 @@ func Collect(stop <-chan struct{}, intf, bpfFilter string, proc Collector, packe
 		akihttp.NewHTTPResponseParserFactory(),
 	}
 
-	parser := col.NewNetworkTrafficParser()
+	parser := col.NewNetworkTrafficParser(bufferShare)
 
 	if packetCount != nil {
 		parser.InstallObserver(CountTcpPackets(intf, packetCount))


### PR DESCRIPTION
Split the configured page cache size up among the different parsers, one per interface and per direction.

This successfully reduces the memory; we don't have a way to measure what it does to "goodput" or if we lose some packets because we could not buffer enough to see the retransmission.