### PR TITLE
Bugfix: Telemetry summaries had too many entries

### DIFF
--- a/trace/stats.go
+++ b/trace/stats.go
@@ -147,6 +147,9 @@ type pair[T constraints.Ordered] struct {
 	v *PacketCounts
 }
 
+// Return a new map with the N entries in counts with the highest TCP packet
+// counts.  In the case of a tie for the Nth position, the entry with the
+// smallest key is selected.
 func topNByTcpPacketCount[T constraints.Ordered](counts map[T]*PacketCounts, n int) map[T]*PacketCounts {
 	rv := make(map[T]*PacketCounts, math.Min(len(counts), n))
 

--- a/trace/stats_test.go
+++ b/trace/stats_test.go
@@ -57,6 +57,16 @@ func TestTopNTCP(t *testing.T) {
 			from:     map[int]*PacketCounts{80: &PacketCounts{}},
 			expected: map[int]*PacketCounts{80: &PacketCounts{}},
 		},
+		{
+			name: "take one from many, all equal",
+			take: 1,
+			from: map[int]*PacketCounts{
+				1: &PacketCounts{TCPPackets: 1},
+				2: &PacketCounts{TCPPackets: 1},
+				3: &PacketCounts{TCPPackets: 1},
+			},
+			expected: map[int]*PacketCounts{1: &PacketCounts{TCPPackets: 1}},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Fixes a bug where too many entries were added to telemetry summaries if the
entries had the same value for TCPPackets.