### PR TITLE
Continue packet collection after collector errors

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -664,10 +664,12 @@ func Run(args Args) error {
 					printer.Stderr.Infof("Received %v, stopping trace collection...\n", received.String())
 					break DoneWaitingForSignal
 				case interfaceErr := <-errChan:
-					printer.Stderr.Errorf("Encountered an error on interface %s, continuing with remaining interfaces.  Error: %s\n", interfaceErr.interfaceName, interfaceErr.err.Error())
 					errorsByInterface[interfaceErr.interfaceName] = interfaceErr.err
 
-					if len(errorsByInterface) == numCollectors {
+					if len(errorsByInterface) < numCollectors {
+						printer.Stderr.Errorf("Encountered an error on interface %s, continuing with remaining interfaces.  Error: %s\n", interfaceErr.interfaceName, interfaceErr.err.Error())
+					} else {
+						printer.Stderr.Errorf("Encountered an error on interface %s.  Error: %s\n", interfaceErr.interfaceName, interfaceErr.err.Error())
 						break DoneWaitingForSignal
 					}
 				}


### PR DESCRIPTION
Unless all collectors have failed, continue collecting traffic on healthy collectors/interfaces.

As an example, ephemeral interfaces are sometimes removed while the Akita client is collecting traffic, e.g. if a Docker container is stopped.  Rather than kill the CLI, we now continue collecting and summarize errors when packet collection is stopped.