### PR TITLE
Remove error messages when an assembly context is nil.

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -18,6 +18,7 @@ import (
 	"github.com/akitasoftware/akita-cli/ci"
 	"github.com/akitasoftware/akita-cli/deployment"
 	"github.com/akitasoftware/akita-cli/location"
+	"github.com/akitasoftware/akita-cli/pcap"
 	"github.com/akitasoftware/akita-cli/plugin"
 	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-cli/rest"
@@ -574,6 +575,15 @@ func Run(args Args) error {
 			DumpPacketCounters(interfaces, inboundPrefilter, nil, false)
 		}
 
+	}
+
+	// Report on recoverable error counts during trace
+	if pcap.CountNilAssemblerContext > 0 || pcap.CountNilAssemblerContextAfterParse > 0 || pcap.CountBadAssemblerContextType > 0 {
+		printer.Stderr.Infof("Detected packet assembly context problems during capture: %v empty, %v bad type, %v empty after parse",
+			pcap.CountNilAssemblerContext,
+			pcap.CountBadAssemblerContextType,
+			pcap.CountNilAssemblerContextAfterParse)
+		printer.Stderr.Infof("These errors may cause some packets to be missing from the trace.")
 	}
 
 	// Check summary to see if the inbound trace will have anything in it.

--- a/pcap/net_parse_test.go
+++ b/pcap/net_parse_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"reflect"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/google/gopacket"
 
 	"github.com/akitasoftware/akita-libs/akinet"
+	"github.com/akitasoftware/akita-libs/akinet/http"
 	"github.com/akitasoftware/akita-libs/memview"
 )
 
@@ -458,5 +460,39 @@ func TestUDP(t *testing.T) {
 
 	if diff := netParseCmp(expected, actual); diff != "" {
 		t.Errorf("mismatch: %s", diff)
+	}
+}
+
+// This test triggers a nil assembly context in tcpFlow.reassembledWithIgnore.
+// Currently we have an error counter, but maybe we should come up with a better long-term solution.
+func XXX_TestHTTPResponseInJumboframe(t *testing.T) {
+	firstResponse := "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2000\r\n\r\n"
+	secondBody := "<html><body>This is some extra text</body></html>"
+	actualResponse := fmt.Sprintf("HTTP/1.1 400 Not Found\r\nContent-Type: text/html\r\nContent-Length: %d\r\n\r\n%s", len(secondBody), secondBody)
+	secondPacket := fmt.Sprintf("%02000d%s", 17, actualResponse)
+
+	pkts := []gopacket.Packet{
+		// Create a response that is in the second page of a jumbo frame packet, and arrived out of order
+		CreatePacketWithSeq(ip2, ip1, port2, port1, []byte(firstResponse[:1]), 0),
+		CreatePacketWithSeq(ip2, ip1, port2, port1, []byte(secondPacket), uint32(len(firstResponse))),
+		CreatePacketWithSeq(ip2, ip1, port2, port1, []byte(firstResponse[1:]), 1),
+		CreatePacketWithSeq(ip2, ip1, port2, port1, []byte("Extra junk"), uint32(len(firstResponse)+len(secondPacket))),
+	}
+
+	closeChan := make(chan struct{})
+	defer close(closeChan)
+	out, err := setupParseFromInterface(fakePcap(pkts), closeChan, http.NewHTTPResponseParserFactory())
+	if err != nil {
+		t.Errorf("unexpected error setting up listener: %v", err)
+		return
+	}
+
+	actual := make([]akinet.ParsedNetworkTraffic, 0, 3)
+	for nt := range out {
+		fmt.Printf("Packet %v: %v\n", len(actual), reflect.TypeOf(nt.Content))
+		actual = append(actual, nt)
+	}
+	if len(actual) != 3 {
+		t.Errorf("Expected three parsed packets")
 	}
 }

--- a/pcap/stream.go
+++ b/pcap/stream.go
@@ -119,7 +119,7 @@ func (f *tcpFlow) reassembledWithIgnore(ignoreCount int, sg reassembly.ScatterGa
 			acForFirstByte := sg.AssemblerContext(ignoreCount + int(discardFront))
 			ctx, ok := acForFirstByte.(*assemblerCtxWithSeq)
 			if !ok {
-				// Previous we errored in this case:
+				// Previously we errored in this case:
 				printer.V(6).Infof("received AssemblerContext %v without TCP seq info, treating %s data as raw bytes\n", acForFirstByte, fact.Name())
 				// but a user ran into quite a lot of them.  One theory is that this occurs when the HTTP response is in the
 				// second (or later) page of a reassembly buffer.  A test validates that, but there might be other causes


### PR DESCRIPTION
Includes a (disabled) unit test demonstrating one way this can arise.
Added counters reporting number of such errors at the end of 'apidump'.

Question: is there a nice counter library we should be using?  Or is everything StatsD-based in the modern era?