### PR TITLE
Add 'akita get graph' to query service graph.

### DIFF
--- a/cmd/internal/get/graph.go
+++ b/cmd/internal/get/graph.go
@@ -1,0 +1,273 @@
+package get
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/akitasoftware/akita-cli/cmd/internal/akiflag"
+	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
+	"github.com/akitasoftware/akita-cli/printer"
+	"github.com/akitasoftware/akita-cli/rest"
+	"github.com/akitasoftware/akita-cli/util"
+	"github.com/akitasoftware/akita-libs/akid"
+	"github.com/akitasoftware/akita-libs/api_schema"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var GetGraphCmd = &cobra.Command{
+	Use:          "graph [SERVICE] [DEPLOYMENT]",
+	Aliases:      []string{"graph"},
+	Short:        "Show the service graph in textual form.",
+	Long:         "Show the service graph in textual form.",
+	SilenceUsage: false,
+	RunE:         getGraph,
+}
+
+var (
+	graphOutputFlag string
+	graphTypeFlag   string
+	hideUnknownFlag bool
+)
+
+func init() {
+	Cmd.AddCommand(GetGraphCmd)
+
+	GetGraphCmd.Flags().StringVar(
+		&serviceFlag,
+		"service",
+		"",
+		"Your Akita service.")
+
+	GetGraphCmd.Flags().StringVar(
+		&deploymentFlag,
+		"deployment",
+		"",
+		"Deployment tag used for traces.")
+
+	GetGraphCmd.Flags().StringVar(
+		&startTimeFlag,
+		"start",
+		"",
+		"Time start (default 1 week ago). Must be given in RFC3339 format, as YYYY-MM-DDTHH:MM:SS+00:00")
+
+	GetGraphCmd.Flags().StringVar(
+		&endTimeFlag,
+		"end",
+		"",
+		"Time end (default now), must be RFC3339 format")
+
+	GetGraphCmd.Flags().StringVar(
+		&graphOutputFlag,
+		"output",
+		"source",
+		"Output format: source, target, dot")
+
+	GetGraphCmd.Flags().StringVar(
+		&graphTypeFlag,
+		"vertices",
+		"services",
+		"Graph vertices: services, endpoints")
+
+	GetGraphCmd.Flags().BoolVar(
+		&hideUnknownFlag,
+		"hide-unknown",
+		false,
+		"Exclude unknown vertices from the output",
+	)
+}
+
+func getGraph(cmd *cobra.Command, args []string) error {
+	// Accept these as either flags or arguments.
+	if serviceFlag == "" {
+		if len(args) == 0 {
+			return errors.New("Must specify a service and deployment name")
+		}
+		serviceFlag = args[0]
+		args = args[1:]
+	}
+	if deploymentFlag == "" {
+		if len(args) == 0 {
+			return errors.New("Must specify a deployment name")
+		}
+		deploymentFlag = args[0]
+		args = args[1:]
+	}
+
+	if len(args) > 0 {
+		return errors.New("Too many command line parameters.")
+	}
+
+	end := time.Now()
+	start := end.Add(-7 * 24 * time.Hour)
+	var err error
+
+	if startTimeFlag != "" {
+		start, err = time.Parse(time.RFC3339, startTimeFlag)
+		if err != nil {
+			return errors.Wrapf(err, "Couldn't parse start time.")
+		}
+	}
+
+	if endTimeFlag != "" {
+		end, err = time.Parse(time.RFC3339, endTimeFlag)
+		if err != nil {
+			return errors.Wrapf(err, "Couldn't parse end time.")
+		}
+	}
+
+	var graphType string
+	switch graphTypeFlag {
+	case "services":
+		graphType = "ServiceToService"
+	case "endpoints":
+		graphType = "ServiceToEndpoint"
+	default:
+		return errors.New("Unsupported graph type.")
+	}
+
+	var outputFn func(*api_schema.GraphResponse)
+	switch graphOutputFlag {
+	case "source":
+		outputFn = printGraphBySource
+	case "target":
+		outputFn = printGraphByTarget
+	case "dot", "graphviz":
+		outputFn = printDot
+	default:
+		return errors.New("Unsupported output format.")
+	}
+
+	printer.Debugf("Loading service %q deployment %q from %v to %v\n", serviceFlag, deploymentFlag, start, end)
+
+	clientID := akid.GenerateClientID()
+	frontClient := rest.NewFrontClient(akiflag.Domain, clientID)
+	serviceID, err := util.GetServiceIDByName(frontClient, serviceFlag)
+	if err != nil {
+		return cmderr.AkitaErr{Err: err}
+	}
+
+	learnClient := rest.NewLearnClient(akiflag.Domain, clientID, serviceID)
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	resp, err := learnClient.GetGraphEdges(ctx, serviceID, deploymentFlag, start, end, graphType)
+	if err != nil {
+		return cmderr.AkitaErr{Err: err}
+	}
+
+	if hideUnknownFlag {
+		replacementEdges := make([]api_schema.GraphEdge, 0, len(resp.Edges))
+		for _, e := range resp.Edges {
+			if e.SourceAttributes.Host != "" {
+				replacementEdges = append(replacementEdges, e)
+			}
+		}
+		resp.Edges = replacementEdges
+	}
+
+	outputFn(&resp)
+	return nil
+}
+
+func endpointLessThan(a1 api_schema.EndpointGroupAttributes, a2 api_schema.EndpointGroupAttributes) bool {
+	if a1.Host < a2.Host {
+		return true
+	}
+	if a1.Host > a2.Host {
+		return false
+	}
+	if a1.PathTemplate < a2.PathTemplate {
+		return true
+	}
+	if a1.PathTemplate > a2.PathTemplate {
+		return false
+	}
+	if a1.Method < a2.Method {
+		return true
+	}
+	// Ignoring response code
+	return false
+}
+
+func hostOrUnknown(h string) string {
+	if h == "" {
+		return "[unknown]"
+	}
+	return h
+}
+
+func printGraphBySource(graph *api_schema.GraphResponse) {
+	sort.Slice(graph.Edges, func(i, j int) bool {
+		return endpointLessThan(graph.Edges[i].SourceAttributes, graph.Edges[j].SourceAttributes) ||
+			(graph.Edges[i].SourceAttributes == graph.Edges[j].SourceAttributes &&
+				endpointLessThan(graph.Edges[i].TargetAttributes, graph.Edges[j].TargetAttributes))
+	})
+
+	for i, e := range graph.Edges {
+		// TODO: this assumes service is the only supported source vertex, which is true right now.
+		if i > 0 && e.SourceAttributes != graph.Edges[i-1].SourceAttributes {
+			fmt.Printf("\n%-30s -> ", hostOrUnknown(e.SourceAttributes.Host))
+		} else if i == 0 {
+			fmt.Printf("%-30s -> ", hostOrUnknown(e.SourceAttributes.Host))
+		} else {
+			// Don't repeat source information
+			fmt.Printf("%-30s -> ", "")
+		}
+
+		if e.TargetAttributes.PathTemplate == "" {
+			fmt.Printf("%-30s\n", hostOrUnknown(e.TargetAttributes.Host))
+		} else {
+			fmt.Printf("%-30s %7s %s\n", e.TargetAttributes.Host, e.TargetAttributes.Method, e.TargetAttributes.PathTemplate)
+		}
+	}
+
+}
+
+func printGraphByTarget(graph *api_schema.GraphResponse) {
+	sort.Slice(graph.Edges, func(i, j int) bool {
+		return endpointLessThan(graph.Edges[i].TargetAttributes, graph.Edges[j].TargetAttributes) ||
+			(graph.Edges[i].TargetAttributes == graph.Edges[j].TargetAttributes &&
+				endpointLessThan(graph.Edges[i].SourceAttributes, graph.Edges[j].SourceAttributes))
+	})
+
+	for i, e := range graph.Edges {
+		if i > 0 && e.TargetAttributes != graph.Edges[i-1].TargetAttributes {
+			fmt.Printf("\n")
+		}
+
+		// TODO: this assumes service is the only supported source vertex, which is true right now.
+		fmt.Printf("%-30s -> ", hostOrUnknown(e.SourceAttributes.Host))
+
+		if (i > 0 && e.TargetAttributes != graph.Edges[i-1].TargetAttributes) || i == 0 {
+			if e.TargetAttributes.PathTemplate == "" {
+				fmt.Printf("%-30s\n", hostOrUnknown(e.TargetAttributes.Host))
+			} else {
+				fmt.Printf("%-30s %7s %s\n", e.TargetAttributes.Host, e.TargetAttributes.Method, e.TargetAttributes.PathTemplate)
+			}
+		} else {
+			fmt.Printf("\n")
+		}
+	}
+}
+
+func printDot(graph *api_schema.GraphResponse) {
+	fmt.Printf("digraph G {\n")
+	for _, e := range graph.Edges {
+		if e.TargetAttributes.PathTemplate == "" {
+			fmt.Printf("  %q -> %q [label=\"%v\"]\n",
+				hostOrUnknown(e.SourceAttributes.Host),
+				e.TargetAttributes.Host,
+				e.Values[api_schema.Event_Count])
+		} else {
+			fmt.Printf("  %q -> \"%s\\n%s %s\" [label=\"%v\"]\n",
+				hostOrUnknown(e.SourceAttributes.Host),
+				e.TargetAttributes.Host,
+				e.TargetAttributes.Method,
+				e.TargetAttributes.PathTemplate,
+				e.Values[api_schema.Event_Count])
+		}
+	}
+	fmt.Printf("}\n")
+}

