### PR TITLE
Memory-usage improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Connect to server",
+      "type": "go",
+      "request": "attach",
+      "mode": "remote",
+      "remotePath": "${workspaceFolder}",
+      "port": 2345,
+      "host": "127.0.0.1"
+    },
+    {
+      "name": "Attach to Process",
+      "type": "go",
+      "request": "attach",
+      "mode": "local",
+      "processId": 0
+    }
+  ]
+}

--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -370,6 +370,11 @@ func Run(args Args) error {
 		}
 	}
 
+	// If --dogfood is specified, enable assertions in the buffer-pool code.
+	if viper.GetBool("dogfood") {
+		buffer_pool.CheckInvariants = true
+	}
+
 	// Create a buffer pool for storing HTTP payloads.
 	pool, err := buffer_pool.MakeBufferPool(20*1024*1024, 4*1024)
 	if err != nil {

--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	kgxapi "github.com/akitasoftware/akita-libs/api_schema"
+	"github.com/akitasoftware/akita-libs/buffer_pool"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
@@ -369,6 +370,12 @@ func Run(args Args) error {
 		}
 	}
 
+	// Create a buffer pool for storing HTTP payloads.
+	pool, err := buffer_pool.MakeBufferPool(20*1024*1024, 4*1024)
+	if err != nil {
+		return errors.Wrapf(err, "Unable to create buffer pool")
+	}
+
 	// If the output is targeted at the backend, create a shared backend
 	// learn session.
 	var backendSvc akid.ServiceID
