### PR TITLE
Disable collection and uploading of outbound witnesses

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -374,7 +374,7 @@ func Run(args Args) error {
 			} else {
 				var localCollector trace.Collector
 				if args.Out.LocalPath != nil {
-					if lc, err := createLocalCollector(interfaceName, *args.Out.LocalPath, dir, traceTags); err == nil {
+					if lc, err := createLocalCollector(interfaceName, *args.Out.LocalPath, traceTags); err == nil {
 						localCollector = lc
 					} else {
 						return err
@@ -618,7 +618,7 @@ func Run(args Args) error {
 	return nil
 }
 
-func createLocalCollector(interfaceName, outDir string, netDir kgxapi.NetworkDirection, tags map[tags.Key]string) (trace.Collector, error) {
+func createLocalCollector(interfaceName, outDir string, tags map[tags.Key]string) (trace.Collector, error) {
 	if fi, err := os.Stat(outDir); err == nil {
 		// File exists, check if it's a directory.
 		if !fi.IsDir() {
@@ -639,5 +639,5 @@ func createLocalCollector(interfaceName, outDir string, netDir kgxapi.NetworkDir
 		}
 	}
 
-	return trace.NewHARCollector(interfaceName, outDir, netDir == kgxapi.Outbound, tags), nil
+	return trace.NewHARCollector(interfaceName, outDir, tags), nil
 }

--- a/apispec/har.go
+++ b/apispec/har.go
@@ -16,15 +16,15 @@ import (
 
 // Extract witnesses from a local HAR file and send them to the collector.
 // Returns the number of entries extracted.
-func ProcessHAR(inboundCol, outboundCol trace.Collector, p string) (int, error) {
+func ProcessHAR(col trace.Collector, p string) (int, error) {
 	harContent, err := hl.LoadCustomHARFromFile(p)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to load HAR file %s", p)
 	}
 
-	col := inboundCol
 	if harContent.AkitaExt.Outbound {
-		col = outboundCol
+		// HAR content was filtered by the user. Ignore it.
+		return 0, nil
 	}
 
 	successCount, errs := parseFromHAR(col, harContent.Log)

--- a/apispec/run.go
+++ b/apispec/run.go
@@ -242,7 +242,7 @@ func Run(args Args) error {
 	if args.Out.AkitaURI != nil && args.Out.AkitaURI.ObjectName != "" {
 		outSpecName = args.Out.AkitaURI.ObjectName
 	}
-	timeout := 10*time.Second
+	timeout := 10 * time.Second
 	if args.Timeout != nil {
 		timeout = *args.Timeout
 	}
@@ -457,16 +457,13 @@ func uploadLocalTraces(domain string, clientID akid.ClientID, svc akid.ServiceID
 			return nil, errors.Wrap(err, "failed to create backend learn session")
 		}
 
-		inboundCol := trace.NewBackendCollector(svc, lrn, learnClient, kgxapi.Inbound, plugins)
-		outboundCol := trace.NewBackendCollector(svc, lrn, learnClient, kgxapi.Outbound, plugins)
+		collector := trace.NewBackendCollector(svc, lrn, learnClient, plugins)
 		if !includeTrackers {
-			inboundCol = trace.New3PTrackerFilterCollector(inboundCol)
-			outboundCol = trace.New3PTrackerFilterCollector(outboundCol)
+			collector = trace.New3PTrackerFilterCollector(collector)
 		}
-		defer inboundCol.Close()
-		defer outboundCol.Close()
+		defer collector.Close()
 
-		witnessCount, err := ProcessHAR(inboundCol, outboundCol, p)
+		witnessCount, err := ProcessHAR(collector, p)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to process HAR file %s", p)
 		}

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -19,7 +19,6 @@ var (
 	serviceFlag         string
 	interfacesFlag      []string
 	filterFlag          string
-	enableOutboundFlag  bool
 	sampleRateFlag      float64
 	rateLimitFlag       float64
 	tagsFlag            []string
@@ -97,7 +96,6 @@ var Cmd = &cobra.Command{
 			WitnessesPerMinute: rateLimitFlag,
 			Interfaces:         interfacesFlag,
 			Filter:             filterFlag,
-			EnableOutbound:     enableOutboundFlag,
 			PathExclusions:     pathExclusionsFlag,
 			HostExclusions:     hostExclusionsFlag,
 			PathAllowlist:      pathAllowlistFlag,
@@ -136,15 +134,6 @@ func init() {
 		"filter",
 		"",
 		"Used to match packets going to and coming from your API service.")
-
-	// Collection of "outbound" traffic is now disabled by default. This is here
-	// in case anyone relies on the old behaviour.
-	Cmd.Flags().BoolVar(
-		&enableOutboundFlag,
-		"enable-outbound-collection",
-		false,
-		"Collect packets that don't match the filter and upload them to Akita Cloud as \"outbound\" traffic.")
-	Cmd.Flags().MarkHidden("enable-outbound-collection")
 
 	Cmd.Flags().StringSliceVar(
 		&interfacesFlag,

--- a/cmd/internal/learn/cmd.go
+++ b/cmd/internal/learn/cmd.go
@@ -284,7 +284,6 @@ func runAPIDump(clientID akid.ClientID, serviceName string, tagsMap map[tags.Key
 		Out:                traceOut,
 		Interfaces:         interfacesFlag,
 		Filter:             packetFilter,
-		EnableOutbound:     enableOutboundFlag,
 		Tags:               tagsMap,
 		SampleRate:         sampleRate,
 		WitnessesPerMinute: rateLimitFlag,

--- a/cmd/internal/learn/flags.go
+++ b/cmd/internal/learn/flags.go
@@ -52,9 +52,6 @@ var (
 	legacyHARDirFlag    string
 	legacyHARSampleFlag float64
 	legacyGitHubURLFlag string
-
-	// Whether to enable the old behaviour of collecting "outbound" witnesses.
-	enableOutboundFlag bool
 )
 
 func init() {
@@ -89,15 +86,6 @@ func registerOptionalFlags() {
 		"filter",
 		"",
 		"Used to match packets going to and coming from your API service.")
-
-	// Collection of "outbound" traffic is now disabled by default. This is here
-	// in case anyone relies on the old behaviour.
-	Cmd.Flags().BoolVar(
-		&enableOutboundFlag,
-		"enable-outbound-collection",
-		false,
-		"Collect packets that don't match the filter and upload them to Akita Cloud as \"outbound\" traffic.")
-	Cmd.Flags().MarkHidden("enable-outbound-collection")
 
 	Cmd.Flags().StringSliceVar(
 		&tagsFlag,

--- a/daemon/internal/cloud_client/cloud_client.go
+++ b/daemon/internal/cloud_client/cloud_client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/akitasoftware/akita-cli/rest"
 	"github.com/akitasoftware/akita-cli/trace"
 	"github.com/akitasoftware/akita-libs/akid"
-	"github.com/akitasoftware/akita-libs/api_schema"
 	"github.com/akitasoftware/akita-libs/daemon"
 	"github.com/akitasoftware/akita-libs/sampled_err"
 	"github.com/google/uuid"
@@ -154,7 +153,7 @@ func (client *cloudClient) startTraceEventCollector(serviceID akid.ServiceID, lo
 func collectTraces(traceEventChannel <-chan *TraceEvent, learnClient rest.LearnClient, serviceID akid.ServiceID, loggingOptions daemon.LoggingOptions, plugins []plugin.AkitaPlugin) {
 	// Create the collector.
 	packetCountSummary := trace.NewPacketCountSummary()
-	collector := trace.NewBackendCollector(serviceID, loggingOptions.TraceID, learnClient, api_schema.Inbound, plugins)
+	collector := trace.NewBackendCollector(serviceID, loggingOptions.TraceID, learnClient, plugins)
 	collector = &trace.PacketCountCollector{
 		PacketCounts: packetCountSummary,
 		Collector:    collector,

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20211111012430-2a7dcb20a144
-	github.com/akitasoftware/akita-libs v0.0.0-20211111012827-383fd9491294
+	github.com/akitasoftware/akita-libs v0.0.0-20211111202033-9d8c300340ac
 	github.com/akitasoftware/plugin-flickr v0.0.0-20211109005045-a66719c1e67f
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20211111012430-2a7dcb20a144
-	github.com/akitasoftware/akita-libs v0.0.0-20211111202033-9d8c300340ac
+	github.com/akitasoftware/akita-libs v0.0.0-20211112000753-112b307bc70a
 	github.com/akitasoftware/plugin-flickr v0.0.0-20211109005045-a66719c1e67f
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/akitasoftware/akita-ir v0.0.0-20211020161529-944af4d11d6e/go.mod h1:W
 github.com/akitasoftware/akita-ir v0.0.0-20211111012430-2a7dcb20a144 h1:mcrsbJ/+2PJ4HOZ3ZodyevF3SL/al34+cmk044Sr1tk=
 github.com/akitasoftware/akita-ir v0.0.0-20211111012430-2a7dcb20a144/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-libs v0.0.0-20211020162041-fe02207174fb/go.mod h1:YLFCjhwQ0ZFfYWSUD2c9KYKEeBn+R+Cz+A5SitXvJz8=
-github.com/akitasoftware/akita-libs v0.0.0-20211111012827-383fd9491294 h1:K+T3v30AL9ZF/neeW+KmGrOjvMVjXTRl+d+0/ip4McY=
-github.com/akitasoftware/akita-libs v0.0.0-20211111012827-383fd9491294/go.mod h1:VCOuaIO3Zly/tntC+FOubxneqwBNDwBjHSR/eTR0h2A=
+github.com/akitasoftware/akita-libs v0.0.0-20211111202033-9d8c300340ac h1:owyNdjJzLWDHBWXIX93B4bPkxwo6ijWM4kom0THSVp8=
+github.com/akitasoftware/akita-libs v0.0.0-20211111202033-9d8c300340ac/go.mod h1:VCOuaIO3Zly/tntC+FOubxneqwBNDwBjHSR/eTR0h2A=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b/go.mod h1:wteInquxIdgWpGJEJmJEMJVtqM2i2vFZJ4W7B8G9ex8=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210608174341-829c1134e9de h1:rWkji88f/EWUY+qGc6pEyhpjgFbpsXwrnlTDTu5mLjY=

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/akitasoftware/akita-ir v0.0.0-20211020161529-944af4d11d6e/go.mod h1:W
 github.com/akitasoftware/akita-ir v0.0.0-20211111012430-2a7dcb20a144 h1:mcrsbJ/+2PJ4HOZ3ZodyevF3SL/al34+cmk044Sr1tk=
 github.com/akitasoftware/akita-ir v0.0.0-20211111012430-2a7dcb20a144/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-libs v0.0.0-20211020162041-fe02207174fb/go.mod h1:YLFCjhwQ0ZFfYWSUD2c9KYKEeBn+R+Cz+A5SitXvJz8=
-github.com/akitasoftware/akita-libs v0.0.0-20211111202033-9d8c300340ac h1:owyNdjJzLWDHBWXIX93B4bPkxwo6ijWM4kom0THSVp8=
-github.com/akitasoftware/akita-libs v0.0.0-20211111202033-9d8c300340ac/go.mod h1:VCOuaIO3Zly/tntC+FOubxneqwBNDwBjHSR/eTR0h2A=
+github.com/akitasoftware/akita-libs v0.0.0-20211112000753-112b307bc70a h1:k+5CvjttBq9lMdDaTS7kKi70fygdVTBQsfLBsHE/V20=
+github.com/akitasoftware/akita-libs v0.0.0-20211112000753-112b307bc70a/go.mod h1:VCOuaIO3Zly/tntC+FOubxneqwBNDwBjHSR/eTR0h2A=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b/go.mod h1:wteInquxIdgWpGJEJmJEMJVtqM2i2vFZJ4W7B8G9ex8=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210608174341-829c1134e9de h1:rWkji88f/EWUY+qGc6pEyhpjgFbpsXwrnlTDTu5mLjY=

--- a/learn/kgx_processor.go
+++ b/learn/kgx_processor.go
@@ -57,7 +57,7 @@ func NewKGXWitnessProcessor(lrn akid.LearnSessionID, client rest.LearnClient, bu
 }
 
 func (w *KGXWitnessProcessor) ProcessWitness(r *witnessResult) error {
-	report, err := r.toReport(w.dir)
+	report, err := r.toReport()
 	if err != nil {
 		return err
 	}

--- a/learn/learn.go
+++ b/learn/learn.go
@@ -35,7 +35,7 @@ type witnessResult struct {
 	id              akid.WitnessID
 }
 
-func (r witnessResult) toReport(dir kgxapi.NetworkDirection) (*kgxapi.WitnessReport, error) {
+func (r witnessResult) toReport() (*kgxapi.WitnessReport, error) {
 	// Hash algorithm defined in
 	// https://docs.google.com/document/d/1ZANeoLTnsO10DcuzsAt6PBCt2MWLYW8oeu_A6d9bTJk/edit#heading=h.tbvm9waph6eu
 	hash := ir_hash.HashWitnessToString(r.witness)
@@ -46,7 +46,7 @@ func (r witnessResult) toReport(dir kgxapi.NetworkDirection) (*kgxapi.WitnessRep
 	}
 
 	return &kgxapi.WitnessReport{
-		Direction:       dir,
+		Direction:       kgxapi.Inbound,
 		OriginAddr:      r.srcIP,
 		OriginPort:      r.srcPort,
 		DestinationAddr: r.dstIP,

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -90,7 +90,7 @@ func TestObfuscate(t *testing.T) {
 		},
 	}
 
-	col := NewBackendCollector(fakeSvc, fakeLrn, mockClient, kgxapi.Inbound, nil)
+	col := NewBackendCollector(fakeSvc, fakeLrn, mockClient, nil)
 	assert.NoError(t, col.Process(req))
 	assert.NoError(t, col.Process(resp))
 	assert.NoError(t, col.Close())
@@ -225,7 +225,7 @@ func TestTiming(t *testing.T) {
 		FinalPacketTime: startTime.Add(13 * time.Millisecond),
 	}
 
-	col := NewBackendCollector(fakeSvc, fakeLrn, mockClient, kgxapi.Inbound, nil)
+	col := NewBackendCollector(fakeSvc, fakeLrn, mockClient, nil)
 	assert.NoError(t, col.Process(req))
 	assert.NoError(t, col.Process(resp))
 	assert.NoError(t, col.Close())
@@ -247,7 +247,7 @@ func TestMultipleInterfaces(t *testing.T) {
 		AnyTimes().
 		Return(nil)
 
-	bc := NewBackendCollector(fakeSvc, fakeLrn, mockClient, kgxapi.Inbound, nil)
+	bc := NewBackendCollector(fakeSvc, fakeLrn, mockClient, nil)
 
 	var wg sync.WaitGroup
 	fakeTrace := func(count int, start_seq int) {

--- a/trace/har_collector.go
+++ b/trace/har_collector.go
@@ -21,16 +21,14 @@ type HARCollector struct {
 	interfaceName string
 	outDir        string
 
-	isOutbound bool
-	tags       map[tags.Key]string
+	tags map[tags.Key]string
 }
 
-func NewHARCollector(interfaceName, outDir string, isOutbound bool, tags map[tags.Key]string) *HARCollector {
+func NewHARCollector(interfaceName, outDir string, tags map[tags.Key]string) *HARCollector {
 	return &HARCollector{
 		logger:        har.NewLogger(),
 		interfaceName: interfaceName,
 		outDir:        outDir,
-		isOutbound:    isOutbound,
 		tags:          tags,
 	}
 }
@@ -64,7 +62,7 @@ func (h *HARCollector) Close() error {
 
 	// Record AkitaExtension
 	harContent.AkitaExt = har.AkitaExtension{
-		Outbound: h.isOutbound,
+		Outbound: false,
 		Tags:     h.tags,
 	}
 

--- a/upload/run.go
+++ b/upload/run.go
@@ -125,29 +125,21 @@ func uploadTraces(learnClient rest.LearnClient, args Args, serviceID akid.Servic
 	outboundCount := trace.NewPacketCountSummary()
 
 	// Create collector for ingesting the trace events.
-	inboundCollector := trace.NewBackendCollector(serviceID, traceID, learnClient, api_schema.Inbound, args.Plugins)
-	outboundCollector := trace.NewBackendCollector(serviceID, traceID, learnClient, api_schema.Outbound, args.Plugins)
+	inboundCollector := trace.NewBackendCollector(serviceID, traceID, learnClient, args.Plugins)
 	defer inboundCollector.Close()
-	defer outboundCollector.Close()
 
 	inboundCollector = &trace.PacketCountCollector{
 		PacketCounts: inboundCount,
 		Collector:    inboundCollector,
 	}
 
-	outboundCollector = &trace.PacketCountCollector{
-		PacketCounts: outboundCount,
-		Collector:    outboundCollector,
-	}
-
 	if !args.IncludeTrackers {
 		inboundCollector = trace.New3PTrackerFilterCollector(inboundCollector)
-		outboundCollector = trace.New3PTrackerFilterCollector(outboundCollector)
 	}
 
 	for _, harFileName := range args.FilePaths {
 		printer.Stderr.Infof("Uploading %q...\n", harFileName)
-		if _, err := apispec.ProcessHAR(inboundCollector, outboundCollector, harFileName); err != nil {
+		if _, err := apispec.ProcessHAR(inboundCollector, harFileName); err != nil {
 			return errors.Wrapf(err, "failed to process HAR file %q", harFileName)
 		}
 	}


### PR DESCRIPTION
Removed `--enable-outbound-collection`.

"Outbound" packets are now only captured during debugging, so the CLI can print summary statistics to the user.