### PR TITLE
Discard control characters when parsing JSON

### DIFF
--- a/learn/json_preprocessor.go
+++ b/learn/json_preprocessor.go
@@ -1,0 +1,54 @@
+package learn
+
+import (
+	"io"
+	"unicode"
+)
+
+type stripControlCharactersReader struct {
+	wrapped io.Reader
+}
+
+func newStripControlCharactersReader(wrapped io.Reader) stripControlCharactersReader {
+	return stripControlCharactersReader{wrapped: wrapped}
+}
+
+// Read up to len(p) bytes, removing any unescaped control characters found.
+// Removed characters do not count toward the total bytes read.  Returns the
+// number of bytes read.
+func (r stripControlCharactersReader) Read(p []byte) (n int, err error) {
+	pIdx := 0
+
+	// Read up to len(p) bytes, then discard any control characters.  Continue
+	// reading (and discarding control characters) until p is full or there are
+	// no more bytes to read.
+	for pIdx < len(p) {
+		remaining := len(p) - pIdx
+		buf := make([]byte, remaining)
+
+		var bufN int
+		bufN, err = r.wrapped.Read(buf)
+
+		// Copy from buf to p, skipping unescaped control characters.
+		hasPrecedingSlash := false
+		for _, r := range string(buf) {
+			if unicode.IsControl(r) && !hasPrecedingSlash {
+				continue
+			}
+			if r == '\\' {
+				hasPrecedingSlash = !hasPrecedingSlash
+			}
+			pIdx += copy(p[pIdx:], string([]rune{r}))
+		}
+
+		// If we hit an error or read fewer bytes than the size of the buffer,
+		// don't bother trying to read more from the underlying reader.
+		if err != nil || bufN < remaining {
+			break
+		}
+
+		// Otherwise, we loop to replace CRs we dropped.
+	}
+
+	return pIdx, err
+}

--- a/learn/json_preprocessor.go
+++ b/learn/json_preprocessor.go
@@ -2,7 +2,6 @@ package learn
 
 import (
 	"io"
-	"unicode"
 )
 
 type stripControlCharactersReader struct {
@@ -13,7 +12,7 @@ func newStripControlCharactersReader(wrapped io.Reader) stripControlCharactersRe
 	return stripControlCharactersReader{wrapped: wrapped}
 }
 
