### PR TITLE
Report on count of TLS handshake messages.

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -117,6 +117,7 @@ type Args struct {
 	CollectTCPAndTLSReports bool
 
 	// Parse TLS handshake messages (even if not reported)
+	// Invariant: this is true if CollectTCPAndTLSReports is true
 	ParseTLSHandshakes bool
 }
 

--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -115,6 +115,9 @@ type Args struct {
 
 	// Whether to report TCP connections and TLS handshakes.
 	CollectTCPAndTLSReports bool
+
+	// Parse TLS handshake messages (even if not reported)
+	ParseTLSHandshakes bool
 }
 
 func (args *Args) lint() {
@@ -567,6 +570,8 @@ func Run(args Args) error {
 				}
 			}
 
+			// If this is false, we will still parse TLS client and server hello messages
+			// but not process them futher.
 			if args.CollectTCPAndTLSReports {
 				// Process TLS traffic into TLS-connection metadata.
 				collector = tls_conn_tracker.NewCollector(collector)
@@ -583,7 +588,7 @@ func Run(args Args) error {
 			go func(interfaceName, filter string) {
 				defer doneWG.Done()
 				// Collect trace. This blocks until stop is closed or an error occurs.
-				if err := pcap.Collect(stop, interfaceName, filter, bufferShare, args.CollectTCPAndTLSReports, collector, summary, pool); err != nil {
+				if err := pcap.Collect(stop, interfaceName, filter, bufferShare, args.ParseTLSHandshakes, collector, summary, pool); err != nil {
 					errChan <- interfaceError{
 						interfaceName: interfaceName,
 						err:           errors.Wrapf(err, "failed to collect trace on interface %s", interfaceName),

--- a/apidump/summary.go
+++ b/apidump/summary.go
@@ -154,7 +154,7 @@ func DumpPacketCounters(logf func(f string, args ...interface{}), interfaces map
 	logf("%8v %7v %5v %5v %5v %5v\n", "port", "packets", "req", "resp", "hello", "unk")
 	for i, summary := range toReport {
 		if filterStates[i] == matchedFilter {
-			logf("--------- matching filter --------------\n")
+			logf("----------- matching filter ------------\n")
 		} else {
 			logf("------- not matching filter ------------\n")
 		}

--- a/apidump/summary.go
+++ b/apidump/summary.go
@@ -87,7 +87,7 @@ func (s *Summary) PrintWarnings() {
 				printer.Stderr.Infof("%s\n", printer.Color.Yellow(msg))
 			}
 		} else if totalCount.TLSHello > 0 {
-			msg := fmt.Sprintf("Captured %d TLS handshake messages out of %d total TCP seegments. ", totalCount.TLSHello, totalCount.TCPPackets) +
+			msg := fmt.Sprintf("Captured %d TLS handshake messages out of %d total TCP segments. ", totalCount.TLSHello, totalCount.TCPPackets) +
 				"This may mean you are trying to capture HTTPS traffic, which is currently unsupported."
 			printer.Stderr.Infof("%s\n", msg)
 		} else if totalCount.Unparsed > 0 {

--- a/apidump/summary.go
+++ b/apidump/summary.go
@@ -156,7 +156,7 @@ func DumpPacketCounters(logf func(f string, args ...interface{}), interfaces map
 		if filterStates[i] == matchedFilter {
 			logf("----------- matching filter ------------\n")
 		} else {
-			logf("------- not matching filter ------------\n")
+			logf("--------- not matching filter ----------\n")
 		}
 		byPort := summary.AllPorts()
 		// We don't really know what's in the BPF filter; we know every packet in

--- a/apidump/summary.go
+++ b/apidump/summary.go
@@ -75,7 +75,6 @@ func (s *Summary) PrintWarnings() {
 	// Check summary to see if the trace will have anything in it.
 	totalCount := s.FilterSummary.Total()
 	if totalCount.HTTPRequests == 0 && totalCount.HTTPResponses == 0 {
-		// TODO: recognize TLS handshakes and count them separately!
 		if totalCount.TCPPackets == 0 {
 			if s.CapturingNegation && s.NegationSummary.Total().TCPPackets == 0 {
 				msg := "Did not capture any TCP packets during the trace. " +
@@ -91,7 +90,7 @@ func (s *Summary) PrintWarnings() {
 			msg := fmt.Sprintf("Captured %d TLS handshake messages out of %d total TCP seegments. ", totalCount.TLSHello, totalCount.TCPPackets) +
 				"This may mean you are trying to capture HTTPS traffic, which is currently unsupported."
 			printer.Stderr.Infof("%s\n", msg)
-		} else if totalCount.TLSHello > 0 {
+		} else if totalCount.Unparsed > 0 {
 			msg := fmt.Sprintf("Captured %d TCP packets total; %d unparsed TCP segments. ", totalCount.TCPPackets, totalCount.Unparsed) +
 				"No TLS headers were found, so this may represent a network protocol that the agent does not know how to parse."
 			printer.Stderr.Infof("%s\n", msg)

--- a/apidump/summary.go
+++ b/apidump/summary.go
@@ -87,13 +87,13 @@ func (s *Summary) PrintWarnings() {
 					"This may mean your filter is incorrect, such as the wrong TCP port."
 				printer.Stderr.Infof("%s\n", printer.Color.Yellow(msg))
 			}
-		} else if totalCount.Unparsed > 0 {
+		} else if totalCount.TLSHello > 0 {
+			msg := fmt.Sprintf("Captured %d TLS handshake messages out of %d total TCP seegments. ", totalCount.TLSHello, totalCount.TCPPackets) +
+				"This may mean you are trying to capture HTTPS traffic, which is currently unsupported."
+			printer.Stderr.Infof("%s\n", msg)
+		} else if totalCount.TLSHello > 0 {
 			msg := fmt.Sprintf("Captured %d TCP packets total; %d unparsed TCP segments. ", totalCount.TCPPackets, totalCount.Unparsed) +
-				"This may mean you are trying to capture HTTPS traffic." +
-				"See https://docs.akita.software/docs/proxy-for-encrypted-traffic " +
-				"for instructions on using a proxy, or generate a HAR file with " +
-				"your browser as described in " +
-				"https://docs.akita.software/docs/collect-client-side-traffic-2."
+				"No TLS headers were found, so this may represent a network protocol that the agent does not know how to parse."
 			printer.Stderr.Infof("%s\n", msg)
 		} else if s.NumUserFilters > 0 && s.PrefilterSummary.Total().HTTPRequests != 0 {
 			printer.Stderr.Infof("Captured %d HTTP requests before allow and exclude rules, but all were filtered.\n",
@@ -129,45 +129,47 @@ func DumpPacketCounters(logf func(f string, args ...interface{}), interfaces map
 	}
 
 	if showInterface {
-		logf("==================================================\n")
+		logf("========================================================\n")
 		logf("Packets per interface:\n")
-		logf("%15v %8v %7v %11v %5v\n", "", "", "TCP  ", "HTTP   ", "")
-		logf("%15v %8v %7v %5v %5v %5v\n", "interface", "dir", "packets", "req", "resp", "unk")
+		logf("%15v %9v %7v %11v %5v %5v\n", "", "", "TCP  ", "HTTP   ", "TLS  ", "")
+		logf("%15v %9v %7v %5v %5v %5v %5v\n", "interface", "dir", "packets", "req", "resp", "hello", "unk")
 		for n := range interfaces {
 			for i, summary := range toReport {
 				count := summary.TotalOnInterface(n)
-				logf("%15s %9s %7d %5d %5d %5d\n",
+				logf("%15s %9s %7d %5d %5d %5d %5d\n",
 					n,
 					filterStates[i],
 					count.TCPPackets,
 					count.HTTPRequests,
 					count.HTTPResponses,
+					count.TLSHello,
 					count.Unparsed,
 				)
 			}
 		}
 	}
 
-	logf("==================================================\n")
+	logf("========================================================\n")
 	logf("Packets per port:\n")
-	logf("%8v %7v %11v %5v\n", "", "TCP  ", "HTTP   ", "")
-	logf("%8v %7v %5v %5v %5v\n", "port", "packets", "req", "resp", "unk")
+	logf("%8v %7v %11v %5v %5v\n", "", "TCP  ", "HTTP   ", "TLS  ", "")
+	logf("%8v %7v %5v %5v %5v %5v\n", "port", "packets", "req", "resp", "hello", "unk")
 	for i, summary := range toReport {
 		if filterStates[i] == matchedFilter {
-			logf("--------- matching filter --------\n")
+			logf("--------- matching filter --------------\n")
 		} else {
-			logf("------- not matching filter ------\n")
+			logf("------- not matching filter ------------\n")
 		}
 		byPort := summary.AllPorts()
 		// We don't really know what's in the BPF filter; we know every packet in
 		// matchedSummary must have matched, but that could be multiple ports, or
 		// some other criteria.
 		for _, count := range byPort {
-			logf("%8d %7d %5d %5d %5d\n",
+			logf("%8d %7d %5d %5d %5d %5d\n",
 				count.SrcPort,
 				count.TCPPackets,
 				count.HTTPRequests,
 				count.HTTPResponses,
+				count.TLSHello,
 				count.Unparsed,
 			)
 		}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20220922001550-c0ca149ee7ae
+	github.com/akitasoftware/akita-libs v0.0.0-20220922225149-8cd7b2f84f14
 	github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20220922000442-7eae95e4b024 h1:hZ3wyv
 github.com/akitasoftware/akita-libs v0.0.0-20220922000442-7eae95e4b024/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/akita-libs v0.0.0-20220922001550-c0ca149ee7ae h1:J1aG7e33+qVLv5OzSlTUYofEUGMszKWjZDX3zrLKeGA=
 github.com/akitasoftware/akita-libs v0.0.0-20220922001550-c0ca149ee7ae/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
+github.com/akitasoftware/akita-libs v0.0.0-20220922225149-8cd7b2f84f14 h1:qUeIXKOCqGbGNyDM3U2zFbwcZOc7Fb5SX8XSVw8bB78=
+github.com/akitasoftware/akita-libs v0.0.0-20220922225149-8cd7b2f84f14/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/trace/collector.go
+++ b/trace/collector.go
@@ -116,6 +116,13 @@ func (pc *PacketCountCollector) Process(t akinet.ParsedNetworkTraffic) error {
 			DstPort:       t.DstPort,
 			HTTPResponses: 1,
 		})
+	case akinet.TLSClientHello, akinet.TLSServerHello:
+		pc.PacketCounts.Update(client_telemetry.PacketCounts{
+			Interface: t.Interface,
+			SrcPort:   t.SrcPort,
+			DstPort:   t.DstPort,
+			TLSHello:  1,
+		})
 	case akinet.TCPPacketMetadata, akinet.TCPConnectionMetadata:
 		// Don't count TCP metadata.
 	case akinet.TLSHandshakeMetadata:


### PR DESCRIPTION
Depends on https://github.com/akitasoftware/akita-libs/pull/159

Example output:
```
mark@ubuntu:~/akita-cli$ sudo -E bin/akita apidump --project mgg-test 
[INFO] Akita Agent 0.0.0
[INFO] Created new trace on Akita Cloud: akita://mgg-test:trace:lace-pig-d35eeeab
[INFO] Running learn mode on interfaces lo, ens33, docker0, br-a17c933efd5a
[WARNING] --filter flag is not set, this means that all network traffic is treated as your API traffic
[INFO] Send SIGINT (Ctrl-C) to stop...
[INFO] Printing packet capture statistics after 60 seconds of capture.
[INFO] ==================================================
[INFO] Packets per interface:
[INFO]                             TCP       HTTP      TLS      
[INFO]       interface       dir packets   req  resp hello   unk
[INFO]              lo   MATCHED       0     0     0     0   244
[INFO]           ens33   MATCHED   29955    32    30   457 16791
[INFO]         docker0   MATCHED       0     0     0     0     0
[INFO] br-a17c933efd5a   MATCHED       0     0     0     0     0
[INFO] ==================================================
```