### PR TITLE
Allow CLI to measure HTTP server latencies up to ~60s.

### DIFF
--- a/learn/parse_http.go
+++ b/learn/parse_http.go
@@ -98,8 +98,6 @@ func ParseHTTP(elem akinet.ParsedNetworkContent) (*PartialWitness, error) {
 
 	switch t := elem.(type) {
 	case akinet.HTTPRequest:
-		printer.Debugf("Parsing HTTP request: %+v\n", t)
-
 		streamID = t.StreamID
 		seq = t.Seq
 
@@ -109,8 +107,6 @@ func ParseHTTP(elem akinet.ParsedNetworkContent) (*PartialWitness, error) {
 		bodyDecompressed = t.BodyDecompressed
 		headers = t.Header
 	case akinet.HTTPResponse:
-		printer.Debugf("Parsing HTTP response: %+v\n", t)
-
 		streamID = t.StreamID
 		seq = t.Seq
 

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -202,6 +202,9 @@ func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
 		}
 
 		c.queueUpload(pair)
+		printer.Debugf("Completed witness %v at %v -- %v\n",
+			partial.PairKey, t.ObservationTime, t.FinalPacketTime)
+
 	} else {
 		// Store the partial witness for now, waiting for its pair or a
 		// flush timeout.
@@ -217,6 +220,8 @@ func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
 		// Store whichever timestamp brackets the processing interval.
 		w.recordTimestamp(isRequest, t)
 		c.pairCache.Store(partial.PairKey, w)
+		printer.Debugf("Partial witness %v request=%v at %v -- %v\n",
+			partial.PairKey, isRequest, t.ObservationTime, t.FinalPacketTime)
 
 	}
 	return nil


### PR DESCRIPTION
Increase "idle" connection timeout to 90 seconds.
Removed dump of reconstructed HTTP packets in hex form.
Added debugging messages about witness pairing.
Added debugging messages about TCP reassembly flushing and closing.