### PR TITLE
Revert "Update CLI to accept tag multisets from the backend (#126)" 

### DIFF
--- a/cmd/internal/get/specs.go
+++ b/cmd/internal/get/specs.go
@@ -61,7 +61,8 @@ func init() {
 
 // All expected tags and values are present in spec.  Other tags may be
 // present, and other values than the one provided may be present for
-// the given tags.
+// the given tags.  Uses the multi-valued tag set when present, falling
+// back to the deprecated single-valued tag set otherwise.
 func allTagsMatch(spec *kgxapi.SpecInfo, expected map[tags.Key]string) bool {
 	// Use the multi-valued tags map if present.  Fall back to the single
 	// valued map otherwise.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20211111012430-2a7dcb20a144
-	github.com/akitasoftware/akita-libs v0.0.0-20220419030717-10b6ba80886d
+	github.com/akitasoftware/akita-libs v0.0.0-20220420200606-0ec39fcc8e1b
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20211111012430-2a7dcb20a144
-	github.com/akitasoftware/akita-libs v0.0.0-20220420200606-0ec39fcc8e1b
+	github.com/akitasoftware/akita-libs v0.0.0-20220420215655-9967c1b061b6
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1
 	github.com/charmbracelet/glamour v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/akitasoftware/akita-ir v0.0.0-20211020161529-944af4d11d6e/go.mod h1:W
 github.com/akitasoftware/akita-ir v0.0.0-20211111012430-2a7dcb20a144 h1:mcrsbJ/+2PJ4HOZ3ZodyevF3SL/al34+cmk044Sr1tk=
 github.com/akitasoftware/akita-ir v0.0.0-20211111012430-2a7dcb20a144/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-libs v0.0.0-20211020162041-fe02207174fb/go.mod h1:YLFCjhwQ0ZFfYWSUD2c9KYKEeBn+R+Cz+A5SitXvJz8=
-github.com/akitasoftware/akita-libs v0.0.0-20220419030717-10b6ba80886d h1:dDjdLGet3z9E7HZy/bpCqxWS+8B4MHUmT7z1hBC6kn4=
-github.com/akitasoftware/akita-libs v0.0.0-20220419030717-10b6ba80886d/go.mod h1:DeQ6CWjxCGs/xaQvSS2ih/DyUQz8QpVjh1szOwyeTwo=
+github.com/akitasoftware/akita-libs v0.0.0-20220420200606-0ec39fcc8e1b h1:3N4EZ6zhm82XeyL++/dSB9DL+wJYHuXO7WkscARnb8o=
+github.com/akitasoftware/akita-libs v0.0.0-20220420200606-0ec39fcc8e1b/go.mod h1:DeQ6CWjxCGs/xaQvSS2ih/DyUQz8QpVjh1szOwyeTwo=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b/go.mod h1:wteInquxIdgWpGJEJmJEMJVtqM2i2vFZJ4W7B8G9ex8=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210608174341-829c1134e9de h1:rWkji88f/EWUY+qGc6pEyhpjgFbpsXwrnlTDTu5mLjY=

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/akitasoftware/akita-ir v0.0.0-20211111012430-2a7dcb20a144/go.mod h1:W
 github.com/akitasoftware/akita-libs v0.0.0-20211020162041-fe02207174fb/go.mod h1:YLFCjhwQ0ZFfYWSUD2c9KYKEeBn+R+Cz+A5SitXvJz8=
 github.com/akitasoftware/akita-libs v0.0.0-20220420200606-0ec39fcc8e1b h1:3N4EZ6zhm82XeyL++/dSB9DL+wJYHuXO7WkscARnb8o=
 github.com/akitasoftware/akita-libs v0.0.0-20220420200606-0ec39fcc8e1b/go.mod h1:DeQ6CWjxCGs/xaQvSS2ih/DyUQz8QpVjh1szOwyeTwo=
+github.com/akitasoftware/akita-libs v0.0.0-20220420215655-9967c1b061b6 h1:02tCMBOOQ6ME5FfFG0AlS1jXvyH6A8FqzGPmJ46FS8c=
+github.com/akitasoftware/akita-libs v0.0.0-20220420215655-9967c1b061b6/go.mod h1:DeQ6CWjxCGs/xaQvSS2ih/DyUQz8QpVjh1szOwyeTwo=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b/go.mod h1:wteInquxIdgWpGJEJmJEMJVtqM2i2vFZJ4W7B8G9ex8=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210608174341-829c1134e9de h1:rWkji88f/EWUY+qGc6pEyhpjgFbpsXwrnlTDTu5mLjY=


### PR DESCRIPTION
#126 adopted a new format for `SpecInfo` that was not backwards compatible.  This PR bumps to a version of akita-libs with a backwards-compatible data structure.