### PR TITLE
Bugfix: Duplicate data items

### DIFF
--- a/learn/parse_http.go
+++ b/learn/parse_http.go
@@ -163,10 +163,15 @@ func ParseHTTP(elem akinet.ParsedNetworkContent) (*PartialWitness, error) {
 	for _, d := range datas {
 		// Use the hash of the data proto as the key so we can deterministically
 		// compare witnesses.
+		//
+		// Some witnesses contain duplicate data elements, such as cookies with
+		// the same name and value (but different domains or paths, which we
+		// don't currently include in the IR).
+		//
+		// If there is a potential hash collision, fall back to an expensive
+		// equality check.  If the witnesses are different, return an error.
 		k := ir_hash.HashDataToString(d)
 		if existing, collision := dataMap[k]; collision && !proto.Equal(d, existing) {
-			fmt.Printf("COLE: collision - existing: %s\n", proto.MarshalTextString(existing))
-			fmt.Printf("COLE: collision -      new: %s\n", proto.MarshalTextString(d))
 			return nil, errors.Errorf("detected collision in data map key")
 		}
 		dataMap[k] = d

--- a/learn/parse_http.go
+++ b/learn/parse_http.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"github.com/golang/protobuf/proto"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -163,7 +164,9 @@ func ParseHTTP(elem akinet.ParsedNetworkContent) (*PartialWitness, error) {
 		// Use the hash of the data proto as the key so we can deterministically
 		// compare witnesses.
 		k := ir_hash.HashDataToString(d)
-		if _, collision := dataMap[k]; collision {
+		if existing, collision := dataMap[k]; collision && !proto.Equal(d, existing) {
+			fmt.Printf("COLE: collision - existing: %s\n", proto.MarshalTextString(existing))
+			fmt.Printf("COLE: collision -      new: %s\n", proto.MarshalTextString(d))
 			return nil, errors.Errorf("detected collision in data map key")
 		}
 		dataMap[k] = d

--- a/learn/parse_http_test.go
+++ b/learn/parse_http_test.go
@@ -518,6 +518,27 @@ prince:
 				newTestMultipartFormData(0),
 			}, nil, standardMethodPostMeta),
 		},
+		&parseTest{
+			name: "duplicate cookies",
+			testContent: newTestHTTPRequest(
+				"GET",
+				"https://www.akitasoftware.com",
+				nil,
+				applicationJSON,
+				map[string][]string{},
+				[]*http.Cookie{
+					&http.Cookie{Name: "furniture", Value: "rococo"},
+					&http.Cookie{Name: "furniture", Value: "rococo"},
+				},
+			),
+			expectedMethod: newMethod(
+				[]*as.Data{
+					newDataCookie("furniture", 0, false, "rococo"),
+				},
+				nil,
+				standardMethodMeta,
+			),
+		},
 	}
 
 	for _, pt := range tests {

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -3,7 +3,6 @@ package trace
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"net"
 	"net/http"
 	"reflect"
@@ -171,16 +170,8 @@ func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
 	switch content := t.Content.(type) {
 	case akinet.HTTPRequest:
 		isRequest = true
-		fmt.Printf("COLE: input request: %s\n", content.Host)
 		partial, parseHTTPErr = learn.ParseHTTP(content)
-		if parseHTTPErr == nil {
-			meta := partial.Witness.Method.GetMeta().GetHttp()
-			fmt.Printf("COLE: input partial: %s\n", meta.Host)
-		} else {
-			fmt.Printf("COLE: ERROR: %s\n", parseHTTPErr)
-		}
 	case akinet.HTTPResponse:
-		fmt.Printf("COLE: input response\n")
 		partial, parseHTTPErr = learn.ParseHTTP(content)
 	case akinet.TCPConnectionMetadata:
 		return c.processTCPConnection(t, content)
@@ -212,9 +203,6 @@ func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
 			pair.srcPort, pair.dstPort = pair.dstPort, pair.srcPort
 		}
 
-		meta := pair.witness.GetMethod().GetMeta().GetHttp()
-		fmt.Printf("COLE - merged: %s %s %s", meta.Method, meta.Host, meta.PathTemplate)
-
 		c.queueUpload(pair)
 		printer.Debugf("Completed witness %v at %v -- %v\n",
 			partial.PairKey, t.ObservationTime, t.FinalPacketTime)
@@ -222,10 +210,6 @@ func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
 	} else {
 		// Store the partial witness for now, waiting for its pair or a
 		// flush timeout.
-
-		meta := partial.Witness.Method.GetMeta().GetHttp()
-		fmt.Printf("COLE - partial: %s %s %s", meta.Method, meta.Host, meta.PathTemplate)
-
 		w := &witnessWithInfo{
 			srcIP:           t.SrcIP,
 			srcPort:         uint16(t.SrcPort),

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -3,6 +3,7 @@ package trace
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"net"
 	"net/http"
 	"reflect"
@@ -170,8 +171,16 @@ func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
 	switch content := t.Content.(type) {
 	case akinet.HTTPRequest:
 		isRequest = true
+		fmt.Printf("COLE: input request: %s\n", content.Host)
 		partial, parseHTTPErr = learn.ParseHTTP(content)
+		if parseHTTPErr == nil {
+			meta := partial.Witness.Method.GetMeta().GetHttp()
+			fmt.Printf("COLE: input partial: %s\n", meta.Host)
+		} else {
+			fmt.Printf("COLE: ERROR: %s\n", parseHTTPErr)
+		}
 	case akinet.HTTPResponse:
+		fmt.Printf("COLE: input response\n")
 		partial, parseHTTPErr = learn.ParseHTTP(content)
 	case akinet.TCPConnectionMetadata:
 		return c.processTCPConnection(t, content)
@@ -203,6 +212,9 @@ func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
 			pair.srcPort, pair.dstPort = pair.dstPort, pair.srcPort
 		}
 
+		meta := pair.witness.GetMethod().GetMeta().GetHttp()
+		fmt.Printf("COLE - merged: %s %s %s", meta.Method, meta.Host, meta.PathTemplate)
+
 		c.queueUpload(pair)
 		printer.Debugf("Completed witness %v at %v -- %v\n",
 			partial.PairKey, t.ObservationTime, t.FinalPacketTime)
@@ -210,6 +222,10 @@ func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
 	} else {
 		// Store the partial witness for now, waiting for its pair or a
 		// flush timeout.
+
+		meta := partial.Witness.Method.GetMeta().GetHttp()
+		fmt.Printf("COLE - partial: %s %s %s", meta.Method, meta.Host, meta.PathTemplate)
+
 		w := &witnessWithInfo{
 			srcIP:           t.SrcIP,
 			srcPort:         uint16(t.SrcPort),


### PR DESCRIPTION
HTTP requests/responses may contain elements that result in duplicate Data items in the IR.  For example, requests may contain cookies with the same name and value (but different domains or paths, which is not currently stored in the IR).

Previously, duplicate items were interpreted as hash collisions, causing parsing to fail.  This PR amends that behavior to check for equality and fail only if items are different.