### PR TITLE
Deprecate commands and flags

### DIFF
--- a/apidiff/run.go
+++ b/apidiff/run.go
@@ -22,7 +22,7 @@ func Run(args Args) error {
 	// Resolve service ID.
 	serviceName := args.BaseSpecURI.ServiceName
 	if serviceName != args.NewSpecURI.ServiceName {
-		return errors.Errorf("only support diffing specs from the same service for now")
+		return errors.Errorf("only support diffing specs from the same project for now")
 	}
 
 	serviceID, err := util.GetServiceIDByName(frontClient, serviceName)

--- a/apispec/run.go
+++ b/apispec/run.go
@@ -153,10 +153,10 @@ func Run(args Args) error {
 	if uri := args.Out.AkitaURI; uri != nil {
 		serviceName = uri.ServiceName
 		if args.Service != "" && serviceName != args.Service {
-			return errors.Errorf("--service and --out cannot specify different services")
+			return errors.Errorf("--project and --out cannot specify different projects")
 		}
 	} else if args.Service == "" {
-		return errors.Errorf("must specify --service if --out is not an AkitaURI")
+		return errors.Errorf("must specify --project if --out is not an AkitaURI")
 	} else {
 		serviceName = args.Service
 	}
@@ -399,7 +399,7 @@ func resolveTraceURI(domain string, clientID akid.ClientID, uri akiuri.URI) (aki
 	// Resolve service name.
 	serviceID, err := util.GetServiceIDByName(frontClient, uri.ServiceName)
 	if err != nil {
-		return akid.LearnSessionID{}, errors.Wrapf(err, "failed to resolve service name %q", uri.ServiceName)
+		return akid.LearnSessionID{}, errors.Wrapf(err, "failed to resolve project name %q", uri.ServiceName)
 	}
 	learnClient := rest.NewLearnClient(domain, clientID, serviceID)
 

--- a/cmd/internal/apidiff/cmd.go
+++ b/cmd/internal/apidiff/cmd.go
@@ -12,6 +12,7 @@ import (
 
 // TODO(kku): support local specs by uploading them first.
 var Cmd = &cobra.Command{
+	Deprecated:   "Differences are now computed through the Akita app.",
 	Use:          "apidiff [BASE_SPEC_AKITA_URI] [NEW_SPEC_AKITA_URI]",
 	Short:        "Compare 2 API specs.",
 	SilenceUsage: true,

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -57,12 +57,12 @@ var Cmd = &cobra.Command{
 			return errors.Wrap(err, "failed to load plugins")
 		}
 
-		// Check that exactly one of --out, or --project is specified.
+		// Check that exactly one of --out or --project is specified.
 		if outFlag.IsSet() == (serviceFlag != "") {
 			return errors.New("exactly one of --out or --project must be specified")
 		}
 
-		// If --service was given, convert it to an equivalent --out.
+		// If --project was given, convert it to an equivalent --out.
 		if serviceFlag != "" {
 			uri, err := akiuri.Parse(akiuri.Scheme + serviceFlag)
 			if err != nil {
@@ -170,13 +170,13 @@ func init() {
 	Cmd.Flags().Var(
 		&outFlag,
 		"out",
-		"The location to store the trace. Can be an AkitaURI or a local directory. Defaults to a trace on the Akita Cloud. Exactly one of --out, --cluster, or --project must be specified.")
+		"The location to store the trace. Can be an AkitaURI or a local directory. Defaults to a trace on the Akita Cloud. Exactly one of --out or --project must be specified.")
 
 	Cmd.Flags().StringVar(
 		&serviceFlag,
 		"project",
 		"",
-		"Your Akita project. Exactly one of --out, --cluster, or --project must be specified.")
+		"Your Akita project. Exactly one of --out or --project must be specified.")
 
 	Cmd.Flags().StringVar(
 		&serviceFlag,
@@ -188,7 +188,7 @@ func init() {
 		&serviceFlag,
 		"cluster",
 		"",
-		"Your Akita cluster (alias for 'project'). Exactly one of --out, --cluster, or --project must be specified.")
+		"Your Akita project. DEPRECATED, prefer --project.")
 
 	Cmd.Flags().StringVar(
 		&filterFlag,

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -57,16 +57,16 @@ var Cmd = &cobra.Command{
 			return errors.Wrap(err, "failed to load plugins")
 		}
 
-		// Check that exactly one of --out or --service is specified.
+		// Check that exactly one of --out, or --project is specified.
 		if outFlag.IsSet() == (serviceFlag != "") {
-			return errors.New("exactly one of --out or --service must be specified")
+			return errors.New("exactly one of --out or --project must be specified")
 		}
 
 		// If --service was given, convert it to an equivalent --out.
 		if serviceFlag != "" {
 			uri, err := akiuri.Parse(akiuri.Scheme + serviceFlag)
 			if err != nil {
-				return errors.Wrap(err, "bad service name")
+				return errors.Wrap(err, "bad project name")
 			}
 			outFlag.AkitaURI = &uri
 		}
@@ -170,19 +170,25 @@ func init() {
 	Cmd.Flags().Var(
 		&outFlag,
 		"out",
-		"The location to store the trace. Can be an AkitaURI or a local directory. Defaults to a trace on the Akita Cloud. Exactly one of --out, --cluster, or --service must be specified.")
+		"The location to store the trace. Can be an AkitaURI or a local directory. Defaults to a trace on the Akita Cloud. Exactly one of --out, --cluster, or --project must be specified.")
+
+	Cmd.Flags().StringVar(
+		&serviceFlag,
+		"project",
+		"",
+		"Your Akita project. Exactly one of --out, --cluster, or --project must be specified.")
 
 	Cmd.Flags().StringVar(
 		&serviceFlag,
 		"service",
 		"",
-		"Your Akita service. Exactly one of --out, --cluster, or --service must be specified.")
+		"Your Akita project. DEPRECATED, prefer --project.")
 
 	Cmd.Flags().StringVar(
 		&serviceFlag,
 		"cluster",
 		"",
-		"Your Akita cluster (alias for 'service'). Exactly one of --out, --cluster, or --service must be specified.")
+		"Your Akita cluster (alias for 'project'). Exactly one of --out, --cluster, or --project must be specified.")
 
 	Cmd.Flags().StringVar(
 		&filterFlag,
@@ -287,7 +293,7 @@ func init() {
 		&deploymentFlag,
 		"deployment",
 		"",
-		"Deployment name to use; this distinguishes different instances of the same service. 'default' if unspecified.",
+		"Deployment name to use.  DEPRECATED, prefer creating separate projects for different deployment environments, e.g. 'my-project-prod' and 'my-project-staging'.",
 	)
 
 	Cmd.Flags().IntVar(

--- a/cmd/internal/apispec/cmd.go
+++ b/cmd/internal/apispec/cmd.go
@@ -32,6 +32,7 @@ func parseTime(s string) (time.Time, error) {
 }
 
 var Cmd = &cobra.Command{
+	Deprecated:   "API specs are created automatically in the Akita app.",
 	Use:          "apispec",
 	Short:        "Convert traces into an OpenAPI3 specification.",
 	SilenceUsage: true,
@@ -79,15 +80,15 @@ var Cmd = &cobra.Command{
 		}
 
 		if len(traceTags) > 0 {
-			var serviceName string
+			var projectName string
 			if serviceFlag != "" {
-				serviceName = serviceFlag
+				projectName = serviceFlag
 			} else if outFlag.AkitaURI != nil {
-				serviceName = outFlag.AkitaURI.ServiceName
+				projectName = outFlag.AkitaURI.ServiceName
 			} else {
-				return errors.New("Must specify \"service\" or \"out\" to use \"trace-tag\"")
+				return errors.New("Must specify \"project\" or \"out\" to use \"trace-tag\"")
 			}
-			destURI, err := util.GetTraceURIByTags(akiflag.Domain, akiflag.GetClientID(), serviceName, traceTags, "trace-tag")
+			destURI, err := util.GetTraceURIByTags(akiflag.Domain, akiflag.GetClientID(), projectName, traceTags, "trace-tag")
 			if err != nil {
 				return err
 			}

--- a/cmd/internal/apispec/flags.go
+++ b/cmd/internal/apispec/flags.go
@@ -66,7 +66,7 @@ func init() {
 		&serviceFlag,
 		"project",
 		"",
-		"Your Akita project. Exactly one of --out or --project must be specified.")
+		"Your Akita project. Only needed if --out is not an AkitaURI.")
 
 	Cmd.Flags().StringVar(
 		&serviceFlag,

--- a/cmd/internal/apispec/flags.go
+++ b/cmd/internal/apispec/flags.go
@@ -66,7 +66,7 @@ func init() {
 		&serviceFlag,
 		"project",
 		"",
-		"Your Akita project. Exactly one of --out, --cluster, or --project must be specified.")
+		"Your Akita project. Exactly one of --out or --project must be specified.")
 
 	Cmd.Flags().StringVar(
 		&serviceFlag,
@@ -78,7 +78,7 @@ func init() {
 		&serviceFlag,
 		"cluster",
 		"",
-		"Akita cloud cluster to use to generate the spec (alias for 'project'). Only needed if --out is not an AkitaURI.")
+		"Your Akita project. DEPRECATED, prefer --project.")
 
 	Cmd.Flags().StringVar(
 		&githubBranchFlag,

--- a/cmd/internal/apispec/flags.go
+++ b/cmd/internal/apispec/flags.go
@@ -64,15 +64,21 @@ func init() {
 
 	Cmd.Flags().StringVar(
 		&serviceFlag,
+		"project",
+		"",
+		"Your Akita project. Exactly one of --out, --cluster, or --project must be specified.")
+
+	Cmd.Flags().StringVar(
+		&serviceFlag,
 		"service",
 		"",
-		"Akita cloud service to use to generate the spec. Only needed if --out is not an AkitaURI.")
+		"Your Akita project. DEPRECATED, prefer --project.")
 
 	Cmd.Flags().StringVar(
 		&serviceFlag,
 		"cluster",
 		"",
-		"Akita cloud cluster to use to generate the spec (alias for 'service'). Only needed if --out is not an AkitaURI.")
+		"Akita cloud cluster to use to generate the spec (alias for 'project'). Only needed if --out is not an AkitaURI.")
 
 	Cmd.Flags().StringVar(
 		&githubBranchFlag,

--- a/cmd/internal/get/graph.go
+++ b/cmd/internal/get/graph.go
@@ -51,7 +51,7 @@ func init() {
 		&serviceFlag,
 		"cluster",
 		"",
-		"Your Akita cluster (alias for 'project').")
+		"Your Akita project. DEPRECATED, prefer --project.")
 
 	GetGraphCmd.Flags().StringVar(
 		&deploymentFlag,

--- a/cmd/internal/get/graph.go
+++ b/cmd/internal/get/graph.go
@@ -37,21 +37,27 @@ func init() {
 
 	GetGraphCmd.Flags().StringVar(
 		&serviceFlag,
+		"project",
+		"",
+		"Your Akita project.")
+
+	GetGraphCmd.Flags().StringVar(
+		&serviceFlag,
 		"service",
 		"",
-		"Your Akita service.")
+		"Your Akita project.  DEPRECATED, prefer --project.")
 
 	GetGraphCmd.Flags().StringVar(
 		&serviceFlag,
 		"cluster",
 		"",
-		"Your Akita cluster (alias for 'service').")
+		"Your Akita cluster (alias for 'project').")
 
 	GetGraphCmd.Flags().StringVar(
 		&deploymentFlag,
 		"deployment",
 		"",
-		"Deployment tag used for traces.")
+		"Deployment tag used for traces.  DEPRECATED.")
 
 	GetGraphCmd.Flags().StringVar(
 		&startTimeFlag,
@@ -89,7 +95,7 @@ func getGraph(cmd *cobra.Command, args []string) error {
 	// Accept these as either flags or arguments.
 	if serviceFlag == "" {
 		if len(args) == 0 {
-			return errors.New("Must specify a service name.")
+			return errors.New("Must specify a project name.")
 		}
 		serviceFlag = args[0]
 		args = args[1:]
@@ -146,7 +152,7 @@ func getGraph(cmd *cobra.Command, args []string) error {
 		return errors.New("Unsupported output format.")
 	}
 
-	printer.Debugf("Loading service %q deployment %q from %v to %v\n", serviceFlag, deploymentFlag, start, end)
+	printer.Debugf("Loading project %q deployment %q from %v to %v\n", serviceFlag, deploymentFlag, start, end)
 
 	clientID := akid.GenerateClientID()
 	frontClient := rest.NewFrontClient(akiflag.Domain, clientID)

--- a/cmd/internal/get/specs.go
+++ b/cmd/internal/get/specs.go
@@ -50,7 +50,7 @@ func init() {
 		&serviceFlag,
 		"cluster",
 		"",
-		"Your Akita cluster (alias for 'project').")
+		"Your Akita project. DEPRECATED, prefer --project.")
 
 	GetSpecsCmd.Flags().StringSliceVar(
 		&tagsFlag,
@@ -237,7 +237,7 @@ func getSpecs(cmd *cobra.Command, args []string) error {
 			return errors.New("Project name does not match URI.")
 		}
 	} else {
-		// Use --service flag to list instead
+		// Use --project flag to list instead
 		if serviceFlag == "" {
 			return errors.New("Must specify an akitaURI or project name.")
 		}

--- a/cmd/internal/get/specs.go
+++ b/cmd/internal/get/specs.go
@@ -25,8 +25,8 @@ import (
 var GetSpecsCmd = &cobra.Command{
 	Use:          "spec [AKITAURI [FILE]]",
 	Aliases:      []string{"specs", "model", "models"},
-	Short:        "List or download specifications for a service.",
-	Long:         "List specifications in the Akita cloud, filtered by service and by tag. Or, specify a particular spec to download it.",
+	Short:        "List or download specifications for a project.",
+	Long:         "List specifications in the Akita cloud, filtered by project and by tag. Or, specify a particular spec to download it.",
 	SilenceUsage: false,
 	RunE:         getSpecs,
 }
@@ -36,15 +36,21 @@ func init() {
 
 	GetSpecsCmd.Flags().StringVar(
 		&serviceFlag,
+		"project",
+		"",
+		"Your Akita project.")
+
+	GetSpecsCmd.Flags().StringVar(
+		&serviceFlag,
 		"service",
 		"",
-		"Your Akita service.")
+		"Your Akita project.  DEPRECATED, prefer --project.")
 
 	GetSpecsCmd.Flags().StringVar(
 		&serviceFlag,
 		"cluster",
 		"",
-		"Your Akita cluster (alias for 'service').")
+		"Your Akita cluster (alias for 'project').")
 
 	GetSpecsCmd.Flags().StringSliceVar(
 		&tagsFlag,
@@ -108,7 +114,7 @@ func listSpecs(src akiuri.URI, tags map[tags.Key]string, limit int) error {
 	}
 
 	if len(specs) == 0 {
-		printer.Warningf("No specs found for service %q.\n", src.ServiceName)
+		printer.Warningf("No specs found for project %q.\n", src.ServiceName)
 		return nil
 	}
 
@@ -228,12 +234,12 @@ func getSpecs(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("%q is not a spec URI", args[0])
 		}
 		if serviceFlag != "" && srcURI.ServiceName != serviceFlag {
-			return errors.New("Service name does not match URI.")
+			return errors.New("Project name does not match URI.")
 		}
 	} else {
 		// Use --service flag to list instead
 		if serviceFlag == "" {
-			return errors.New("Must specify an akitaURI or service name.")
+			return errors.New("Must specify an akitaURI or project name.")
 		}
 
 		srcURI.ServiceName = serviceFlag

--- a/cmd/internal/get/timeline.go
+++ b/cmd/internal/get/timeline.go
@@ -47,13 +47,13 @@ func init() {
 		&serviceFlag,
 		"service",
 		"",
-		"Your Akita project.  DEPRECATED, prefer --project.")
+		"Your Akita project. DEPRECATED, prefer --project.")
 
 	GetTimelineCmd.Flags().StringVar(
 		&serviceFlag,
 		"cluster",
 		"",
-		"Your Akita cluster (alias for 'project').")
+		"Your Akita project. DEPRECATED, prefer --project.")
 
 	GetTimelineCmd.Flags().StringVar(
 		&deploymentFlag,

--- a/cmd/internal/get/timeline.go
+++ b/cmd/internal/get/timeline.go
@@ -21,8 +21,8 @@ import (
 var GetTimelineCmd = &cobra.Command{
 	Use:          "timeline [SERVICE] [DEPLOYMENT]",
 	Aliases:      []string{"timeline"},
-	Short:        "List timeline for the given service.",
-	Long:         "List timeline of API calls for the given service.",
+	Short:        "List timeline for the given project.",
+	Long:         "List timeline of API calls for the given project.",
 	SilenceUsage: false,
 	RunE:         getTimeline,
 }
@@ -39,21 +39,27 @@ func init() {
 
 	GetTimelineCmd.Flags().StringVar(
 		&serviceFlag,
+		"project",
+		"",
+		"Your Akita project.")
+
+	GetTimelineCmd.Flags().StringVar(
+		&serviceFlag,
 		"service",
 		"",
-		"Your Akita service.")
+		"Your Akita project.  DEPRECATED, prefer --project.")
 
 	GetTimelineCmd.Flags().StringVar(
 		&serviceFlag,
 		"cluster",
 		"",
-		"Your Akita cluster (alias for 'service').")
+		"Your Akita cluster (alias for 'project').")
 
 	GetTimelineCmd.Flags().StringVar(
 		&deploymentFlag,
 		"deployment",
 		"",
-		"Deployment tag used for traces.")
+		"Deployment tag used for traces. DEPRECATED.")
 
 	GetTimelineCmd.Flags().StringVar(
 		&startTimeFlag,
@@ -109,16 +115,17 @@ func getTimeline(cmd *cobra.Command, args []string) error {
 	// Accept these as either flags or arguments.
 	if serviceFlag == "" {
 		if len(args) == 0 {
-			return errors.New("Must specify a service and deployment name")
+			return errors.New("Must specify a project")
 		}
 		serviceFlag = args[0]
 		args = args[1:]
 	}
 	if deploymentFlag == "" {
 		if len(args) == 0 {
-			return errors.New("Must specify a deployment name")
+			deploymentFlag = "default"
+		} else {
+			deploymentFlag = args[0]
 		}
-		deploymentFlag = args[0]
 		args = args[1:]
 	}
 
@@ -144,7 +151,7 @@ func getTimeline(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	printer.Debugf("Loading service %q deployment %q from %v to %v\n", serviceFlag, deploymentFlag, start, end)
+	printer.Debugf("Loading project %q deployment %q from %v to %v\n", serviceFlag, deploymentFlag, start, end)
 
 	clientID := akid.GenerateClientID()
 	frontClient := rest.NewFrontClient(akiflag.Domain, clientID)

--- a/cmd/internal/get/traces.go
+++ b/cmd/internal/get/traces.go
@@ -45,7 +45,7 @@ func init() {
 		&serviceFlag,
 		"cluster",
 		"",
-		"Your Akita cluster (alias for 'project').")
+		"Your Akita project. DEPRECATED, prefer --project.")
 
 	GetTracesCmd.Flags().StringSliceVar(
 		&tagsFlag,

--- a/cmd/internal/get/traces.go
+++ b/cmd/internal/get/traces.go
@@ -20,8 +20,8 @@ import (
 var GetTracesCmd = &cobra.Command{
 	Use:          "traces [AKITAURI|SERVICE]",
 	Aliases:      []string{"trace"},
-	Short:        "List traces for the given service.",
-	Long:         "List traces in the Akita cloud, filtered by service and by tag.",
+	Short:        "List traces for the given project.",
+	Long:         "List traces in the Akita cloud, filtered by project and by tag.",
 	SilenceUsage: false,
 	RunE:         getTraces,
 }
@@ -31,15 +31,21 @@ func init() {
 
 	GetTracesCmd.Flags().StringVar(
 		&serviceFlag,
+		"project",
+		"",
+		"Your Akita project.")
+
+	GetTracesCmd.Flags().StringVar(
+		&serviceFlag,
 		"service",
 		"",
-		"Your Akita service.")
+		"Your Akita project.  DEPRECATED, prefer --project.")
 
 	GetTracesCmd.Flags().StringVar(
 		&serviceFlag,
 		"cluster",
 		"",
-		"Your Akita cluster (alias for 'service').")
+		"Your Akita cluster (alias for 'project').")
 
 	GetTracesCmd.Flags().StringSliceVar(
 		&tagsFlag,
@@ -56,7 +62,7 @@ func init() {
 
 func getTraces(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 {
-		return errors.New("Only one service permitted.")
+		return errors.New("Only one project permitted.")
 	}
 
 	var serviceArg string
@@ -81,14 +87,14 @@ func getTraces(cmd *cobra.Command, args []string) error {
 
 	switch {
 	case serviceFlag == "" && serviceArg == "":
-		return fmt.Errorf("Must specify a service name using argument or --service flag.")
+		return fmt.Errorf("Must specify a project name using argument or --project flag.")
 	case serviceFlag == "":
 		serviceFlag = serviceArg
 	case serviceArg == "":
 		// servceFlag is nonempty
 		break
 	case serviceFlag != serviceArg:
-		return fmt.Errorf("Difference services specified in flag and URI.")
+		return fmt.Errorf("Different projects specified in flag and URI.")
 	}
 
 	clientID := akid.GenerateClientID()

--- a/cmd/internal/learn/cmd.go
+++ b/cmd/internal/learn/cmd.go
@@ -82,7 +82,7 @@ func runLearnMode() error {
 	frontClient := rest.NewFrontClient(akiflag.Domain, clientID)
 	svc, err := util.GetServiceIDByName(frontClient, projectName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to lookup project %q", projectName)
+		return errors.Wrapf(err, "failed to look up project %q", projectName)
 	}
 	learnClient := rest.NewLearnClient(akiflag.Domain, clientID, svc)
 
@@ -120,7 +120,7 @@ func runLearnMode() error {
 			defer cancel()
 			spec, err := learnClient.GetSpec(ctx, specID, rest.GetSpecOptions{})
 			if err != nil {
-				return errors.Wrapf(err, "failed to lookup extend spec %q", akid.String(specID))
+				return errors.Wrapf(err, "failed to look up extend spec %q", akid.String(specID))
 			}
 
 			if len(spec.LearnSessionIDs) > 0 {
@@ -138,7 +138,7 @@ func runLearnMode() error {
 			defer cancel()
 			session, err := learnClient.GetLearnSession(ctx, svc, lrn)
 			if err != nil {
-				return errors.Wrapf(err, "failed to lookup extend session %q", akid.String(lrn))
+				return errors.Wrapf(err, "failed to look up extend session %q", akid.String(lrn))
 			}
 
 			legacyExtendTraces = append(legacyExtendTraces, &akiuri.URI{
@@ -229,7 +229,7 @@ func runAPIDump(clientID akid.ClientID, projectName string, tagsMap map[tags.Key
 		frontClient := rest.NewFrontClient(akiflag.Domain, clientID)
 		svc, err := util.GetServiceIDByName(frontClient, projectName)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to lookup project id from name")
+			return nil, errors.Wrap(err, "failed to look up project id from name")
 		}
 
 		learnClient := rest.NewLearnClient(akiflag.Domain, clientID, svc)
@@ -237,7 +237,7 @@ func runAPIDump(clientID akid.ClientID, projectName string, tagsMap map[tags.Key
 		session, err := learnClient.GetLearnSession(ctx, svc, lrn)
 		cancel()
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to lookup learn session %s", akid.String(lrn))
+			return nil, errors.Wrapf(err, "failed to look up learn session %s", akid.String(lrn))
 		} else if session.Name == "" {
 			// This should never happen since we migrated all learn sessions to use
 			// the ID as the default name.

--- a/cmd/internal/learn/cmd.go
+++ b/cmd/internal/learn/cmd.go
@@ -34,6 +34,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
+	Deprecated:   "Prefer 'apidump' to capture traffic.  API specs are built automatically in the Akita app.",
 	Use:          "learn",
 	Short:        "Run learn mode monitor",
 	Long:         "Generate API specifications from network traffic with Akita Learn Mode!",
@@ -57,18 +58,18 @@ func runLearnMode() error {
 
 	// XXX Some of this input validation duplicates the input validation for `apispec` (and maybe `apidump`). We should refactor this.
 
-	// Determine service name and validate --out.
-	var serviceName string
+	// Determine project name and validate --out.
+	var projectName string
 	if uri := outFlag.AkitaURI; uri == nil {
 		if serviceFlag == "" {
-			return errors.Errorf("must specify --service when --out is not an AkitaURI")
+			return errors.Errorf("must specify --project when --out is not an AkitaURI")
 		}
-		serviceName = serviceFlag
+		projectName = serviceFlag
 	} else {
-		serviceName = uri.ServiceName
+		projectName = uri.ServiceName
 
-		if serviceFlag != "" && serviceFlag != serviceName {
-			return errors.Errorf("--service and --out cannot specify different services")
+		if serviceFlag != "" && serviceFlag != projectName {
+			return errors.Errorf("--project and --out cannot specify different projects")
 		}
 
 		// If an object type is provided, it must be Spec.
@@ -77,11 +78,11 @@ func runLearnMode() error {
 		}
 	}
 
-	// Resolve service name and get a learn client.
+	// Resolve project name and get a learn client.
 	frontClient := rest.NewFrontClient(akiflag.Domain, clientID)
-	svc, err := util.GetServiceIDByName(frontClient, serviceName)
+	svc, err := util.GetServiceIDByName(frontClient, projectName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to lookup service %q", serviceName)
+		return errors.Wrapf(err, "failed to lookup project %q", projectName)
 	}
 	learnClient := rest.NewLearnClient(akiflag.Domain, clientID, svc)
 
@@ -141,7 +142,7 @@ func runLearnMode() error {
 			}
 
 			legacyExtendTraces = append(legacyExtendTraces, &akiuri.URI{
-				ServiceName: serviceName,
+				ServiceName: projectName,
 				ObjectType:  akiuri.TRACE.Ptr(),
 				ObjectName:  session.Name,
 			})
@@ -177,12 +178,12 @@ func runLearnMode() error {
 	// internal/apidump/cmd, or internal/apispec/cmd, instead
 	// of doing it twice in this case.
 
-	traceURI, err := runAPIDump(clientID, serviceName, tagsMap, plugins)
+	traceURI, err := runAPIDump(clientID, projectName, tagsMap, plugins)
 	if err != nil {
 		return errors.Wrap(err, "failed to create trace")
 	}
 
-	if err := runAPISpec(clientID, serviceName, traceURI, tagsMap, legacyExtendTraces, plugins); err != nil {
+	if err := runAPISpec(clientID, projectName, traceURI, tagsMap, legacyExtendTraces, plugins); err != nil {
 		return errors.Wrap(err, "failed to create spec")
 	}
 
@@ -194,7 +195,7 @@ func runLearnMode() error {
 // The give tagsMap is expected to already contain information about how the
 // trace is captured (e.g., whether the capture was user-initiated or is from
 // CI, and any applicable information from CI).
-func runAPIDump(clientID akid.ClientID, serviceName string, tagsMap map[tags.Key]string, plugins []plugin.AkitaPlugin) (*akiuri.URI, error) {
+func runAPIDump(clientID akid.ClientID, projectName string, tagsMap map[tags.Key]string, plugins []plugin.AkitaPlugin) (*akiuri.URI, error) {
 	// Determing packet filter.
 	var packetFilter string
 	{
@@ -226,9 +227,9 @@ func runAPIDump(clientID akid.ClientID, serviceName string, tagsMap map[tags.Key
 		}
 
 		frontClient := rest.NewFrontClient(akiflag.Domain, clientID)
-		svc, err := util.GetServiceIDByName(frontClient, serviceName)
+		svc, err := util.GetServiceIDByName(frontClient, projectName)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to lookup service id from name")
+			return nil, errors.Wrap(err, "failed to lookup project id from name")
 		}
 
 		learnClient := rest.NewLearnClient(akiflag.Domain, clientID, svc)
@@ -244,7 +245,7 @@ func runAPIDump(clientID akid.ClientID, serviceName string, tagsMap map[tags.Key
 		}
 
 		traceOut.AkitaURI = &akiuri.URI{
-			ServiceName: serviceName,
+			ServiceName: projectName,
 			ObjectType:  akiuri.TRACE.Ptr(),
 			ObjectName:  session.Name,
 		}
@@ -259,7 +260,7 @@ func runAPIDump(clientID akid.ClientID, serviceName string, tagsMap map[tags.Key
 		}, "-")
 
 		traceOut.AkitaURI = &akiuri.URI{
-			ServiceName: serviceName,
+			ServiceName: projectName,
 			ObjectType:  akiuri.TRACE.Ptr(),
 			ObjectName:  traceName,
 		}
@@ -305,7 +306,7 @@ func runAPIDump(clientID akid.ClientID, serviceName string, tagsMap map[tags.Key
 	return traceOut.AkitaURI, apidump.Run(args)
 }
 
-func runAPISpec(clientID akid.ClientID, serviceName string, traceURI *akiuri.URI, tagsMap map[tags.Key]string, legacyExtendTraces []*akiuri.URI, plugins []plugin.AkitaPlugin) error {
+func runAPISpec(clientID akid.ClientID, projectName string, traceURI *akiuri.URI, tagsMap map[tags.Key]string, legacyExtendTraces []*akiuri.URI, plugins []plugin.AkitaPlugin) error {
 	githubRepo, err := getGitHubRepo()
 	if err != nil {
 		return err
@@ -331,7 +332,7 @@ func runAPISpec(clientID akid.ClientID, serviceName string, traceURI *akiuri.URI
 		Domain:         akiflag.Domain,
 		Traces:         traces,
 		Out:            outFlag,
-		Service:        serviceName,
+		Service:        projectName,
 		Format:         "yaml",
 		Tags:           tagsMap,
 		Versions:       versionsFlag,

--- a/cmd/internal/learn/flags.go
+++ b/cmd/internal/learn/flags.go
@@ -69,7 +69,7 @@ func registerOptionalFlags() {
 		&serviceFlag,
 		"project",
 		"",
-		"Your Akita project. Exactly one of --out, --cluster, or --project must be specified.")
+		"Your Akita project. Exactly one of --out or --project must be specified.")
 
 	Cmd.Flags().StringVar(
 		&serviceFlag,
@@ -81,7 +81,7 @@ func registerOptionalFlags() {
 		&serviceFlag,
 		"cluster",
 		"",
-		"Akita cloud cluster to use to generate the spec (alias for 'project'). Only needed if --out is not an AkitaURI.")
+		"Your Akita project. DEPRECATED, prefer --project.")
 
 	Cmd.Flags().Var(
 		&outFlag,

--- a/cmd/internal/learn/flags.go
+++ b/cmd/internal/learn/flags.go
@@ -69,7 +69,7 @@ func registerOptionalFlags() {
 		&serviceFlag,
 		"project",
 		"",
-		"Your Akita project. Exactly one of --out or --project must be specified.")
+		"Your Akita project. Only needed if --out is not an AkitaURI.")
 
 	Cmd.Flags().StringVar(
 		&serviceFlag,

--- a/cmd/internal/learn/flags.go
+++ b/cmd/internal/learn/flags.go
@@ -67,15 +67,21 @@ func registerRequiredFlags() {
 func registerOptionalFlags() {
 	Cmd.Flags().StringVar(
 		&serviceFlag,
+		"project",
+		"",
+		"Your Akita project. Exactly one of --out, --cluster, or --project must be specified.")
+
+	Cmd.Flags().StringVar(
+		&serviceFlag,
 		"service",
 		"",
-		"Akita cloud service to use to generate the spec. Only needed if --out is not an AkitaURI.")
+		"Your Akita project. DEPRECATED, prefer --project.")
 
 	Cmd.Flags().StringVar(
 		&serviceFlag,
 		"cluster",
 		"",
-		"Akita cloud cluster to use to generate the spec (alias for 'service'). Only needed if --out is not an AkitaURI.")
+		"Akita cloud cluster to use to generate the spec (alias for 'project'). Only needed if --out is not an AkitaURI.")
 
 	Cmd.Flags().Var(
 		&outFlag,
@@ -102,7 +108,7 @@ Ignored if --session is used to attach to an existing learn session.
 		&versionsFlag,
 		"versions",
 		nil,
-		`Assigns versions to the spec.  Versions are similar to tags, but a version may only be assigned to one spec within a service. Specified as a comma separated list of strings.
+		`Assigns versions to the spec.  Versions are similar to tags, but a version may only be assigned to one spec within a project. Specified as a comma separated list of strings.
 
 Ignored if --session is used to attach to an existing learn session.
 `,

--- a/cmd/internal/login/login.go
+++ b/cmd/internal/login/login.go
@@ -17,7 +17,7 @@ import (
 
 var Cmd = &cobra.Command{
 	Use:   "login",
-	Short: "Authenticate with SuperFuzz.",
+	Short: "Authenticate with Akita.",
 	Long: `The CLI will prompt you to enter information for your Akita API key.
 
 API key information will be stored in ` + cfg.GetCredentialsConfigPath(),

--- a/cmd/internal/login/login.go
+++ b/cmd/internal/login/login.go
@@ -17,7 +17,7 @@ import (
 
 var Cmd = &cobra.Command{
 	Use:   "login",
-	Short: "Authenticate with SuperFuzz",
+	Short: "Authenticate with SuperFuzz.",
 	Long: `The CLI will prompt you to enter information for your Akita API key.
 
 API key information will be stored in ` + cfg.GetCredentialsConfigPath(),

--- a/cmd/internal/man/apidiff_page.go
+++ b/cmd/internal/man/apidiff_page.go
@@ -9,7 +9,7 @@ Compare 2 API specs.
 
 # Examples
 
-## akita apidiff akita://my-service:spec:spec1 akita://my-service:spec:spec2
+## akita apidiff akita://my-project:spec:spec1 akita://my-project:spec:spec2
 
 # Optional Flags
 

--- a/cmd/internal/man/apidump_page.go
+++ b/cmd/internal/man/apidump_page.go
@@ -5,7 +5,7 @@ var apidumpPage = `
 
 # Description
 
-Capture and store a sequence of requests/responses to a by observing
+Capture and store a sequence of requests/responses to your services by observing
 network traffic.
 
 # Examples

--- a/cmd/internal/man/apidump_page.go
+++ b/cmd/internal/man/apidump_page.go
@@ -5,7 +5,7 @@ var apidumpPage = `
 
 # Description
 
-Capture and store a sequence of requests/responses to a service by observing
+Capture and store a sequence of requests/responses to a by observing
 network traffic.
 
 # Examples
@@ -14,11 +14,11 @@ network traffic.
 
 Capture requests/responses going to or coming from port 80 and store them into a directory called "mytracedir".
 
-## akita apidump --filter "port 80" --out akita://my-service:trace:mytrace
+## akita apidump --filter "port 80" --out akita://my-project:trace:mytrace
 
 Capture requests/responses going to or coming from port 80 and store them into a trace on the Akita cloud called "mytrace".
 
-## akita apidump --filter "port 80" --out akita://my-service:trace
+## akita apidump --filter "port 80" --out akita://my-project:trace
 
 Capture requests/responses going to or coming from port 80 and store them into a trace on the Akita cloud with a generated name.
 
@@ -32,17 +32,17 @@ Run <bt>my_tests.sh<bt> as <bt>${USER}<bt> and capture requests/responses going 
 
 The location to store the trace. Can be an AkitaURI or a local directory.
 
-If not specified, defaults to a trace on Akita Cloud. Note that you must supply <bt>--service<bt> in this case.
+If not specified, defaults to a trace on Akita Cloud. Note that you must supply <bt>--project<bt> in this case.
 
 When specifying a local directory, Akita writes HAR files to the directory.
 
-When specifying an AkitaURI, the format is "akita://{SERVICE}:trace" or "akita://{SERVICE}:trace:{NAME}", where "SERVICE" is the name of your service and "NAME" is the name of the trace on Akita Cloud where the collected data is stored. A trace name will be generated if "NAME" is not provided.
+When specifying an AkitaURI, the format is "akita://{PROJECT}:trace" or "akita://{PROJECT}:trace:{NAME}", where "PROJECT" is the name of your project and "NAME" is the name of the trace on Akita Cloud where the collected data is stored. A trace name will be generated if "NAME" is not provided.
 
-Exactly one of <bt>--out<bt> or <bt>--service<bt> must be provided.
+Exactly one of <bt>--out<bt> or <bt>--project<bt> must be provided.
 
-## --service string
+## --project string
 
-Your Akita service. Exactly one of <bt>--out<bt> or <bt>--service<bt> must be provided.
+Your Akita project. Exactly one of <bt>--out<bt> or <bt>--project<bt> must be provided.
 
 ## --filter string
 

--- a/cmd/internal/man/apispec_page.go
+++ b/cmd/internal/man/apispec_page.go
@@ -51,7 +51,7 @@ Alias for --project.  DEPRECATED, prefer --project.
 
 ## --cluster string
 
-Akita cloud cluster to use to generate the spec (alias for 'project'). Only needed if --out is not specified or is not an AkitaURI.
+Alias for --project.  DEPRECATED, prefer --project.
 
 ## --format {yaml|json}
 

--- a/cmd/internal/man/apispec_page.go
+++ b/cmd/internal/man/apispec_page.go
@@ -9,11 +9,11 @@ Upload traces to the Akita Cloud or use traces already stored on Akita Cloud to 
 
 # Examples
 
-## akita apispec --service my-service --traces ./mytrace.har
+## akita apispec --project my-project --traces ./mytrace.har
 
 Generates a spec from a local trace file and outputs it to stdout.
 
-## akita apispec --service my-service --traces ./trace1.har --traces akita://my-service:trace:trace2
+## akita apispec --project my-project --traces ./trace1.har --traces akita://my-project:trace:trace2
 
 Generates a spec from a combination of local trace file and trace file on Akita cloud.
 
@@ -25,7 +25,7 @@ The locations to read traces from. Can be a mix of AkitaURI and local file paths
 
 When specifying a local file, Akita reads the HAR file and uploads it to the Akita cloud.
 
-When specifying an AkitaURI, the format is "akita://{SERVICE}:trace:{NAME}", where "SERVICE" is the name of your service and "NAME" is the name of the trace on Akita Cloud.
+When specifying an AkitaURI, the format is "akita://{PROJECT}:trace:{NAME}", where "PROJECT" is the name of your project and "NAME" is the name of the trace on Akita Cloud.
 
 # Optional Flags
 
@@ -33,21 +33,25 @@ When specifying an AkitaURI, the format is "akita://{SERVICE}:trace:{NAME}", whe
 
 The location to store the spec. Can be an AkitaURI or a local file.
 
-If unspecified, defaults to a new spec on Akita Cloud. Note that you must also set <bt>--service<bt>.
+If unspecified, defaults to a new spec on Akita Cloud. Note that you must also set <bt>--project<bt>.
 
-When specifying a local file, Akita writes the spec to the file. Note that you must also set <bt>--service<bt> when outputing to local file.
+When specifying a local file, Akita writes the spec to the file. Note that you must also set <bt>--project<bt> when outputing to local file.
 
 To specify <bt>stdout<bt>, use <bt>--out="-"<bt>.
 
-When specifying an AkitaURI, the format is "akita://{SERVICE}:spec" or "akita://{SERVICE}:spec:{NAME}", where "SERVICE" is the name of your service and "NAME" is the name of the spec to create. A spec name will be generated if "NAME" is not provided.
+When specifying an AkitaURI, the format is "akita://{PROJECT}:spec" or "akita://{PROJECT}:spec:{NAME}", where "PROJECT" is the name of your project and "NAME" is the name of the spec to create. A spec name will be generated if "NAME" is not provided.
+
+## --project string
+
+Akita cloud project to use to generate the spec. Only needed if --out is not specified or is not an AkitaURI.
 
 ## --service string
 
-Akita cloud service to use to generate the spec. Only needed if --out is not specified or is not an AkitaURI.
+Alias for --project.  DEPRECATED, prefer --project.
 
 ## --cluster string
 
-Akita cloud cluster to use to generate the spec (alias for 'service'). Only needed if --out is not specified or is not an AkitaURI.
+Akita cloud cluster to use to generate the spec (alias for 'project'). Only needed if --out is not specified or is not an AkitaURI.
 
 ## --format {yaml|json}
 

--- a/cmd/internal/man/learn_page.go
+++ b/cmd/internal/man/learn_page.go
@@ -9,7 +9,7 @@ Generate API specifications from network traffic.
 
 # Examples
 
-## akita learn --filter "port 80" --service my-service
+## akita learn --filter "port 80" --project my-project
 
 Capture requests/responses going to or coming from port 80 and convert them into an API spec.
 
@@ -23,21 +23,25 @@ Run <bt>my_tests.sh<bt> as <bt>${USER}<bt> and capture requests/responses going 
 
 The location to store the spec. Can be an AkitaURI or a local file.
 
-If not specified, defaults to a trace on Akita Cloud. Note that you must supply <bt>--service<bt> in this case.
+If not specified, defaults to a trace on Akita Cloud. Note that you must supply <bt>--project<bt> in this case.
 
-When specifying an AkitaURI, the format is "akita://{SERVICE}:spec" or "akita://{SERVICE}:spec:{NAME}", where "SERVICE" is the name of your service and "NAME" is the name of the spec on Akita Cloud where the collected data is stored. A spec name will be generated if "NAME" is not provided.
+When specifying an AkitaURI, the format is "akita://{PROJECT}:spec" or "akita://{PROJECT}:spec:{NAME}", where "PROJECT" is the name of your project and "NAME" is the name of the spec on Akita Cloud where the collected data is stored. A spec name will be generated if "NAME" is not provided.
+
+## --project string
+
+Your Akita project. Only needed if <bt>--out<bt> is not an AkitaURI.
 
 ## --service string
 
-Your Akita service. Only needed if <bt>--out<bt> is not an AkitaURI.
+Alias for --project.  DEPRECATED, prefer --project.
 
 ## --cluster string
 
-Your Akita cluster (alias for 'service'). Only needed if <bt>--out<bt> is not an AkitaURI.
+Your Akita cluster (alias for 'project'). Only needed if <bt>--out<bt> is not an AkitaURI.
 
 ## --filter string
 
-Used to match packets going to and coming from your API service.
+Used to match packets going to and coming from your API project.
 
 For example, to match packets destined/originated from port 80, you would set <bt>--filter="port 80"<bt>.
 

--- a/cmd/internal/man/learn_page.go
+++ b/cmd/internal/man/learn_page.go
@@ -37,7 +37,7 @@ Alias for --project.  DEPRECATED, prefer --project.
 
 ## --cluster string
 
-Your Akita cluster (alias for 'project'). Only needed if <bt>--out<bt> is not an AkitaURI.
+Alias for --project.  DEPRECATED, prefer --project.
 
 ## --filter string
 

--- a/cmd/internal/man/setversion_page.go
+++ b/cmd/internal/man/setversion_page.go
@@ -5,15 +5,15 @@ var setversionPage = `
 
 # Description
 
-Sets the version name of an API spec. Version names are unique within a service. For example, "latest" is a version name automatically assigned to the most recent API spec.
+Sets the version name of an API spec. Version names are unique within a project. For example, "latest" is a version name automatically assigned to the most recent API spec.
 
 # Examples
 
-## akita setversion v1.0.0 akita://my-service:spec:beta
+## akita setversion v1.0.0 akita://my-project:spec:beta
 
-Marks the spec identified by <bt>akita://myservice:spec:beta<bt> as "v1.0.0" for <bt>my-service<bt>. Any spec in <bt>my-service<bt> that was previously marked with "v1.0.0" will no longer be associated with that version name.
+Marks the spec identified by <bt>akita://my-project:spec:beta<bt> as "v1.0.0" for <bt>my-project<bt>. Any spec in <bt>my-project<bt> that was previously marked with "v1.0.0" will no longer be associated with that version name.
 
-## akita setversion stable akita://my-service:spec:public
+## akita setversion stable akita://my-project:spec:public
 
-Marks the spec identified by <bt>akita://myservice:spec:public<bt> as "stable" for <bt>my-service<bt>. This removes the "stable" designation from all other specs in <bt>my-service<bt>.
+Marks the spec identified by <bt>akita://my-project:spec:public<bt> as "stable" for <bt>my-project<bt>. This removes the "stable" designation from all other specs in <bt>my-project<bt>.
 `

--- a/cmd/internal/man/upload_page.go
+++ b/cmd/internal/man/upload_page.go
@@ -11,27 +11,27 @@ Uploads an OpenAPI 3 spec or a HAR file to Akita Cloud. When the upload complete
 
 # Examples
 
-## akita upload --dest akita://my-service:spec /path/to/spec.yaml
+## akita upload --dest akita://my-project:spec /path/to/spec.yaml
 
-Upload the given file as a spec for my-service. A new name is generated for the spec.
+Upload the given file as a spec for my-project. A new name is generated for the spec.
 
-## akita upload --dest akita://my-service:spec:spec1 /path/to/spec.yaml
+## akita upload --dest akita://my-project:spec:spec1 /path/to/spec.yaml
 
-Upload the given file as a spec for my-service. The uploaded spec will be called "spec1".
+Upload the given file as a spec for my-project. The uploaded spec will be called "spec1".
 
-## akita upload --dest akita://my-service:trace /path/to/trace1.har /path/to/trace2.har
+## akita upload --dest akita://my-project:trace /path/to/trace1.har /path/to/trace2.har
 
-Upload the given files as a trace for my-service. A new name is generated for the trace.
+Upload the given files as a trace for my-project. A new name is generated for the trace.
 
-## akita upload --dest akita://my-service:trace:trace1 /path/to/trace1.har /path/to/trace2.har
+## akita upload --dest akita://my-project:trace:trace1 /path/to/trace1.har /path/to/trace2.har
 
-Upload the given files as a trace for my-service. The uploaded trace will be called "trace1".
+Upload the given files as a trace for my-project. The uploaded trace will be called "trace1".
 
 # Required Flags
 
 ## --dest akita_uri
 
-The Akita URI where you want to upload to, specifying the Akita service, the type of the upload, and optionally, the name of the upload.
+The Akita URI where you want to upload to, specifying the Akita project, the type of the upload, and optionally, the name of the upload.
 
 If a name is provided and an object already exists with that name, an error occurs, unless '--append' is also specified.
 

--- a/cmd/internal/setversion/cmd.go
+++ b/cmd/internal/setversion/cmd.go
@@ -11,6 +11,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
+	Deprecated:   "API models are now created automatically by time range.",
 	Use:          "setversion NAME SPEC_AKITA_URI",
 	Short:        "Sets the version name for an API model.",
 	SilenceUsage: true,
@@ -26,7 +27,7 @@ var Cmd = &cobra.Command{
 			return errors.Wrapf(err, "%q is not a well-formed AkitaURI", args[1])
 		}
 		if !modelURI.ObjectType.IsSpec() {
-			return errors.New("Must specify an API model. For example, \"akita://serviceName:spec:specName\"")
+			return errors.New("Must specify an API model. For example, \"akita://projectName:spec:specName\"")
 		}
 
 		// Check for reserved versions.

--- a/cmd/internal/upload/cmd.go
+++ b/cmd/internal/upload/cmd.go
@@ -50,7 +50,7 @@ var Cmd = &cobra.Command{
 
 		// Destination must specify an object type.
 		if destURI.ObjectType == nil {
-			return errors.New("\"dest\" must specify an object type. For example, \"akita://serviceName:trace\"")
+			return errors.New("\"dest\" must specify an object type. For example, \"akita://projectName:trace\"")
 		}
 
 		// If more than one file is given, then the object type must be "trace".

--- a/upload/run.go
+++ b/upload/run.go
@@ -24,7 +24,7 @@ func Run(args Args) error {
 	frontClient := rest.NewFrontClient(args.Domain, args.ClientID)
 	svc, err := util.GetServiceIDByName(frontClient, args.DestURI.ServiceName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to resolve service name %q", args.DestURI.ServiceName)
+		return errors.Wrapf(err, "failed to resolve project name %q", args.DestURI.ServiceName)
 	}
 
 	// Determine the object's name.

--- a/util/util.go
+++ b/util/util.go
@@ -53,7 +53,7 @@ func GetServiceIDByName(c rest.FrontClient, name string) (akid.ServiceID, error)
 	name = strings.ToLower(name)
 
 	if id, found := serviceNameCache.Get(name); found {
-		printer.Stderr.Debugf("Cached service name %q is %q\n", name, akid.String(id.(akid.ServiceID)))
+		printer.Stderr.Debugf("Cached project name %q is %q\n", name, akid.String(id.(akid.ServiceID)))
 		return id.(akid.ServiceID), nil
 	}
 
@@ -85,7 +85,7 @@ func GetServiceIDByName(c rest.FrontClient, name string) (akid.ServiceID, error)
 		printer.Stderr.Debugf("Service name %q is %q\n", name, akid.String(result))
 		return result, nil
 	}
-	return akid.ServiceID{}, errors.Errorf("cannot determine service ID for %s", name)
+	return akid.ServiceID{}, errors.Errorf("cannot determine project ID for %s", name)
 }
 
 func DaemonHeartbeat(c rest.FrontClient, daemonName string) error {
@@ -162,7 +162,7 @@ func GetTraceURIByTags(domain string, clientID akid.ClientID, serviceName string
 	frontClient := rest.NewFrontClient(domain, clientID)
 	serviceID, err := GetServiceIDByName(frontClient, serviceName)
 	if err != nil {
-		return akiuri.URI{}, errors.Wrapf(err, "failed to resolve service name %q", serviceName)
+		return akiuri.URI{}, errors.Wrapf(err, "failed to resolve project name %q", serviceName)
 	}
 
 	learnClient := rest.NewLearnClient(domain, clientID, serviceID)


### PR DESCRIPTION
Deprecates the following commands, which are either no longer relevant or
replaced by the Akita app:
 - apidiff
 - apispec
 - learn
 - setversion

Deprecates the --deployment flag.  We recommend creating separate projects for
different deployment environments, e.g. my-project-staging and my-project-prod.

Deprecates the --service flag and replaces it with --project.