### PR TITLE
Ensure no pagination in 'get specs'

### DIFF
--- a/rest/learn_client.go
+++ b/rest/learn_client.go
@@ -123,6 +123,11 @@ func (c *learnClientImpl) GetSpec(ctx context.Context, api akid.APISpecID, opts 
 
 func (c *learnClientImpl) ListSpecs(ctx context.Context) ([]kgxapi.SpecInfo, error) {
 	qs := make(url.Values)
+
+	// Set limit to 0 to ensure no pagination is applied.
+	qs.Add("limit", "0")
+	qs.Add("offset", "0")
+
 	p := path.Join("/v1/services", akid.String(c.serviceID), "specs")
 
 	var resp kgxapi.ListSpecsResponse


### PR DESCRIPTION
By default, the backend paginates calls to list specs with a page size of 250.
This is a quick fix to ensure backwards compatibility in the CLI.  We'll add
pagination options (e.g. --limit and --offset) to this CLI command in a later
commit.