### PR TITLE
Use improved hashing in CLI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210406221235-f036dc848087
-	github.com/akitasoftware/akita-libs v0.0.0-20210729224535-6dad693e4176
+	github.com/akitasoftware/akita-libs v0.0.0-20210805235804-b5407c148c9a
 	github.com/akitasoftware/objecthash-proto v0.0.0-20210728061301-b7904b31cc09 // indirect
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210406221235-f036dc848087
-	github.com/akitasoftware/akita-libs v0.0.0-20210803190946-dba9cda594b6
+	github.com/akitasoftware/akita-libs v0.0.0-20210806205723-3940663d2620
 	github.com/akitasoftware/objecthash-proto v0.0.0-20210728061301-b7904b31cc09 // indirect
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210728062013-8bfc8c89bbdc h1:KcOoP7
 github.com/akitasoftware/akita-libs v0.0.0-20210728062013-8bfc8c89bbdc/go.mod h1:vJ075NqOkCGEJLjrQEY2D66huv0igrNmzpWVnzmKyBc=
 github.com/akitasoftware/akita-libs v0.0.0-20210729224535-6dad693e4176 h1:Tua4K65RITfJEpsPm5zBf6rELxRZQbbMoOOxklzrEfE=
 github.com/akitasoftware/akita-libs v0.0.0-20210729224535-6dad693e4176/go.mod h1:vJ075NqOkCGEJLjrQEY2D66huv0igrNmzpWVnzmKyBc=
+github.com/akitasoftware/akita-libs v0.0.0-20210805235804-b5407c148c9a h1:zfXEamet2RK7EHnEkD7FmwYRfWU4tBgHm9LgLeenm1U=
+github.com/akitasoftware/akita-libs v0.0.0-20210805235804-b5407c148c9a/go.mod h1:MnR2O/58EymCy46FsFtHP8Yp6SrnX4ny8NMc3TG20Ao=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/go.sum
+++ b/go.sum
@@ -155,10 +155,12 @@ github.com/akitasoftware/akita-libs v0.0.0-20210728062013-8bfc8c89bbdc h1:KcOoP7
 github.com/akitasoftware/akita-libs v0.0.0-20210728062013-8bfc8c89bbdc/go.mod h1:vJ075NqOkCGEJLjrQEY2D66huv0igrNmzpWVnzmKyBc=
 github.com/akitasoftware/akita-libs v0.0.0-20210729224535-6dad693e4176 h1:Tua4K65RITfJEpsPm5zBf6rELxRZQbbMoOOxklzrEfE=
 github.com/akitasoftware/akita-libs v0.0.0-20210729224535-6dad693e4176/go.mod h1:vJ075NqOkCGEJLjrQEY2D66huv0igrNmzpWVnzmKyBc=
-github.com/akitasoftware/akita-libs v0.0.0-20210805235804-b5407c148c9a h1:zfXEamet2RK7EHnEkD7FmwYRfWU4tBgHm9LgLeenm1U=
-github.com/akitasoftware/akita-libs v0.0.0-20210805235804-b5407c148c9a/go.mod h1:MnR2O/58EymCy46FsFtHP8Yp6SrnX4ny8NMc3TG20Ao=
 github.com/akitasoftware/akita-libs v0.0.0-20210803190946-dba9cda594b6 h1:YreyovdiWaCc6SvH6aXkDk30+V5hRvEmxcjgVr7vwPY=
 github.com/akitasoftware/akita-libs v0.0.0-20210803190946-dba9cda594b6/go.mod h1:5wJqUDIUbA/n2EgNq+48aMyz9J268tRld6zt2zKhsis=