@@ -562,7 +569,7 @@ func Run(args Args) error {
 			go func(interfaceName, filter string) {
 				defer doneWG.Done()
 				// Collect trace. This blocks until stop is closed or an error occurs.
-				if err := pcap.Collect(stop, interfaceName, filter, bufferShare, collector, summary); err != nil {
+				if err := pcap.Collect(stop, interfaceName, filter, bufferShare, collector, summary, pool); err != nil {
 					errChan <- interfaceError{
 						interfaceName: interfaceName,
 						err:           errors.Wrapf(err, "failed to collect trace on interface %s", interfaceName),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -186,7 +186,7 @@ func init() {
 	rootCmd.PersistentFlags().MarkHidden("test_only_disable_https")
 	viper.BindPFlag("test_only_disable_https", rootCmd.PersistentFlags().Lookup("test_only_disable_https"))
 
-	rootCmd.PersistentFlags().BoolVar(&dogfoodFlag, "dogfood", false, "Capture HTTP traffic to Akita services that would ordinarily be filtered")
+	rootCmd.PersistentFlags().BoolVar(&dogfoodFlag, "dogfood", false, "Capture HTTP traffic to Akita services that would ordinarily be filtered, and enable assertions")
 	rootCmd.PersistentFlags().MarkHidden("dogfood")
 	viper.BindPFlag("dogfood", rootCmd.PersistentFlags().Lookup("dogfood"))
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20220820112912-482e737437dd
+	github.com/akitasoftware/akita-libs v0.0.0-20220824034521-e2bab8ad2ef6
 	github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20220819015239-e2cb897bff83
+	github.com/akitasoftware/akita-libs v0.0.0-20220820112912-482e737437dd
 	github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20220719015343-60f5a9de9a88
+	github.com/akitasoftware/akita-libs v0.0.0-20220819015239-e2cb897bff83
 	github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/akitasoftware/akita-ir v0.0.0-20211020161529-944af4d11d6e/go.mod h1:W
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe h1:0BeBDjLDFPwv2bkk6YuRAPf1r6U4Wby98NHI9+Lddvs=
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-libs v0.0.0-20211020162041-fe02207174fb/go.mod h1:YLFCjhwQ0ZFfYWSUD2c9KYKEeBn+R+Cz+A5SitXvJz8=
-github.com/akitasoftware/akita-libs v0.0.0-20220820112912-482e737437dd h1:q7jela2is6DvNdEaHpAl7iYn8JTX40Kdou/f2DAqyus=
-github.com/akitasoftware/akita-libs v0.0.0-20220820112912-482e737437dd/go.mod h1:IHn4wvJhG1DzDvEp944L0JFWupZ5hiojx8LFNKvI7GA=
+github.com/akitasoftware/akita-libs v0.0.0-20220824034521-e2bab8ad2ef6 h1:clRqxGfOvsBbqB1IZb/ULO+G6VvZWDEjgBlWXj7MlsU=
+github.com/akitasoftware/akita-libs v0.0.0-20220824034521-e2bab8ad2ef6/go.mod h1:IHn4wvJhG1DzDvEp944L0JFWupZ5hiojx8LFNKvI7GA=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/akitasoftware/akita-ir v0.0.0-20211020161529-944af4d11d6e/go.mod h1:W
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe h1:0BeBDjLDFPwv2bkk6YuRAPf1r6U4Wby98NHI9+Lddvs=
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-libs v0.0.0-20211020162041-fe02207174fb/go.mod h1:YLFCjhwQ0ZFfYWSUD2c9KYKEeBn+R+Cz+A5SitXvJz8=
-github.com/akitasoftware/akita-libs v0.0.0-20220819015239-e2cb897bff83 h1:FBn3l7gC+MySdGe1OZECCHUcsaKkqkOaGB+EgAs1ah4=
-github.com/akitasoftware/akita-libs v0.0.0-20220819015239-e2cb897bff83/go.mod h1:IHn4wvJhG1DzDvEp944L0JFWupZ5hiojx8LFNKvI7GA=
+github.com/akitasoftware/akita-libs v0.0.0-20220820112912-482e737437dd h1:q7jela2is6DvNdEaHpAl7iYn8JTX40Kdou/f2DAqyus=
+github.com/akitasoftware/akita-libs v0.0.0-20220820112912-482e737437dd/go.mod h1:IHn4wvJhG1DzDvEp944L0JFWupZ5hiojx8LFNKvI7GA=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/akitasoftware/akita-ir v0.0.0-20211020161529-944af4d11d6e/go.mod h1:W
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe h1:0BeBDjLDFPwv2bkk6YuRAPf1r6U4Wby98NHI9+Lddvs=
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-libs v0.0.0-20211020162041-fe02207174fb/go.mod h1:YLFCjhwQ0ZFfYWSUD2c9KYKEeBn+R+Cz+A5SitXvJz8=
-github.com/akitasoftware/akita-libs v0.0.0-20220719015343-60f5a9de9a88 h1:wwJTUSANZUlFqbafT5o3VQuFga7bUivL8SBvZAd/orI=
-github.com/akitasoftware/akita-libs v0.0.0-20220719015343-60f5a9de9a88/go.mod h1:IHn4wvJhG1DzDvEp944L0JFWupZ5hiojx8LFNKvI7GA=
+github.com/akitasoftware/akita-libs v0.0.0-20220819015239-e2cb897bff83 h1:FBn3l7gC+MySdGe1OZECCHUcsaKkqkOaGB+EgAs1ah4=
+github.com/akitasoftware/akita-libs v0.0.0-20220819015239-e2cb897bff83/go.mod h1:IHn4wvJhG1DzDvEp944L0JFWupZ5hiojx8LFNKvI7GA=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/learn/learn_test.go
+++ b/learn/learn_test.go
@@ -12,6 +12,7 @@ import (
 	pb "github.com/akitasoftware/akita-ir/go/api_spec"
 
 	"github.com/akitasoftware/akita-libs/akinet"
+	"github.com/akitasoftware/akita-libs/memview"
 	"github.com/akitasoftware/akita-libs/spec_util"
 )
 
@@ -34,7 +35,7 @@ var (
 			Header: map[string][]string{
 				"Content-Type": []string{"application/json"},
 			},
-			Body: []byte(`"2020-07-22T18:55:17.911Z"`),
+			Body: memview.New([]byte(`"2020-07-22T18:55:17.911Z"`)),
 		},
 	}
 
@@ -46,7 +47,7 @@ var (
 			Header: map[string][]string{
 				"Content-Type": []string{"application/json"},
 			},
-			Body: []byte(`{"you said": "2020-07-22T18:55:17.911Z"}`),
+			Body: memview.New([]byte(`{"you said": "2020-07-22T18:55:17.911Z"}`)),
 		},
 	}
 
@@ -115,12 +116,12 @@ var (
 			Header: map[string][]string{
 				"Content-Type": []string{"application/json"},
 			},
-			Body: []byte(`
+			Body: memview.New([]byte(`
 {
 	"num1": 6119717375543385000,
 	"num2": 14201265876841261000
 }
-`),
+`)),
 		},
 	}
 

--- a/learn/util_test.go
+++ b/learn/util_test.go
@@ -11,6 +11,7 @@ import (
 	as "github.com/akitasoftware/akita-ir/go/api_spec"
 	pb "github.com/akitasoftware/akita-ir/go/api_spec"
 	"github.com/akitasoftware/akita-libs/akinet"
+	"github.com/akitasoftware/akita-libs/memview"
 	"github.com/akitasoftware/akita-libs/pbhash"
 	"github.com/akitasoftware/akita-libs/spec_util"
 )
@@ -71,7 +72,7 @@ func newTestHTTPRequest(
 		Method:     method,
 		URL:        testURL,
 		Host:       "www.akitasoftware.com",
-		Body:       body,
+		Body:       memview.New(body),
 		Cookies:    cookies,
 		Header:     h,
 	}
@@ -93,7 +94,7 @@ func newTestHTTPResponse(
 		ProtoMajor: 1,
 		ProtoMinor: 1,
 		Header:     h,
-		Body:       body,
+		Body:       memview.New(body),
 		Cookies:    cookies,
 	}
 }

--- a/pcap/http_timing_test.go
+++ b/pcap/http_timing_test.go
@@ -6,10 +6,16 @@ import (
 
 	"github.com/akitasoftware/akita-libs/akinet"
 	akihttp "github.com/akitasoftware/akita-libs/akinet/http"
+	"github.com/akitasoftware/akita-libs/buffer_pool"
 	"github.com/google/gopacket"
 )
 
 func TestHTTPRequestTimes(t *testing.T) {
+	pool, err := buffer_pool.MakeBufferPool(1024*1024, 4*1024)
+	if err != nil {
+		t.Error(err)
+	}
+
 	// create an abnormal trace with one byte every 100ms
 	startTime := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 	input := "POST /foo HTTP/1.1\r\nHost: example.com\r\nContent-Length: 9\r\n\r\nfoobarbaz"
@@ -22,7 +28,7 @@ func TestHTTPRequestTimes(t *testing.T) {
 
 	closeChan := make(chan struct{})
 	defer close(closeChan)
-	out, err := setupParseFromInterface(fakePcap(pkts), closeChan, akihttp.NewHTTPRequestParserFactory())
+	out, err := setupParseFromInterface(fakePcap(pkts), closeChan, akihttp.NewHTTPRequestParserFactory(pool))
 	if err != nil {
 		t.Errorf("unexpected error setting up listener: %v", err)
 		return
@@ -44,5 +50,9 @@ func TestHTTPRequestTimes(t *testing.T) {
 	endTime := startTime.Add(time.Duration((len(input)-1)*100) * time.Millisecond)
 	if actual[0].FinalPacketTime != endTime {
 		t.Fatalf("Final time %v does not match %v", actual[0].FinalPacketTime, endTime)
+	}
+
+	for _, pnt := range actual {
+		pnt.Content.ReleaseBuffers()
 	}
 }

--- a/pcap/net_parse.go
+++ b/pcap/net_parse.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-libs/akinet"
-	"github.com/akitasoftware/akita-libs/memview"
 )
 
 // The maximum time we will wait before flushing a connection and delivering
@@ -30,7 +29,6 @@ var StreamCloseTimeoutSeconds int64 = 90
 // We want to cap the total memory usage at about 200MB = 105263 pages
 var MaxBufferedPagesTotal int = 100_000
 
-//
 // What is a reasonable worst case? We should have enough so that if the
 // packet is retransmitted, we will get it before giving up.
 // 10Gb/s networking * 1ms RTT = 1.25 MB = 1Gb/s networking * 10ms RTT
@@ -217,7 +215,7 @@ func (p *NetworkTrafficParser) packetToParsedNetworkTraffic(out chan<- akinet.Pa
 		out <- akinet.ParsedNetworkTraffic{
 			SrcIP:           srcIP,
 			DstIP:           dstIP,
-			Content:         akinet.RawBytes(memview.New(packet.NetworkLayer().LayerPayload())),
+			Content:         akinet.DroppedBytes(len(packet.NetworkLayer().LayerPayload())),
 			ObservationTime: observationTime,
 		}
 		return
@@ -233,14 +231,14 @@ func (p *NetworkTrafficParser) packetToParsedNetworkTraffic(out chan<- akinet.Pa
 			SrcPort:         int(t.SrcPort),
 			DstIP:           dstIP,
 			DstPort:         int(t.DstPort),
-			Content:         akinet.RawBytes(memview.New(t.LayerPayload())),
+			Content:         akinet.DroppedBytes(len(t.LayerPayload())),
 			ObservationTime: observationTime,
 		}
 	default:
 		out <- akinet.ParsedNetworkTraffic{
 			SrcIP:           srcIP,
 			DstIP:           dstIP,
-			Content:         akinet.RawBytes(memview.New(t.LayerPayload())),
+			Content:         akinet.DroppedBytes(len(t.LayerPayload())),
 			ObservationTime: observationTime,
 		}
 	}

--- a/pcap/stream_test.go
+++ b/pcap/stream_test.go
@@ -69,7 +69,6 @@ func (sg fakeScatterGather) Info() (direction reassembly.TCPFlowDirection, start
 
 func (sg fakeScatterGather) Stats() reassembly.TCPAssemblyStats {
 	panic("unimplemented")
-	return reassembly.TCPAssemblyStats{}
 }
 
 type tcpFlowTestCase struct {
@@ -133,34 +132,34 @@ func TestTCPFlow(t *testing.T) {
 			name:   "unparsable single byte",
 			inputs: []string{"?"},
 			expected: []akinet.ParsedNetworkTraffic{
-				dummyPNT(akinet.RawBytes(memview.New([]byte("?")))),
+				dummyPNT(akinet.DroppedBytes(len("?"))),
 			},
 		},
 		{
 			name:   "discard single byte from front and back",
 			inputs: []string{"?prince|bread!|&"},
 			expected: []akinet.ParsedNetworkTraffic{
-				dummyPNT(akinet.RawBytes(memview.New([]byte("?")))),
+				dummyPNT(akinet.DroppedBytes(len("?"))),
 				dummyPNT(akinet.AkitaPrince("bread!")),
-				dummyPNT(akinet.RawBytes(memview.New([]byte("&")))),
+				dummyPNT(akinet.DroppedBytes(len("&"))),
 			},
 		},
 		{
 			name:   "discard single byte from front and back - segmented",
 			inputs: []string{"?pr", "ince|bre", "ad!|&"},
 			expected: []akinet.ParsedNetworkTraffic{
-				dummyPNT(akinet.RawBytes(memview.New([]byte("?")))),
+				dummyPNT(akinet.DroppedBytes(len("?"))),
 				dummyPNT(akinet.AkitaPrince("bread!")),
-				dummyPNT(akinet.RawBytes(memview.New([]byte("&")))),
+				dummyPNT(akinet.DroppedBytes(len("&"))),
 			},
 		},
 		{
 			name:   "discard multiple bytes from front and back - segmented",
 			inputs: []string{"hellopr", "ince|bre", "ad!", "|bye"},
 			expected: []akinet.ParsedNetworkTraffic{
-				dummyPNT(akinet.RawBytes(memview.New([]byte("hello")))),
+				dummyPNT(akinet.DroppedBytes(len("hello"))),
 				dummyPNT(akinet.AkitaPrince("bread!")),
-				dummyPNT(akinet.RawBytes(memview.New([]byte("bye")))),
+				dummyPNT(akinet.DroppedBytes(len("bye"))),
 			},
 		},
 		{
@@ -192,7 +191,7 @@ func TestTCPFlow(t *testing.T) {
 			inputs: []string{"pr", "ince|bre", "ad!|pr", "ince|ya"},
 			expected: []akinet.ParsedNetworkTraffic{
 				dummyPNT(akinet.AkitaPrince("bread!")),
-				dummyPNT(akinet.RawBytes(memview.New([]byte("prince|ya")))),
+				dummyPNT(akinet.DroppedBytes(len("prince|ya"))),
 			},
 		},
 		{

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/akitasoftware/akita-libs/akinet"
 	kgxapi "github.com/akitasoftware/akita-libs/api_schema"
 	"github.com/akitasoftware/akita-libs/batcher"
+	"github.com/akitasoftware/akita-libs/memview"
 	"github.com/akitasoftware/akita-libs/spec_util"
 )
 
@@ -74,7 +75,7 @@ func TestObfuscate(t *testing.T) {
 			Header: map[string][]string{
 				"Content-Type": {"application/json"},
 			},
-			Body: []byte(`{"name": "prince", "number": 6119717375543385000}`),
+			Body: memview.New([]byte(`{"name": "prince", "number": 6119717375543385000}`)),
 		},
 	}
 
@@ -86,7 +87,7 @@ func TestObfuscate(t *testing.T) {
 			Header: map[string][]string{
 				"Content-Type": {"application/json"},
 			},
-			Body: []byte(`{"homes": ["burbank, ca", "jeuno, ak", "versailles"]}`),
+			Body: memview.New([]byte(`{"homes": ["burbank, ca", "jeuno, ak", "versailles"]}`)),
 		},
 	}
 
@@ -266,7 +267,7 @@ func TestMultipleInterfaces(t *testing.T) {
 					Header: map[string][]string{
 						"Content-Type": {"application/json"},
 					},
-					Body: []byte(`{"name": "prince", "number": 6119717375543385000}`),
+					Body: memview.New([]byte(`{"name": "prince", "number": 6119717375543385000}`)),
 				},
 			}
 			bc.Process(req)
@@ -278,7 +279,7 @@ func TestMultipleInterfaces(t *testing.T) {
 					Header: map[string][]string{
 						"Content-Type": {"application/json"},
 					},
-					Body: []byte(`{"homes": ["burbank, ca", "jeuno, ak", "versailles"]}`),
+					Body: memview.New([]byte(`{"homes": ["burbank, ca", "jeuno, ak", "versailles"]}`)),
 				},
 			}
 			bc.Process(resp)

--- a/trace/rate_limit_test.go
+++ b/trace/rate_limit_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/akitasoftware/akita-libs/akinet"
+	"github.com/akitasoftware/akita-libs/memview"
 	"github.com/google/uuid"
 	"github.com/spf13/viper"
 )
@@ -60,7 +61,7 @@ func TestRateLimit_FirstSample(t *testing.T) {
 				Header: map[string][]string{
 					"Content-Type": {"application/json"},
 				},
-				Body: []byte(`{"name": "prince", "number": 6119717375543385000}`),
+				Body: memview.New([]byte(`{"name": "prince", "number": 6119717375543385000}`)),
 			},
 			ObservationTime: time.Now(),
 			FinalPacketTime: time.Now(),


### PR DESCRIPTION
Two improvements to memory usage:
* Don't buffer HTTP requests and responses during parsing. Previously, we were buffering the entire request/response so that it could be emitted as raw data when parsing failed. Instead we now just emit a count of how much data was consumed.
* Read HTTP payloads from a fixed-size buffer pool. Currently, this is a 20 MiB pool that gets allocated in 4-KiB chunks. These numbers were chosen arbitrarily.

I am concerned that this second change will cause the agent to stop reading full HTTP payloads when there are a lot of concurrent connections.

To evaluate the effects of these changes, 10 concurrent GET requests were continually made to a test service, once every <20 seconds for at least 6 hours. The response payload consisted of about 27 MiB of random JSON data. As a result of these changes, the agent's maximum RSS as reported by Linux (VmHWM) was reduced by 76%, from 1,307 MiB to 310 MiB. The effect of the first change was also measured independently: VmHWM was reduced by 41%, from 1,307 MiB to 771 MiB.