### PR TITLE
Stream decompressed data to a parser instead of buffering it.

### DIFF
--- a/learn/parse_http.go
+++ b/learn/parse_http.go
@@ -202,7 +202,7 @@ func decompress(compression string, body io.Reader) (io.Reader, error) {
 	case "identity":
 		dr = body
 	case "br":
-		dr = io.NopCloser(brotli.NewReader(body))
+		dr = brotli.NewReader(body)
 	default:
 		return nil, errors.New("unsupported compression type")
 	}
@@ -225,7 +225,7 @@ func attemptDecompress(body []byte) (io.Reader, error) {
 		limitReader := &io.LimitedReader{R: dr, N: MaxFallbackOutput}
 		bufferedResult, err := ioutil.ReadAll(limitReader)
 		if err == nil {
-			return io.NopCloser(bytes.NewReader(bufferedResult)), nil
+			return bytes.NewReader(bufferedResult), nil
 		}
 	}
 	return nil, errors.New("unrecognized compression type")
@@ -268,7 +268,7 @@ func decodeBody(headers http.Header, body io.Reader, bodyDecompressed bool) (io.
 		}
 
 		if n, _ := ianaindex.MIME.Name(enc); n != "UTF-8" {
-			body = io.NopCloser(transform.NewReader(body, enc.NewDecoder()))
+			body = transform.NewReader(body, enc.NewDecoder())
 		}
 	}
 

--- a/learn/parse_http.go
+++ b/learn/parse_http.go
@@ -276,7 +276,7 @@ func decodeBody(headers http.Header, body io.Reader, bodyDecompressed bool) (io.
 }
 
 func limitedBufferBody(bodyStream io.Reader) ([]byte, error) {
-	body, err := io.ReadAll(io.LimitReader(bodyStream, MaxBufferedBody))
+	body, err := ioutil.ReadAll(io.LimitReader(bodyStream, MaxBufferedBody))
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading body")
 	}


### PR DESCRIPTION
Limit the size of decompressed data than cannot be streamed.

In the future, we might be able to give this layer a HTTP request or response whose body has not yet been completely read.  But,  that would be challenging because the Parser interface can't currently signal "Here's your data, but I'm still reading to keep feeding me bytes."
