### PR TITLE
Check the number of witnesses reported by the server

### DIFF
--- a/apispec/har.go
+++ b/apispec/har.go
@@ -15,10 +15,10 @@ import (
 )
 
 // Extract witnesses from a local HAR file and send them to the collector.
-func ProcessHAR(inboundCol, outboundCol trace.Collector, p string) error {
+func ProcessHAR(inboundCol, outboundCol trace.Collector, p string) (int, error) {
 	harContent, err := hl.LoadCustomHARFromFile(p)
 	if err != nil {
-		return errors.Wrapf(err, "failed to load HAR file %s", p)
+		return 0, errors.Wrapf(err, "failed to load HAR file %s", p)
 	}
 
 	col := inboundCol
@@ -38,7 +38,7 @@ func ProcessHAR(inboundCol, outboundCol trace.Collector, p string) error {
 		}
 	}
 
-	return nil
+	return successCount, nil
 }
 
 // ReconstructedTimestamps holds times we can use to fill in

--- a/rest/interface.go
+++ b/rest/interface.go
@@ -31,6 +31,7 @@ type CreateSpecOptions struct {
 
 type LearnClient interface {
 	ListLearnSessions(context.Context, akid.ServiceID, map[tags.Key]string) ([]*kgxapi.ListedLearnSession, error)
+	ListLearnSessionsWithStats(context.Context, akid.ServiceID, int) ([]*kgxapi.ListedLearnSession, error)
 	GetLearnSession(context.Context, akid.ServiceID, akid.LearnSessionID) (*kgxapi.LearnSession, error)
 	CreateLearnSession(context.Context, *kgxapi.APISpecReference, string, map[tags.Key]string) (akid.LearnSessionID, error)
 	ReportWitnesses(context.Context, akid.LearnSessionID, []*kgxapi.WitnessReport) error

--- a/rest/learn_client.go
+++ b/rest/learn_client.go
@@ -46,6 +46,20 @@ func (c *learnClientImpl) ListLearnSessions(ctx context.Context, svc akid.Servic
 	return resp.Sessions, nil
 }
 
+func (c *learnClientImpl) ListLearnSessionsWithStats(ctx context.Context, svc akid.ServiceID, limit int) ([]*kgxapi.ListedLearnSession, error) {
+	p := path.Join("/v1/services", akid.String(c.serviceID), "learn")
+	q := url.Values{}
+	q.Add("limit", fmt.Sprintf("%d", limit))
+	q.Add("get_stats", "true")
+
+	var resp kgxapi.ListSessionsResponse
+	err := c.getWithQuery(ctx, p, q, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Sessions, nil
+}
+
 func (c *learnClientImpl) GetLearnSession(ctx context.Context, svc akid.ServiceID, lrn akid.LearnSessionID) (*kgxapi.LearnSession, error) {
 	p := path.Join("/v1/services", akid.String(c.serviceID), "learn", akid.String(lrn))
 	var resp kgxapi.LearnSession

--- a/upload/run.go
+++ b/upload/run.go
@@ -147,7 +147,7 @@ func uploadTraces(learnClient rest.LearnClient, args Args, serviceID akid.Servic
 
 	for _, harFileName := range args.FilePaths {
 		printer.Stderr.Infof("Uploading %q...\n", harFileName)
-		if err := apispec.ProcessHAR(inboundCollector, outboundCollector, harFileName); err != nil {
+		if _, err := apispec.ProcessHAR(inboundCollector, outboundCollector, harFileName); err != nil {
 			return errors.Wrapf(err, "failed to process HAR file %q", harFileName)
 		}
 	}


### PR DESCRIPTION
before continuing with `apispec` on a local HAR file.