### PR TITLE
Display that no edges have been returned if that is the case.

### DIFF
--- a/cmd/internal/get/graph.go
+++ b/cmd/internal/get/graph.go
@@ -157,6 +157,11 @@ func getGraph(cmd *cobra.Command, args []string) error {
 		return cmderr.AkitaErr{Err: err}
 	}
 
+	if len(resp.Edges) == 0 {
+		printer.Infof("No edges found.")
+		return nil
+	}
+
 	if hideUnknownFlag {
 		replacementEdges := make([]api_schema.GraphEdge, 0, len(resp.Edges))
 		for _, e := range resp.Edges {


### PR DESCRIPTION
(Before, we got a 404 which caused an error message to be printed.)