+github.com/akitasoftware/akita-libs v0.0.0-20210805235804-b5407c148c9a h1:zfXEamet2RK7EHnEkD7FmwYRfWU4tBgHm9LgLeenm1U=
+github.com/akitasoftware/akita-libs v0.0.0-20210805235804-b5407c148c9a/go.mod h1:MnR2O/58EymCy46FsFtHP8Yp6SrnX4ny8NMc3TG20Ao=
+github.com/akitasoftware/akita-libs v0.0.0-20210806205723-3940663d2620 h1:M6Y1wWPctE0IwgefOFtRiq9bJ8KGEzu6cwVZlzQXc0c=
+github.com/akitasoftware/akita-libs v0.0.0-20210806205723-3940663d2620/go.mod h1:MnR2O/58EymCy46FsFtHP8Yp6SrnX4ny8NMc3TG20Ao=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/learn/learn.go
+++ b/learn/learn.go
@@ -9,12 +9,12 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/akitasoftware/akita-cli/printer"
+	pb "github.com/akitasoftware/akita-ir/go/api_spec"
 	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/akita-libs/akinet"
-	"github.com/akitasoftware/akita-libs/pbhash"
-	"github.com/akitasoftware/akita-libs/spec_util"
-	pb "github.com/akitasoftware/akita-ir/go/api_spec"
 	kgxapi "github.com/akitasoftware/akita-libs/api_schema"
+	"github.com/akitasoftware/akita-libs/spec_util"
+	"github.com/akitasoftware/akita-libs/spec_util/ir_hash"
 )
 
 const (
@@ -38,10 +38,7 @@ type witnessResult struct {
 func (r witnessResult) toReport(dir kgxapi.NetworkDirection) (*kgxapi.WitnessReport, error) {
 	// Hash algorithm defined in
 	// https://docs.google.com/document/d/1ZANeoLTnsO10DcuzsAt6PBCt2MWLYW8oeu_A6d9bTJk/edit#heading=h.tbvm9waph6eu
-	hash, err := pbhash.HashProto(r.witness)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to hash witness proto")
-	}
+	hash := ir_hash.HashWitnessToString(r.witness)
 
 	b, err := proto.Marshal(r.witness)
 	if err != nil {

--- a/learn/parse_http.go
+++ b/learn/parse_http.go
@@ -25,8 +25,8 @@ import (
 	"github.com/akitasoftware/akita-cli/printer"
 	pb "github.com/akitasoftware/akita-ir/go/api_spec"
 	"github.com/akitasoftware/akita-libs/akinet"
-	"github.com/akitasoftware/akita-libs/pbhash"
 	"github.com/akitasoftware/akita-libs/spec_util"
+	"github.com/akitasoftware/akita-libs/spec_util/ir_hash"
 )
 
 var (
@@ -153,10 +153,7 @@ func ParseHTTP(elem akinet.ParsedNetworkContent) (*PartialWitness, error) {
 	for _, d := range datas {
 		// Use the hash of the data proto as the key so we can deterministically
 		// compare witnesses.
-		k, err := pbhash.HashProto(d)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to hash data proto")
-		}
+		k := ir_hash.HashDataToString(d)
 		if _, collision := dataMap[k]; collision {
 			return nil, errors.Errorf("detected collision in data map key")
 		}

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -19,8 +19,8 @@ import (
 	"github.com/akitasoftware/akita-libs/akinet"
 	kgxapi "github.com/akitasoftware/akita-libs/api_schema"
 	"github.com/akitasoftware/akita-libs/batcher"
-	"github.com/akitasoftware/akita-libs/pbhash"
 	"github.com/akitasoftware/akita-libs/spec_util"
+	"github.com/akitasoftware/akita-libs/spec_util/ir_hash"
 )
 
 const (
@@ -53,10 +53,7 @@ type witnessWithInfo struct {
 func (r witnessWithInfo) toReport(dir kgxapi.NetworkDirection) (*kgxapi.WitnessReport, error) {
 	// Hash algorithm defined in
 	// https://docs.google.com/document/d/1ZANeoLTnsO10DcuzsAt6PBCt2MWLYW8oeu_A6d9bTJk/edit#heading=h.tbvm9waph6eu
-	hash, err := pbhash.HashProto(r.witness)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to hash witness proto")
-	}
+	hash := ir_hash.HashWitnessToString(r.witness)
 
 	b, err := proto.Marshal(r.witness)
 	if err != nil {


### PR DESCRIPTION
Only a small number of places in the CLI that use protohash; replace them by more-specific calls to the new hashing functions.

Depends on https://github.com/akitasoftware/akita-libs/pull/71
