### PR TITLE
Handle any content type that has +json at the end as JSON.

### DIFF
--- a/learn/parse_http.go
+++ b/learn/parse_http.go
@@ -295,8 +295,6 @@ func parseBody(contentType string, bodyStream io.Reader, statusCode int) (*pb.Da
 	switch {
 	case strings.HasSuffix(mediaType, "+json"):
 		mediaType = "application/json"
-	case mediaType == "text/csv":
-		mediaType = "text/plain"
 	}
 
 	var bodyData *pb.Data
@@ -347,7 +345,7 @@ func parseBody(contentType string, bodyStream io.Reader, statusCode int) (*pb.Da
 		}
 		bodyData = parseElem(body, spec_util.NO_INTERPRET_STRINGS)
 		pbContentType = pb.HTTPBody_OCTET_STREAM
-	case "text/plain":
+	case "text/plain", "text/csv":
 		body, err := limitedBufferBody(bodyStream)
 		if err != nil {
 			return nil, err

--- a/learn/parse_http.go
+++ b/learn/parse_http.go
@@ -288,6 +288,17 @@ func parseBody(contentType string, bodyStream io.Reader, statusCode int) (*pb.Da
 		return nil, errors.Wrapf(err, "failed to parse MIME from Content-Type %q", contentType)
 	}
 
+	// Rewrite media type to JSON for types encoded as JSON
+	// TODO: XML parsing
+	// TODO: application/json-seq (RFC 7466)?
+	// TODO: more text/* types
+	switch {
+	case strings.HasSuffix(mediaType, "+json"):
+		mediaType = "application/json"
+	case mediaType == "text/csv":
+		mediaType = "text/plain"
+	}
+
 	var bodyData *pb.Data
 	var pbContentType pb.HTTPBody_ContentType
 	switch mediaType {


### PR DESCRIPTION
I thought about adding more text/* types, but that quickly got complex as we already handle text/yaml and text/x-yaml so there would have to be exception lists.

I don't know if there are any application/* types that are actually JSON but don't indicate it; we could add them later.

Tested locally with akibox:

```
@app.get("/users/{user_id}/test")
async def get_user(user_id: str):
    if user_id not in users:
        raise HTTPException(status_code=404, detail="User not found")
    return Response(content='{"user":"test", "value":17}',
                    media_type="application/vnd.api+json",
                    status_code=200)
```
