### PR TITLE
Disabled deprecated features by default

### DIFF
--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -19,25 +19,26 @@ import (
 
 var (
 	// Optional flags
-	outFlag             location.Location
-	serviceFlag         string
-	interfacesFlag      []string
-	filterFlag          string
-	sampleRateFlag      float64
-	rateLimitFlag       float64
-	tagsFlag            []string
-	appendByTagFlag     bool
-	pathExclusionsFlag  []string
-	hostExclusionsFlag  []string
-	pathAllowlistFlag   []string
-	hostAllowlistFlag   []string
-	execCommandFlag     string
-	execCommandUserFlag string
-	pluginsFlag         []string
-	traceRotateFlag     string
-	deploymentFlag      string
-	statsLogDelay       int
-	telemetryInterval   int
+	outFlag                 location.Location
+	serviceFlag             string
+	interfacesFlag          []string
+	filterFlag              string
+	sampleRateFlag          float64
+	rateLimitFlag           float64
+	tagsFlag                []string
+	appendByTagFlag         bool
+	pathExclusionsFlag      []string
+	hostExclusionsFlag      []string
+	pathAllowlistFlag       []string
+	hostAllowlistFlag       []string
+	execCommandFlag         string
+	execCommandUserFlag     string
+	pluginsFlag             []string
+	traceRotateFlag         string
+	deploymentFlag          string
+	statsLogDelay           int
+	telemetryInterval       int
+	collectTCPAndTLSReports bool
 )
 
 var Cmd = &cobra.Command{
@@ -139,25 +140,26 @@ var Cmd = &cobra.Command{
 		}
 
 		args := apidump.Args{
-			ClientID:             akiflag.GetClientID(),
-			Domain:               akiflag.Domain,
-			Out:                  outFlag,
-			Tags:                 traceTags,
-			SampleRate:           sampleRateFlag,
-			WitnessesPerMinute:   rateLimitFlag,
-			Interfaces:           interfacesFlag,
-			Filter:               filterFlag,
-			PathExclusions:       pathExclusionsFlag,
-			HostExclusions:       hostExclusionsFlag,
-			PathAllowlist:        pathAllowlistFlag,
-			HostAllowlist:        hostAllowlistFlag,
-			ExecCommand:          execCommandFlag,
-			ExecCommandUser:      execCommandUserFlag,
-			Plugins:              plugins,
-			LearnSessionLifetime: traceRotateInterval,
-			Deployment:           deploymentFlag,
-			StatsLogDelay:        statsLogDelay,
-			TelemetryInterval:    telemetryInterval,
+			ClientID:                akiflag.GetClientID(),
+			Domain:                  akiflag.Domain,
+			Out:                     outFlag,
+			Tags:                    traceTags,
+			SampleRate:              sampleRateFlag,
+			WitnessesPerMinute:      rateLimitFlag,
+			Interfaces:              interfacesFlag,
+			Filter:                  filterFlag,
+			PathExclusions:          pathExclusionsFlag,
+			HostExclusions:          hostExclusionsFlag,
+			PathAllowlist:           pathAllowlistFlag,
+			HostAllowlist:           hostAllowlistFlag,
+			ExecCommand:             execCommandFlag,
+			ExecCommandUser:         execCommandUserFlag,
+			Plugins:                 plugins,
+			LearnSessionLifetime:    traceRotateInterval,
+			Deployment:              deploymentFlag,
+			StatsLogDelay:           statsLogDelay,
+			TelemetryInterval:       telemetryInterval,
+			CollectTCPAndTLSReports: collectTCPAndTLSReports,
 		}
 		if err := apidump.Run(args); err != nil {
 			return cmderr.AkitaErr{Err: err}
@@ -310,4 +312,12 @@ func init() {
 		"Upload client telemetry every N seconds.",
 	)
 	Cmd.Flags().MarkHidden("telemetry-interval")
+
+	Cmd.Flags().BoolVar(
+		&collectTCPAndTLSReports,
+		"report-tcp-and-tls",
+		false,
+		"Collect TCP and TLS reports.",
+	)
+	Cmd.Flags().MarkHidden("report-tcp-and-tls")
 }

--- a/cmd/internal/get/graph.go
+++ b/cmd/internal/get/graph.go
@@ -24,6 +24,7 @@ var GetGraphCmd = &cobra.Command{
 	Long:         "Show the service graph in textual form.",
 	SilenceUsage: false,
 	RunE:         getGraph,
+	Hidden:       true,
 }
 
 var (

--- a/pcap/run.go
+++ b/pcap/run.go
@@ -13,14 +13,27 @@ import (
 	. "github.com/akitasoftware/akita-libs/client_telemetry"
 )
 
-func Collect(stop <-chan struct{}, intf, bpfFilter string, bufferShare float32, proc trace.Collector, packetCount trace.PacketCountConsumer, pool buffer_pool.BufferPool) error {
+func Collect(
+	stop <-chan struct{},
+	intf string,
+	bpfFilter string,
+	bufferShare float32,
+	parseTCPAndTLS bool,
+	proc trace.Collector,
+	packetCount trace.PacketCountConsumer,
+	pool buffer_pool.BufferPool,
+) error {
 	defer proc.Close()
 
 	facts := []akinet.TCPParserFactory{
 		akihttp.NewHTTPRequestParserFactory(pool),
 		akihttp.NewHTTPResponseParserFactory(pool),
-		tls.NewTLSClientParserFactory(),
-		tls.NewTLSServerParserFactory(),
+	}
+	if parseTCPAndTLS {
+		facts = append(facts,
+			tls.NewTLSClientParserFactory(),
+			tls.NewTLSServerParserFactory(),
+		)
 	}
 
 	parser := NewNetworkTrafficParser(bufferShare)


### PR DESCRIPTION
- Collection of TCP and TLS reports now disabled by default, since these are now being ignored by the back end. Use `akita apidump --report-tcp-and-tls` if you want these back for whatever reason.

- The subcommand `akita get graph` is now hidden, since the back end is no longer producing service graphs.