-// Read up to len(p) bytes, removing any unescaped control characters found.
+// Read up to len(p) bytes, removing any control characters found.
 // Removed characters do not count toward the total bytes read.  Returns the
 // number of bytes read.
 func (r stripControlCharactersReader) Read(p []byte) (n int, err error) {
@@ -30,12 +29,13 @@ func (r stripControlCharactersReader) Read(p []byte) (n int, err error) {
 		var bufN int
 		bufN, err = r.wrapped.Read(bufSlice)
 
-		// Copy from buf to p, skipping unescaped control characters.
-		for _, r := range string(bufSlice) {
-			if unicode.IsControl(r) {
+		// Copy from buf to p, skipping control characters.
+		for _, c := range bufSlice {
+			if c < 0x1f {
 				continue
 			}
-			pIdx += copy(p[pIdx:], string([]rune{r}))
+			p[pIdx] = c
+			pIdx += 1
 		}
 
 		// If we hit an error or read fewer bytes than the size of the buffer,

--- a/learn/json_preprocessor.go
+++ b/learn/json_preprocessor.go
@@ -18,19 +18,20 @@ func newStripControlCharactersReader(wrapped io.Reader) stripControlCharactersRe
 // number of bytes read.
 func (r stripControlCharactersReader) Read(p []byte) (n int, err error) {
 	pIdx := 0
+	buf := make([]byte, len(p))
 
 	// Read up to len(p) bytes, then discard any control characters.  Continue
 	// reading (and discarding control characters) until p is full or there are
 	// no more bytes to read.
 	for pIdx < len(p) {
 		remaining := len(p) - pIdx
-		buf := make([]byte, remaining)
+		bufSlice := buf[:remaining]
 
 		var bufN int
-		bufN, err = r.wrapped.Read(buf)
+		bufN, err = r.wrapped.Read(bufSlice)
 
 		// Copy from buf to p, skipping unescaped control characters.
-		for _, r := range string(buf) {
+		for _, r := range string(bufSlice) {
 			if unicode.IsControl(r) {
 				continue
 			}

--- a/learn/json_preprocessor.go
+++ b/learn/json_preprocessor.go
@@ -31,7 +31,7 @@ func (r stripControlCharactersReader) Read(p []byte) (n int, err error) {
 
 		// Copy from buf to p, skipping control characters.
 		for _, c := range bufSlice {
-			if c < 0x1f {
+			if c <= 0x1f {
 				continue
 			}
 			p[pIdx] = c

--- a/learn/json_preprocessor.go
+++ b/learn/json_preprocessor.go
@@ -30,7 +30,7 @@ func (r stripControlCharactersReader) Read(p []byte) (n int, err error) {
 		bufN, err = r.wrapped.Read(bufSlice)
 
 		// Copy from buf to p, skipping control characters.
-		for _, c := range bufSlice {
+		for _, c := range bufSlice[:bufN] {
 			if c <= 0x1f {
 				continue
 			}

--- a/learn/json_preprocessor.go
+++ b/learn/json_preprocessor.go
@@ -30,13 +30,9 @@ func (r stripControlCharactersReader) Read(p []byte) (n int, err error) {
 		bufN, err = r.wrapped.Read(buf)
 
 		// Copy from buf to p, skipping unescaped control characters.
-		hasPrecedingSlash := false
 		for _, r := range string(buf) {
-			if unicode.IsControl(r) && !hasPrecedingSlash {
+			if unicode.IsControl(r) {
 				continue
-			}
-			if r == '\\' {
-				hasPrecedingSlash = !hasPrecedingSlash
 			}
 			pIdx += copy(p[pIdx:], string([]rune{r}))
 		}

--- a/learn/json_preprocessor_test.go
+++ b/learn/json_preprocessor_test.go
@@ -1,0 +1,119 @@
+package learn
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSkipCarriageReturnReader(t *testing.T) {
+	testCases := []struct {
+		Name                 string
+		Input                string
+		BytesToRead          int
+		DifferentEOFBehavior bool
+	}{
+		{
+			Name:        "empty",
+			Input:       "",
+			BytesToRead: 128,
+		},
+		{
+			Name:        "read 0 bytes",
+			Input:       "foo",
+			BytesToRead: 0,
+		},
+		{
+			Name:        "no CR string",
+			Input:       "foo",
+			BytesToRead: 128,
+		},
+		{
+			Name:        "CR",
+			Input:       "foo\rbar",
+			BytesToRead: 128,
+		},
+		{
+			Name:        "CRs",
+			Input:       "foo\rbar\r",
+			BytesToRead: 128,
+		},
+		{
+			Name:        "fill in after removing CRs",
+			Input:       "foo\rbar",
+			BytesToRead: 4,
+		},
+		{
+			Name:        "CRLFs",
+			Input:       "f\r\noo\r\nbar\r\n",
+			BytesToRead: 128,
+		},
+		{
+			Name:        "fill in after removing CRLFs",
+			Input:       "f\r\noo\r\nbar\r\n",
+			BytesToRead: 4,
+		},
+		{
+			Name:        "fill in after removing trailing CRLFs",
+			Input:       "f\r\noo\r\nbar\r\n",
+			BytesToRead: 7,
+
+			// The strip reader returns an EOF where the strings.Reader
+			// doesn't, because it tries to read more characters after the
+			// trailing CRLF and fails.
+			DifferentEOFBehavior: true,
+		},
+	}
+
+	// For each test case, read bytes from the CR stripper and compare the
+	// results to reading bytes straight from a strings.Reader and then
+	// manually removing CRs.
+	for _, tc := range testCases {
+		numCRs := countControlCharacters(tc.Input)
+
+		// Read bytes from the CR stripper.
+		buf := make([]byte, tc.BytesToRead)
+		n, err := newStripControlCharactersReader(strings.NewReader(tc.Input)).Read(buf)
+
+		// Read bytes straight from strings.Reader. Read extra bytes to make up
+		// for manually removing CRs afterwards.
+		expectedBuf := make([]byte, tc.BytesToRead+numCRs)
+		expectedN, expectedErr := strings.NewReader(tc.Input).Read(expectedBuf)
+
+		// Manually remove CRs from the string read from the strings.Reader.
+		expectedStr := removeControlCharacters(string(expectedBuf))
+
+		// Copy the expected string into a BytesToRead-sized buffer, to
+		// ensure the sizes of the underlying buffers match.
+		expectedBuf = make([]byte, tc.BytesToRead)
+		copy(expectedBuf, expectedStr)
+
+		if !(tc.DifferentEOFBehavior && err == io.EOF) {
+			assert.Equal(t, expectedErr, err, tc.Name+": error")
+		}
+		assert.Equal(t, expectedBuf, buf, tc.Name+": string")
+		assert.Equal(t, expectedN-numCRs, n, tc.Name+": character count")
+	}
+}
+
+func countControlCharacters(s string) (count int) {
+	for _, r := range s {
+		if unicode.IsControl(r) {
+			count += 1
+		}
+	}
+
+	return count
+}
+
+func removeControlCharacters(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+}

--- a/learn/parse_http.go
+++ b/learn/parse_http.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"github.com/golang/protobuf/proto"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -16,6 +15,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/golang/protobuf/proto"
+
 	"github.com/andybalholm/brotli"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -23,13 +24,14 @@ import (
 	"golang.org/x/text/transform"
 	"gopkg.in/yaml.v2"
 
-	"github.com/akitasoftware/akita-cli/printer"
-	"github.com/akitasoftware/akita-cli/telemetry"
 	pb "github.com/akitasoftware/akita-ir/go/api_spec"
 	"github.com/akitasoftware/akita-libs/akinet"
 	"github.com/akitasoftware/akita-libs/memview"
 	"github.com/akitasoftware/akita-libs/spec_util"
 	"github.com/akitasoftware/akita-libs/spec_util/ir_hash"
+
+	"github.com/akitasoftware/akita-cli/printer"
+	"github.com/akitasoftware/akita-cli/telemetry"
 )
 
 var (
@@ -632,7 +634,7 @@ func parseMethodMeta(req *akinet.HTTPRequest) *pb.MethodMeta {
 
 func parseHTTPBodyJSON(stream io.Reader) (*pb.Data, error) {
 	var top interface{}
-	decoder := json.NewDecoder(stream)
+	decoder := json.NewDecoder(newStripControlCharactersReader(stream))
 	decoder.UseNumber()
 
 	err := decoder.Decode(&top)

--- a/learn/parse_http_test.go
+++ b/learn/parse_http_test.go
@@ -32,7 +32,7 @@ func init() {
 var testBodyDict = `
 {
   "name": "prince",
-  "name_with_escaped_CRLF": "prince\\r\\n",
+  "name_with_escaped_CRLF": "prince\r\n",
   "number_teeth": 9000,
   "dog": true,
   "canadian_social_insurance_number": "378734493671000",
@@ -65,7 +65,7 @@ func newTestBodySpec(statusCode int) *as.Data {
 func newTestBodySpecContentType(contentType string, statusCode int) *as.Data {
 	return newTestBodySpecFromStruct(statusCode, as.HTTPBody_JSON, contentType, map[string]*as.Data{
 		"name":                             dataFromPrimitive(spec_util.NewPrimitiveString("prince")),
-		"name_with_escaped_CRLF":           dataFromPrimitive(spec_util.NewPrimitiveString("prince\\r\\n")),
+		"name_with_escaped_CRLF":           dataFromPrimitive(spec_util.NewPrimitiveString("prince\r\n")),
 		"number_teeth":                     dataFromPrimitive(spec_util.NewPrimitiveInt64(9000)),
 		"dog":                              dataFromPrimitive(spec_util.NewPrimitiveBool(true)),
 		"canadian_social_insurance_number": dataFromPrimitive(annotateIfSensitiveForTest(true, spec_util.NewPrimitiveString("378734493671000"))),


### PR DESCRIPTION
The Go JSON parser rejects JSON strings that contain control characters (U+0000
- U+001F).  We'd like to be more permissive.  Rather than implementing our own parser, this PR adds a preprocessing step that removes unescaped control characters before invoking Go's JSON parser.