--- a/cmd/internal/get/graph.go
+++ b/cmd/internal/get/graph.go
@@ -63,13 +63,13 @@ func init() {
 		&graphOutputFlag,
 		"output",
 		"source",
-		"Output format: source, target, dot")
+		"Output format: source (grouped by source), target (grouped by target), dot")
 
 	GetGraphCmd.Flags().StringVar(
 		&graphTypeFlag,
 		"vertices",
 		"services",
-		"Graph vertices: services, endpoints")
+		"Graph target vertices: services, endpoints")
 
 	GetGraphCmd.Flags().BoolVar(
 		&hideUnknownFlag,
@@ -83,21 +83,21 @@ func getGraph(cmd *cobra.Command, args []string) error {
 	// Accept these as either flags or arguments.
 	if serviceFlag == "" {
 		if len(args) == 0 {
-			return errors.New("Must specify a service and deployment name")
+			return errors.New("Must specify a service name.")
 		}
 		serviceFlag = args[0]
 		args = args[1:]
 	}
 	if deploymentFlag == "" {
 		if len(args) == 0 {
-			return errors.New("Must specify a deployment name")
+			return errors.New("Must specify a deployment name.")
 		}
 		deploymentFlag = args[0]
 		args = args[1:]
 	}
 
 	if len(args) > 0 {
-		return errors.New("Too many command line parameters.")
+		return errors.New("Too many command line arguments.")
 	}
 
 	end := time.Now()

--- a/cmd/internal/get/timeline.go
+++ b/cmd/internal/get/timeline.go
@@ -28,9 +28,10 @@ var GetTimelineCmd = &cobra.Command{
 }
 
 var (
-	deploymentFlag string
-	startTimeFlag  string
-	endTimeFlag    string
+	deploymentFlag    string
+	startTimeFlag     string
+	endTimeFlag       string
+	timelineLimitFlag int
 )
 
 func init() {
@@ -61,7 +62,7 @@ func init() {
 		"Time end (default now), must be RFC3339 format")
 
 	GetTimelineCmd.Flags().IntVar(
-		&limitFlag,
+		&timelineLimitFlag,
 		"limit",
 		100,
 		"Show N time points.")
@@ -149,7 +150,7 @@ func getTimeline(cmd *cobra.Command, args []string) error {
 	learnClient := rest.NewLearnClient(akiflag.Domain, clientID, serviceID)
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
-	resp, err := learnClient.GetUnaggregatedTimeline(ctx, serviceID, deploymentFlag, start, end, limitFlag)
+	resp, err := learnClient.GetUnaggregatedTimeline(ctx, serviceID, deploymentFlag, start, end, timelineLimitFlag)
 	if err != nil {
 		return cmderr.AkitaErr{Err: err}
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20210818150446-55531f1ef499
-	github.com/akitasoftware/akita-libs v0.0.0-20210929005706-971ec9798d82
+	github.com/akitasoftware/akita-libs v0.0.0-20210929223217-aed570ae8061
 	github.com/akitasoftware/objecthash-proto v0.0.0-20210728061301-b7904b31cc09 // indirect
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20210913222640-fd1aa4abccc5 h1:uLFJFn
 github.com/akitasoftware/akita-libs v0.0.0-20210913222640-fd1aa4abccc5/go.mod h1:xJ/BooeoQcWq7GBx7wkYJHYnSXcWzxajdK6UwCCP+wo=
 github.com/akitasoftware/akita-libs v0.0.0-20210929005706-971ec9798d82 h1:ul5UWCQmnVe6GiFEXQ3xMRdv+CNKbPn6qUlfdMMZPZg=
 github.com/akitasoftware/akita-libs v0.0.0-20210929005706-971ec9798d82/go.mod h1:xJ/BooeoQcWq7GBx7wkYJHYnSXcWzxajdK6UwCCP+wo=
+github.com/akitasoftware/akita-libs v0.0.0-20210929223217-aed570ae8061 h1:5VbhDT59X3TRnmc0iaat8GlDe6ftbpdX9Bo+TtAtEgc=
+github.com/akitasoftware/akita-libs v0.0.0-20210929223217-aed570ae8061/go.mod h1:xJ/BooeoQcWq7GBx7wkYJHYnSXcWzxajdK6UwCCP+wo=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293 h1:lrR1zarKR584gABHjW4Kd7ZQTb3h1LHJXYAUo5wh6do=
 github.com/akitasoftware/gopacket v1.1.18-0.20201119235945-f584f5125293/go.mod h1:MBrCPyoWRP/pI7XvrdNAVmh6l3jHcGbIhYmF4J6xPrk=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/rest/learn_client.go
+++ b/rest/learn_client.go
@@ -222,3 +222,17 @@ func (c *learnClientImpl) GetUnaggregatedTimeline(ctx context.Context, serviceID
 	err := c.getWithQuery(ctx, path, q, &resp)
 	return resp, err
 }
+
+// Return the edges of the service graph in the specified time window
+func (c *learnClientImpl) GetGraphEdges(ctx context.Context, serviceID akid.ServiceID, deployment string, start time.Time, end time.Time, graphType string) (kgxapi.GraphResponse, error) {
+	path := fmt.Sprintf("/v1/services/%s/servicegraph/%s/query",
+		akid.String(serviceID), deployment)
+	q := url.Values{}
+	q.Add("start", fmt.Sprintf("%d", start.Unix()*1000000))
+	q.Add("end", fmt.Sprintf("%d", end.Unix()*1000000))
+	q.Add("type", graphType)
+
+	var resp kgxapi.GraphResponse
+	err := c.getWithQuery(ctx, path, q, &resp)
+	return resp, err
+}


### PR DESCRIPTION
Also fixed a bug with 'get timeline' where the wrong default was being used.

Example usage:
```
mark@ubuntu:~/akita-cli$ bin/akita --domain staging.akita.software get graph --start 2021-09-30T00:00:00-05:00 akita-prod production --vertices=endpoints
[unknown]                      -> 10.0.187.101:10250                POST /exec/AbY97z1N
                               -> 10.0.187.101:10250                POST /exec/l2hDbH5r
                               -> 10.0.37.201:8080                   GET /
                               -> api.akita.software                 GET /v1/daemon/active
                               -> api.akita.software             OPTIONS /v1/daemon/active
                               -> api.akita.software                 GET /v1/integrations/github/repos
                               -> api.akita.software             OPTIONS /v1/integrations/github/repos
                               -> api.akita.software                 GET /v1/integrations/github/repos/{arg5}/{arg6}/prs/{arg8}/akita-enabled
                               -> api.akita.software                 GET /v1/integrations/gitlab/projects
                               -> api.akita.software             OPTIONS /v1/integrations/gitlab/projects
                               -> api.akita.software                 GET /v1/services
                               -> api.akita.software             OPTIONS /v1/services
                               -> api.akita.software                 GET /v1/services/svc_40fyzouDejBshE5xwK21za/active_middleware
                               -> api.akita.software             OPTIONS /v1/services/svc_40fyzouDejBshE5xwK21za/active_middleware
                               -> api.akita.software                 GET /v1/services/svc_40fyzouDejBshE5xwK21za/spec-versions
                               -> api.akita.software             OPTIONS /v1/services/svc_40fyzouDejBshE5xwK21za/spec-versions
                               -> api.akita.software                 GET /v1/services/svc_4jtWBvWalFlQp2Xagok7dL/ids/specs/cerulean-antelope-0aaadcb4
                               -> api.akita.software                 GET /v1/services/svc_4jtWBvWalFlQp2Xagok7dL/ids/specs/orchid-ape-f72ec0c5
                               -> api.akita.software                 GET /v1/services/svc_4jtWBvWalFlQp2Xagok7dL/ids/specs/void-walker-63710ca0
                               -> api.akita.software                POST /v1/services/svc_4jtWBvWalFlQp2Xagok7dL/spec-versions/stable
                               -> api.akita.software                 GET /v1/services/{arg3}
                               -> api.akita.software             OPTIONS /v1/services/{arg3}
                               -> api.akita.software                 GET /v1/services/{arg3}/ids/learn_sessions/{arg6}
                               -> api.akita.software                 GET /v1/services/{arg3}/learn
                               -> api.akita.software             OPTIONS /v1/services/{arg3}/learn
                               -> api.akita.software                POST /v1/services/{arg3}/learn
                               -> api.akita.software                 GET /v1/services/{arg3}/learn/{arg5}
                               -> api.akita.software                POST /v1/services/{arg3}/learn/{arg5}/async_witnesses
                               -> api.akita.software                 GET /v1/services/{arg3}/specs
                               -> api.akita.software             OPTIONS /v1/services/{arg3}/specs
                               -> api.akita.software                POST /v1/services/{arg3}/specs
                               -> api.akita.software                 GET /v1/services/{arg3}/specs/{arg5}/{arg6}
                               -> api.akita.software             OPTIONS /v1/services/{arg3}/specs/{arg5}/{arg6}
                               -> api.akita.software                 GET /v1/services/{arg3}/stats
                               -> api.akita.software             OPTIONS /v1/services/{arg3}/stats
                               -> api.akita.software                 GET /v1/user
                               -> api.akita.software             OPTIONS /v1/user
                               -> api.akita.software                 GET /v1/user/features
                               -> api.akita.software             OPTIONS /v1/user/features
                               -> api.akita.software                POST /v1/webhooks/github/events
                               -> integration-gateway:50080          GET /v1/orgs/org_60DbQCj22e6C59SKVmFn7p/github/teams/Medology/akita-users/dependabot[bot]
                               -> integration-gateway:50080          GET /v1/orgs/{arg3}/github/repos/Medology/stdcheck.com/prs/{arg9}
                               -> integration-gateway:50080          GET /v1/orgs/{arg3}/github/teams/Medology/akita-users
                               -> integration-gateway:50080          GET /v1/orgs/{arg3}/github/teams/Medology/akita-users/gamanuel
                               -> integration-gateway:50080          GET /v1/orgs/{arg3}/github/teams/Medology/akita-users/luchiniii
                               -> integration-gateway:50080          GET /v1/orgs/{arg3}/github/teams/akitasoftware/akita-users
                               -> integration-gateway:50080         POST /v1/webhooks/github/events
                               -> kings-cross:50060                  GET /v1/services/{arg3}/ids/learn_sessions/{arg6}
                               -> kings-cross:50060                 POST /v1/services/{arg3}/learn
                               -> kings-cross:50060                  GET /v1/services/{arg3}/learn/{arg5}

api.akita.software             -> integration-gateway:50080          GET /v1/orgs/org_76pbCzxpCziGHBQi8GzPd3/github/repos
                               -> integration-gateway:50080          GET /v1/orgs/org_76pbCzxpCziGHBQi8GzPd3/gitlab/projects
                               -> integration-gateway:50080         POST /v1/webhooks/github/events
                               -> kings-cross:50060                  GET /v1/services/svc_40fyzouDejBshE5xwK21za/spec-versions
                               -> kings-cross:50060                  GET /v1/services/svc_4jtWBvWalFlQp2Xagok7dL/ids/specs/cerulean-antelope-0aaadcb4
                               -> kings-cross:50060                 POST /v1/services/svc_4jtWBvWalFlQp2Xagok7dL/spec-versions/stable
                               -> kings-cross:50060                  GET /v1/services/{arg3}/ids/learn_sessions/{arg6}
                               -> kings-cross:50060                  GET /v1/services/{arg3}/learn
                               -> kings-cross:50060                 POST /v1/services/{arg3}/learn
                               -> kings-cross:50060                  GET /v1/services/{arg3}/learn/{arg5}
                               -> kings-cross:50060                  GET /v1/services/{arg3}/specs
                               -> kings-cross:50060                 POST /v1/services/{arg3}/specs
                               -> kings-cross:50060                  GET /v1/services/{arg3}/specs/{arg5}/metadata
                               -> kings-cross:50060                  GET /v1/services/{arg3}/specs/{arg5}/summary
                               -> kings-cross:50060                  GET /v1/services/{arg3}/stats
```