### PR TITLE
Update 'learn-sessions checkpoint' to return URI rather than ID

### DIFF
--- a/cmd/internal/legacy/sessions_checkpoint.go
+++ b/cmd/internal/legacy/sessions_checkpoint.go
@@ -60,10 +60,10 @@ func runCheckpointSession(rawSessionID string) error {
 	}
 
 	learnClient := rest.NewLearnClient(akiflag.Domain, clientID, serviceID)
-	specID, err := checkpointWithProgress(learnClient, sessionID, checkpointSessionTimeoutFlag)
+	specID, specName, err := checkpointWithProgress(learnClient, sessionID, checkpointSessionTimeoutFlag)
 	if err != nil {
 		return err
 	}
-	printViewSpecMessage(serviceID, specID)
+	printViewSpecMessage(serviceID, sessionsServiceFlag, specID, specName)
 	return nil
 }

--- a/cmd/internal/legacy/sessions_create.go
+++ b/cmd/internal/legacy/sessions_create.go
@@ -9,14 +9,15 @@ import (
 
 	"github.com/akitasoftware/akita-libs/akid"
 
+	kgxapi "github.com/akitasoftware/akita-libs/api_schema"
+	"github.com/akitasoftware/akita-libs/tags"
+
 	"github.com/akitasoftware/akita-cli/ci"
 	"github.com/akitasoftware/akita-cli/cmd/internal/akiflag"
 	"github.com/akitasoftware/akita-cli/cmd/internal/ci_guard"
 	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
 	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-cli/rest"
-	kgxapi "github.com/akitasoftware/akita-libs/api_schema"
-	"github.com/akitasoftware/akita-libs/tags"
 )
 
 var createSessionCmd = &cobra.Command{

--- a/rest/interface.go
+++ b/rest/interface.go
@@ -35,10 +35,6 @@ type LearnClient interface {
 	CreateLearnSession(context.Context, *kgxapi.APISpecReference, string, map[tags.Key]string) (akid.LearnSessionID, error)
 	ReportWitnesses(context.Context, akid.LearnSessionID, []*kgxapi.WitnessReport) error
 
-	// Deprecated: old way of creating a spec from a single learn session.
-	// Use CreateSpec instead.
-	CheckpointLearnSession(context.Context, akid.LearnSessionID) (akid.APISpecID, error)
-
 	// Creates a spec from a set of learn sessions.
 	CreateSpec(context.Context, string, []akid.LearnSessionID, CreateSpecOptions) (akid.APISpecID, error)
 	GetSpec(context.Context, akid.APISpecID, GetSpecOptions) (kgxapi.GetSpecResponse, error)

--- a/rest/learn_client.go
+++ b/rest/learn_client.go
@@ -77,16 +77,6 @@ func (c *learnClientImpl) ReportWitnesses(ctx context.Context, lrn akid.LearnSes
 	return c.post(ctx, p, req, &resp)
 }
 
-func (c *learnClientImpl) CheckpointLearnSession(ctx context.Context, lrn akid.LearnSessionID) (akid.APISpecID, error) {
-	var resp kgxapi.CheckpointResponse
-	p := path.Join("/v1/services", akid.String(c.serviceID), "learn", akid.String(lrn), "async_checkpoint")
-	err := c.post(ctx, p, emptyObject, &resp)
-	if err != nil {
-		return akid.APISpecID{}, err
-	}
-	return resp.APISpecID, nil
-}
-
 func (c *learnClientImpl) CreateSpec(ctx context.Context, name string, lrns []akid.LearnSessionID, opts CreateSpecOptions) (akid.APISpecID, error) {
 	// Go cannot marshal regexp into JSON unfortunately.
 	pathExclusions := make([]string, len(opts.PathExclusions))


### PR DESCRIPTION
As part of this change, `learn-sessions checkpoint` now creates an API model with a randomly-generated name rather than `""`, matching the behavior of `apispec` when no name is specified.