### PR TITLE
Disable collection of outbound witnesses by default

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -60,6 +60,7 @@ type Args struct {
 
 	Interfaces     []string
 	Filter         string
+	EnableOutbound bool
 	Tags           map[tags.Key]string
 	PathExclusions []string
 	HostExclusions []string
@@ -245,6 +246,12 @@ func compileRegexps(filters []string, name string) ([]*regexp.Regexp, error) {
 func Run(args Args) error {
 	args.lint()
 
+	debugEnabled := viper.GetBool("debug")
+
+	if args.EnableOutbound {
+		printer.Warningln("Enabling collection of outbound traffic. The \"--enable-outbound-collection\" flag is deprecated and may be removed in a future release.")
+	}
+
 	// Get the interfaces to listen on.
 	interfaces, err := getEligibleInterfaces(args.Interfaces)
 	if err != nil {
@@ -252,12 +259,14 @@ func Run(args Args) error {
 	}
 
 	// Build inbound and outbound filters for each interface.
-	inboundFilters, outboundFilters, err := createBPFFilters(interfaces, args.Filter, 0)
+	inboundFilters, outboundFilters, err := createBPFFilters(interfaces, args.Filter, args.EnableOutbound || debugEnabled, 0)
 	if err != nil {
 		return err
 	}
 	printer.Debugln("Inbound BPF filters:", inboundFilters)
-	printer.Debugln("Outbound BPF filters:", outboundFilters)
+	if args.EnableOutbound {
+		printer.Debugln("Outbound BPF filters:", outboundFilters)
+	}
 
 	traceTags := collectTraceTags(&args)
 
@@ -355,7 +364,13 @@ func Run(args Args) error {
 
 		for interfaceName, filter := range filters {
 			var collector trace.Collector
-			{
+			if dir == kgxapi.Outbound && !args.EnableOutbound {
+				// During debugging, we enable outbound filters regardless of whether
+				// the user has enabled outbound collection. This allows us to report
+				// statistics for packets not matching the user's filters. We need to
+				// avoid sending this traffic to the back end, however.
+				collector = trace.NewDummyCollector()
+			} else {
 				var localCollector trace.Collector
 				if args.Out.LocalPath != nil {
 					if lc, err := createLocalCollector(interfaceName, *args.Out.LocalPath, dir, traceTags); err == nil {
@@ -457,10 +472,20 @@ func Run(args Args) error {
 		}
 		printer.Stderr.Infof("Running learn mode on interfaces %s\n", strings.Join(iNames, ", "))
 	}
-	if len(outboundFilters) == 0 {
+
+	unfiltered := true
+	for _, f := range inboundFilters {
+		if f != "" {
+			unfiltered = false
+			break
+		}
+	}
+	if unfiltered {
 		printer.Stderr.Warningf("%s\n", printer.Color.Yellow("--filter flag is not set, this means that:"))
 		printer.Stderr.Warningf("%s\n", printer.Color.Yellow("  - all network traffic is treated as your API traffic"))
-		printer.Stderr.Warningf("%s\n", printer.Color.Yellow("  - outbound witness collection is disabled"))
+		if args.EnableOutbound {
+			printer.Stderr.Warningf("%s\n", printer.Color.Yellow("  - outbound witness collection is disabled"))
+		}
 	}
 
 	var stopErr error

--- a/apidump/net.go
+++ b/apidump/net.go
@@ -201,7 +201,7 @@ func getInboundBPFFilter(interfaces map[string]interfaceInfo, bpfFilter string, 
 	return results, nil
 }
 
-func createBPFFilters(interfaces map[string]interfaceInfo, bpfFilter string, port uint16) (map[string]string, map[string]string, error) {
+func createBPFFilters(interfaces map[string]interfaceInfo, bpfFilter string, createOutbound bool, port uint16) (map[string]string, map[string]string, error) {
 	inboundFilters, err := getInboundBPFFilter(interfaces, bpfFilter, port)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to build BPF filters for inbound traffic")
@@ -210,11 +210,13 @@ func createBPFFilters(interfaces map[string]interfaceInfo, bpfFilter string, por
 	// for random traffic on the machine, but is the best we can do without an
 	// explicit outbound filter flag.
 	outboundFilters := make(map[string]string, len(inboundFilters))
-	for n, f := range inboundFilters {
-		// No inbound filter means that we can't differentiate between inbound and
-		// outbound (i.e. user didn't set --port or --bpf-filter).
-		if f != "" {
-			outboundFilters[n] = fmt.Sprintf("not (%s)", f)
+	if createOutbound {
+		for n, f := range inboundFilters {
+			// No inbound filter means that we can't differentiate between inbound and
+			// outbound (i.e. user didn't set --port or --bpf-filter).
+			if f != "" {
+				outboundFilters[n] = fmt.Sprintf("not (%s)", f)
+			}
 		}
 	}
 

--- a/apidump/net.go
+++ b/apidump/net.go
@@ -119,7 +119,7 @@ func checkPcapPermissions(interfaces map[string]interfaceInfo) map[string]error 
 	}
 
 	wg.Wait()
-	printer.Debugf("Check pcap permission done after %s\n", time.Now().Sub(start))
+	printer.Debugf("Check pcap permission done after %s\n", time.Since(start))
 	close(errChan)
 	errs := map[string]error{}
 	for pe := range errChan {

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -19,6 +19,7 @@ var (
 	serviceFlag         string
 	interfacesFlag      []string
 	filterFlag          string
+	enableOutboundFlag  bool
 	sampleRateFlag      float64
 	rateLimitFlag       float64
 	tagsFlag            []string
@@ -96,6 +97,7 @@ var Cmd = &cobra.Command{
 			WitnessesPerMinute: rateLimitFlag,
 			Interfaces:         interfacesFlag,
 			Filter:             filterFlag,
+			EnableOutbound:     enableOutboundFlag,
 			PathExclusions:     pathExclusionsFlag,
 			HostExclusions:     hostExclusionsFlag,
 			PathAllowlist:      pathAllowlistFlag,
@@ -134,6 +136,15 @@ func init() {
 		"filter",
 		"",
 		"Used to match packets going to and coming from your API service.")
+
+	// Collection of "outbound" traffic is now disabled by default. This is here
+	// in case anyone relies on the old behaviour.
+	Cmd.Flags().BoolVar(
+		&enableOutboundFlag,
+		"enable-outbound-collection",
+		false,
+		"Collect packets that don't match the filter and upload them to Akita Cloud as \"outbound\" traffic.")
+	Cmd.Flags().MarkHidden("enable-outbound-collection")
 
 	Cmd.Flags().StringSliceVar(
 		&interfacesFlag,

--- a/cmd/internal/learn/cmd.go
+++ b/cmd/internal/learn/cmd.go
@@ -284,6 +284,7 @@ func runAPIDump(clientID akid.ClientID, serviceName string, tagsMap map[tags.Key
 		Out:                traceOut,
 		Interfaces:         interfacesFlag,
 		Filter:             packetFilter,
+		EnableOutbound:     enableOutboundFlag,
 		Tags:               tagsMap,
 		SampleRate:         sampleRate,
 		WitnessesPerMinute: rateLimitFlag,

--- a/cmd/internal/learn/flags.go
+++ b/cmd/internal/learn/flags.go
@@ -52,6 +52,9 @@ var (
 	legacyHARDirFlag    string
 	legacyHARSampleFlag float64
 	legacyGitHubURLFlag string
+
+	// Whether to enable the old behaviour of collecting "outbound" witnesses.
+	enableOutboundFlag bool
 )
 
 func init() {
@@ -86,6 +89,15 @@ func registerOptionalFlags() {
 		"filter",
 		"",
 		"Used to match packets going to and coming from your API service.")
+
+	// Collection of "outbound" traffic is now disabled by default. This is here
+	// in case anyone relies on the old behaviour.
+	Cmd.Flags().BoolVar(
+		&enableOutboundFlag,
+		"enable-outbound-collection",
+		false,
+		"Collect packets that don't match the filter and upload them to Akita Cloud as \"outbound\" traffic.")
+	Cmd.Flags().MarkHidden("enable-outbound-collection")
 
 	Cmd.Flags().StringSliceVar(
 		&tagsFlag,

--- a/trace/dummy_collector.go
+++ b/trace/dummy_collector.go
@@ -1,0 +1,19 @@
+package trace
+
+import "github.com/akitasoftware/akita-libs/akinet"
+
+type dummyCollector struct{}
+
+var _ Collector = (*dummyCollector)(nil)
+
+func (*dummyCollector) Process(akinet.ParsedNetworkTraffic) error {
+	return nil
+}
+
+func (*dummyCollector) Close() error {
+	return nil
+}
+
+func NewDummyCollector() Collector {
+	return &dummyCollector{}
+}


### PR DESCRIPTION
Anyone wishing to restore the old behaviour can use the hidden flag `--enable-outbound-collection`. When this flag is used, the user is warned that the flag might be removed in a future release.