### PR TITLE
Make 'learn' an alias for 'apidump'

### DIFF
--- a/apidump/defaults.go
+++ b/apidump/defaults.go
@@ -1,0 +1,26 @@
+package apidump
+
+// Specifies default values for command-line parameters.
+const (
+	// Whether to send TCP and TLS reports to the back end.
+	//
+	// Invariant: if this is true, then so is DefaultParseTLSHandshakes.
+	DefaultCollectTCPAndTLSReports = false
+
+	// The name of the deployment.
+	DefaultDeployment = "default"
+
+	// Whether to enable parsing of TLS handshakes.
+	//
+	// Invariant: if this is false, then so is DefaultCollectTCPAndTLSReports.
+	DefaultParseTLSHandshakes = true
+
+	// How many requests to capture per minute.
+	DefaultRateLimit = 1000.0
+
+	// How long to wait after starting up before printing packet-capture statistics.
+	DefaultStatsLogDelay_seconds = 60
+
+	// How often to upload client telemetry.
+	DefaultTelemetryInterval_seconds = 5 * 60 // 5 minutes
+)

--- a/apidump/defaults.go
+++ b/apidump/defaults.go
@@ -1,5 +1,7 @@
 package apidump
 
+import "time"
+
 // Specifies default values for command-line parameters.
 const (
 	// Whether to send TCP and TLS reports to the back end.
@@ -23,4 +25,7 @@ const (
 
 	// How often to upload client telemetry.
 	DefaultTelemetryInterval_seconds = 5 * 60 // 5 minutes
+
+	// How often to rotate traces in the back end.
+	DefaultTraceRotateInterval = time.Hour
 )

--- a/cmd/internal/akiflag/ignore.go
+++ b/cmd/internal/akiflag/ignore.go
@@ -1,0 +1,49 @@
+package akiflag
+
+import (
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+// Convenience functions for creating legacy command-line flags whose values are
+// ignored.
+
+func IgnoreDurationFlags(fs *pflag.FlagSet, flagNames []string, usage string) {
+	var ignored time.Duration
+	for _, flagName := range flagNames {
+		fs.DurationVar(
+			&ignored,
+			flagName,
+			0,
+			usage,
+		)
+		fs.MarkDeprecated(flagName, "and is now ignored. Please remove this flag from your command.")
+	}
+}
+
+func IgnoreIntFlags(fs *pflag.FlagSet, flagNames []string, usage string) {
+	var ignored int
+	for _, flagName := range flagNames {
+		fs.IntVar(
+			&ignored,
+			flagName,
+			0,
+			usage,
+		)
+		fs.MarkDeprecated(flagName, "and is now ignored. Please remove this flag from your command.")
+	}
+}
+
+func IgnoreStringFlags(fs *pflag.FlagSet, flagNames []string, usage string) {
+	var ignored string
+	for _, flagName := range flagNames {
+		fs.StringVar(
+			&ignored,
+			flagName,
+			"",
+			usage,
+		)
+		fs.MarkDeprecated(flagName, "and is now ignored. Please remove this flag from your command.")
+	}
+}

--- a/cmd/internal/akiflag/rename.go
+++ b/cmd/internal/akiflag/rename.go
@@ -1,27 +1,29 @@
 package akiflag
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 )
 
 // Rename a flag by creating 2 flags that share the same variable:
-// - one that uses the old name but is hidden
+// - one that uses the old name but is deprecated
 // - one that uses the new name
 
 func RenameStringFlag(fs *pflag.FlagSet, flagVar *string, oldName, newName, defaultVal, usage string) {
 	fs.StringVar(flagVar, oldName, defaultVal, usage)
 	fs.StringVar(flagVar, newName, defaultVal, usage)
-	fs.MarkHidden(oldName)
+	fs.MarkDeprecated(oldName, fmt.Sprintf("use --%s instead.", newName))
 }
 
 func RenameStringSliceFlag(fs *pflag.FlagSet, flagVar *[]string, oldName, newName string, defaultVal []string, usage string) {
 	fs.StringSliceVar(flagVar, oldName, defaultVal, usage)
 	fs.StringSliceVar(flagVar, newName, defaultVal, usage)
-	fs.MarkHidden(oldName)
+	fs.MarkDeprecated(oldName, fmt.Sprintf("use --%s instead.", newName))
 }
 
 func RenameIntFlag(fs *pflag.FlagSet, flagVar *int, oldName, newName string, defaultVal int, usage string) {
 	fs.IntVar(flagVar, oldName, defaultVal, usage)
 	fs.IntVar(flagVar, newName, defaultVal, usage)
-	fs.MarkHidden(oldName)
+	fs.MarkDeprecated(oldName, fmt.Sprintf("use --%s instead.", newName))
 }

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -113,7 +113,7 @@ var Cmd = &cobra.Command{
 				}
 			} else {
 				if outFlag.AkitaURI.ObjectName == "" {
-					traceRotateInterval = time.Hour
+					traceRotateInterval = apidump.DefaultTraceRotateInterval
 				}
 			}
 		}

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -119,7 +119,7 @@ var Cmd = &cobra.Command{
 		}
 
 		if deploymentFlag == "" {
-			deploymentFlag = "default"
+			deploymentFlag = apidump.DefaultDeployment
 			if os.Getenv("AKITA_DEPLOYMENT") != "" {
 				deploymentFlag = os.Getenv("AKITA_DEPLOYMENT")
 			}
@@ -195,13 +195,15 @@ func init() {
 		&serviceFlag,
 		"service",
 		"",
-		"Your Akita project. DEPRECATED, prefer --project.")
+		"Your Akita project.")
+	Cmd.Flags().MarkDeprecated("service", "use --project instead.")
 
 	Cmd.Flags().StringVar(
 		&serviceFlag,
 		"cluster",
 		"",
-		"Your Akita project. DEPRECATED, prefer --project.")
+		"Your Akita project.")
+	Cmd.Flags().MarkDeprecated("cluster", "use --project instead.")
 
 	Cmd.Flags().StringVar(
 		&filterFlag,
@@ -219,13 +221,14 @@ func init() {
 		&sampleRateFlag,
 		"sample-rate",
 		1.0,
-		"A number between [0.0, 1.0] to control sampling. DEPRECATED, prefer --rate-limit.",
+		"A number between [0.0, 1.0] to control sampling.",
 	)
+	Cmd.Flags().MarkDeprecated("sample-rate", "use --rate-limit instead.")
 
 	Cmd.Flags().Float64Var(
 		&rateLimitFlag,
 		"rate-limit",
-		1000.0,
+		apidump.DefaultRateLimit,
 		"Number of requests per minute to capture.",
 	)
 
@@ -241,6 +244,7 @@ func init() {
 		"append-by-tag",
 		false,
 		"Add to the most recent Akita trace with matching tag.")
+	Cmd.Flags().MarkDeprecated("append-by-tag", "and is no longer necessary. All traces in a project are now combined into a single model. Please remove this flag.")
 
 	Cmd.Flags().StringSliceVar(
 		&pathExclusionsFlag,
@@ -306,20 +310,21 @@ func init() {
 		&deploymentFlag,
 		"deployment",
 		"",
-		"Deployment name to use.  DEPRECATED, prefer creating separate projects for different deployment environments, e.g. 'my-project-prod' and 'my-project-staging'.",
+		"Deployment name to use.",
 	)
+	Cmd.Flags().MarkDeprecated("deployment", "create separate projects for different deployment environments instead. For example, 'my-project-prod' and 'my-project-staging'.")
 
 	Cmd.Flags().IntVar(
 		&statsLogDelay,
 		"stats-log-delay",
-		60,
+		apidump.DefaultStatsLogDelay_seconds,
 		"Print packet capture statistics after N seconds.",
 	)
 
 	Cmd.Flags().IntVar(
 		&telemetryInterval,
 		"telemetry-interval",
-		5*60, // 5 minutes
+		apidump.DefaultTelemetryInterval_seconds,
 		"Upload client telemetry every N seconds.",
 	)
 	Cmd.Flags().MarkHidden("telemetry-interval")
@@ -327,7 +332,7 @@ func init() {
 	Cmd.Flags().BoolVar(
 		&collectTCPAndTLSReports,
 		"report-tcp-and-tls",
-		false,
+		apidump.DefaultCollectTCPAndTLSReports,
 		"Collect TCP and TLS reports.",
 	)
 	Cmd.Flags().MarkHidden("report-tcp-and-tls")
@@ -335,7 +340,7 @@ func init() {
 	Cmd.Flags().BoolVar(
 		&parseTLSHandshakes,
 		"parse-tls-handshakes",
-		true,
+		apidump.DefaultParseTLSHandshakes,
 		"Parse TLS handshake packets.",
 	)
 	Cmd.Flags().MarkHidden("parse-tls-handshakes")

--- a/cmd/internal/apispec/cmd.go
+++ b/cmd/internal/apispec/cmd.go
@@ -33,7 +33,7 @@ func parseTime(s string) (time.Time, error) {
 }
 
 var Cmd = &cobra.Command{
-	Deprecated:   "API specs are created automatically in the Akita app.",
+	Deprecated:   "API models are created automatically in the Akita app.",
 	Use:          "apispec",
 	Short:        "Convert traces into an OpenAPI3 specification.",
 	SilenceUsage: true,

--- a/cmd/internal/learn/cmd.go
+++ b/cmd/internal/learn/cmd.go
@@ -3,25 +3,16 @@ package learn
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"path"
-	"strconv"
-	"strings"
 	"time"
 
-	randomdata "github.com/Pallinder/go-randomdata"
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/akita-libs/akiuri"
-	"github.com/akitasoftware/akita-libs/gitlab"
 	"github.com/akitasoftware/akita-libs/tags"
-	"github.com/akitasoftware/akita-libs/version_names"
 
 	"github.com/akitasoftware/akita-cli/apidump"
-	"github.com/akitasoftware/akita-cli/apispec"
 	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
 	"github.com/akitasoftware/akita-cli/cmd/internal/pluginloader"
 	"github.com/akitasoftware/akita-cli/location"
@@ -34,10 +25,10 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Deprecated:   "Prefer 'apidump' to capture traffic.  API specs are built automatically in the Akita app.",
+	Deprecated:   "please use 'apidump' to capture traffic instead. API models are now created automatically in the Akita app.",
 	Use:          "learn",
 	Short:        "Run learn mode monitor",
-	Long:         "Generate API specifications from network traffic with Akita Learn Mode!",
+	Long:         "Generate API models from network traffic",
 	SilenceUsage: true,
 	Args:         cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -56,13 +47,15 @@ func runLearnMode() error {
 		return errors.Wrap(err, "failed to load plugins")
 	}
 
-	// XXX Some of this input validation duplicates the input validation for `apispec` (and maybe `apidump`). We should refactor this.
-
-	// Determine project name and validate --out.
+	// Determine project name from --out.
 	var projectName string
 	if uri := outFlag.AkitaURI; uri == nil {
 		if serviceFlag == "" {
-			return errors.Errorf("must specify --project when --out is not an AkitaURI")
+			if outFlag.LocalPath == nil {
+				return errors.Errorf("must specify --project")
+			} else {
+				return errors.Errorf("must specify --project when --out is not an AkitaURI")
+			}
 		}
 		projectName = serviceFlag
 	} else {
@@ -71,82 +64,6 @@ func runLearnMode() error {
 		if serviceFlag != "" && serviceFlag != projectName {
 			return errors.Errorf("--project and --out cannot specify different projects")
 		}
-
-		// If an object type is provided, it must be Spec.
-		if uri.ObjectType != nil && !uri.ObjectType.IsSpec() {
-			return errors.Errorf("output AkitaURI must refer to a spec object")
-		}
-	}
-
-	// Resolve project name and get a learn client.
-	frontClient := rest.NewFrontClient(rest.Domain, clientID)
-	svc, err := util.GetServiceIDByName(frontClient, projectName)
-	if err != nil {
-		return errors.Wrapf(err, "failed to look up project %q", projectName)
-	}
-	learnClient := rest.NewLearnClient(rest.Domain, clientID, svc)
-
-	// If a spec name was given, check if the spec already exists.
-	if uri := outFlag.AkitaURI; uri != nil && uri.ObjectName != "" {
-		if _, err := util.ResolveSpecURI(learnClient, *uri); err == nil {
-			return errors.Errorf("spec %q already exists", uri)
-		} else {
-			var httpErr rest.HTTPError
-			if ok := errors.As(err, &httpErr); ok && httpErr.StatusCode != 404 {
-				return errors.Wrap(err, "failed to check whether output spec exists already")
-			}
-		}
-	}
-
-	// Support legacy --extend.
-	// Resolve the API spec ID or version label to learn session AkitaURIs.
-	var legacyExtendTraces []*akiuri.URI
-	if legacyExtendFlag != "" {
-		var specID akid.APISpecID
-		if err := akid.ParseIDAs(legacyExtendFlag, &specID); err != nil {
-			// The flag is a version label, resolve that.
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			v, err := learnClient.GetSpecVersion(ctx, legacyExtendFlag)
-			if err != nil {
-				return errors.Wrapf(err, "failed to resolve API spec version label %q", legacyExtendFlag)
-			}
-			specID = v.APISpecID
-		}
-
-		var lrns []akid.LearnSessionID
-		{
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			spec, err := learnClient.GetSpec(ctx, specID, rest.GetSpecOptions{})
-			if err != nil {
-				return errors.Wrapf(err, "failed to look up extend spec %q", akid.String(specID))
-			}
-
-			if len(spec.LearnSessionIDs) > 0 {
-				lrns = spec.LearnSessionIDs
-			} else if spec.LearnSessionID != nil {
-				lrns = append(lrns, *spec.LearnSessionID)
-			} else {
-				return errors.Errorf("extend spec has no learn session: %q", akid.String(specID))
-			}
-		}
-
-		// Resolve learn session ID to name.
-		for _, lrn := range lrns {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			session, err := learnClient.GetLearnSession(ctx, svc, lrn)
-			if err != nil {
-				return errors.Wrapf(err, "failed to look up extend session %q", akid.String(lrn))
-			}
-
-			legacyExtendTraces = append(legacyExtendTraces, &akiuri.URI{
-				ServiceName: projectName,
-				ObjectType:  akiuri.TRACE.Ptr(),
-				ObjectName:  session.Name,
-			})
-		}
 	}
 
 	tagsMap, err := util.ParseTagsAndWarn(tagsFlag)
@@ -154,37 +71,9 @@ func runLearnMode() error {
 		return err
 	}
 
-	// Check for reserved versions.
-	for _, version := range versionsFlag {
-		if version_names.IsReservedVersionName(version) {
-			return errors.Errorf("'%s' is an Akita-reserved version", version)
-		}
-	}
-
-	// Populate legacy github integration tag.
-	// See https://github.com/akitasoftware/superstar/blob/93c546b6522453c277507696d1fefd56d52d6c55/services/witness_processor/github/util.go#L36
-	if legacyGitHubURLFlag != "" {
-		githubURL, err := url.Parse(legacyGitHubURLFlag)
-		if err != nil {
-			return errors.Wrap(err, "failed to parse github URL flag")
-		}
-		tagsMap[tags.XAkitaGitHubPRURL] = path.Join(githubURL.Path, "pull", strconv.Itoa(githubPRFlag))
-
-		// Tag as coming from CI.
-		tagsMap[tags.XAkitaSource] = tags.CISource
-	}
-	// Other tags are set up in apidump and/or apispec
-	// TODO: completely refactor so tags are only set here, or
-	// internal/apidump/cmd, or internal/apispec/cmd, instead
-	// of doing it twice in this case.
-
-	traceURI, err := runAPIDump(clientID, projectName, tagsMap, plugins)
+	_, err = runAPIDump(clientID, projectName, tagsMap, plugins)
 	if err != nil {
 		return errors.Wrap(err, "failed to create trace")
-	}
-
-	if err := runAPISpec(clientID, projectName, traceURI, tagsMap, legacyExtendTraces, plugins); err != nil {
-		return errors.Wrap(err, "failed to create spec")
 	}
 
 	return nil
@@ -250,19 +139,9 @@ func runAPIDump(clientID akid.ClientID, projectName string, tagsMap map[tags.Key
 			ObjectName:  session.Name,
 		}
 	} else {
-		// Create a new trace.
-		var traceName string
-		uid := uuid.New()
-		traceName = strings.Join([]string{
-			randomdata.Adjective(),
-			randomdata.Noun(),
-			uid.String()[0:8],
-		}, "-")
-
 		traceOut.AkitaURI = &akiuri.URI{
 			ServiceName: projectName,
 			ObjectType:  akiuri.TRACE.Ptr(),
-			ObjectName:  traceName,
 		}
 	}
 
@@ -285,89 +164,28 @@ func runAPIDump(clientID akid.ClientID, projectName string, tagsMap map[tags.Key
 
 	// Create a trace on the cloud.
 	args := apidump.Args{
-		ClientID:           clientID,
-		Domain:             rest.Domain,
-		Out:                traceOut,
-		Interfaces:         interfacesFlag,
-		Filter:             packetFilter,
-		Tags:               tagsMap,
-		SampleRate:         sampleRate,
-		WitnessesPerMinute: rateLimitFlag,
-		PathExclusions:     pathExclusionsFlag,
-		HostExclusions:     hostExclusionsFlag,
-		PathAllowlist:      pathAllowlistFlag,
-		HostAllowlist:      hostAllowlistFlag,
-		ExecCommand:        execCommandFlag,
-		ExecCommandUser:    execCommandUserFlag,
-		Plugins:            plugins,
-		StatsLogDelay:      statsLogDelay,
+		ClientID:                clientID,
+		Domain:                  rest.Domain,
+		Out:                     traceOut,
+		Interfaces:              interfacesFlag,
+		Filter:                  packetFilter,
+		Tags:                    tagsMap,
+		SampleRate:              sampleRate,
+		WitnessesPerMinute:      rateLimitFlag,
+		PathExclusions:          pathExclusionsFlag,
+		HostExclusions:          hostExclusionsFlag,
+		PathAllowlist:           pathAllowlistFlag,
+		HostAllowlist:           hostAllowlistFlag,
+		ExecCommand:             execCommandFlag,
+		ExecCommandUser:         execCommandUserFlag,
+		Plugins:                 plugins,
+		LearnSessionLifetime:    time.Hour,
+		Deployment:              apidump.DefaultDeployment,
+		StatsLogDelay:           statsLogDelay,
+		TelemetryInterval:       apidump.DefaultTelemetryInterval_seconds,
+		CollectTCPAndTLSReports: apidump.DefaultCollectTCPAndTLSReports,
+		ParseTLSHandshakes:      apidump.DefaultParseTLSHandshakes,
 	}
 
 	return traceOut.AkitaURI, apidump.Run(args)
-}
-
-func runAPISpec(clientID akid.ClientID, projectName string, traceURI *akiuri.URI, tagsMap map[tags.Key]string, legacyExtendTraces []*akiuri.URI, plugins []plugin.AkitaPlugin) error {
-	githubRepo, err := getGitHubRepo()
-	if err != nil {
-		return err
-	}
-
-	traces := []location.Location{location.Location{AkitaURI: traceURI}}
-	for _, et := range legacyExtendTraces {
-		traces = append(traces, location.Location{AkitaURI: et})
-	}
-
-	var gitlabMR *gitlab.MRInfo
-	if gitlabProjectFlag != "" {
-		gitlabMR = &gitlab.MRInfo{
-			Project: gitlabProjectFlag,
-			IID:     gitlabMRFlag,
-			Branch:  gitlabBranchFlag,
-			Commit:  gitlabCommitFlag,
-		}
-	}
-
-	args := apispec.Args{
-		ClientID:       clientID,
-		Domain:         rest.Domain,
-		Traces:         traces,
-		Out:            outFlag,
-		Service:        projectName,
-		Format:         "yaml",
-		Tags:           tagsMap,
-		Versions:       versionsFlag,
-		PathParams:     pathParamsFlag,
-		PathExclusions: pathExclusionsFlag,
-
-		Plugins: plugins,
-
-		GitHubRepo:   githubRepo,
-		GitHubBranch: githubBranchFlag,
-		GitHubCommit: githubCommitFlag,
-		GitHubPR:     githubPRFlag,
-
-		GitLabMR: gitlabMR,
-	}
-
-	return apispec.Run(args)
-}
-
-// Reconcile legacy --github_repo_url flag with new --github-repo flag.
-func getGitHubRepo() (string, error) {
-	if githubRepoFlag != "" {
-		return githubRepoFlag, nil
-	} else if legacyGitHubURLFlag != "" {
-		u, err := url.Parse(legacyGitHubURLFlag)
-		if err != nil {
-			return "", errors.Wrap(err, "failed to parse GitHub repo URL")
-		}
-
-		// GitHub URL should look like https://github.com/akitasoftware/superstar
-		parts := strings.Split(u.Path, "/")
-		if len(parts) < 2 {
-			return "", errors.Errorf("failed to get repo owner and name from GitHub repo URL")
-		}
-		return strings.Join(parts[0:2], "/"), nil
-	}
-	return "", nil
 }

--- a/cmd/internal/learn/cmd.go
+++ b/cmd/internal/learn/cmd.go
@@ -179,7 +179,7 @@ func runAPIDump(clientID akid.ClientID, projectName string, tagsMap map[tags.Key
 		ExecCommand:             execCommandFlag,
 		ExecCommandUser:         execCommandUserFlag,
 		Plugins:                 plugins,
-		LearnSessionLifetime:    time.Hour,
+		LearnSessionLifetime:    apidump.DefaultTraceRotateInterval,
 		Deployment:              apidump.DefaultDeployment,
 		StatsLogDelay:           statsLogDelay,
 		TelemetryInterval:       apidump.DefaultTelemetryInterval_seconds,


### PR DESCRIPTION
We now also use Cobra's built-in facility for deprecating flags.

Factored command-line defaults for 'apidump' into symbolic constants, so they can be shared with 'learn'.

Removed auto-generation of CI-specific Akita-internal tags on learn sessions. No recent models have this tag, so it's not being used.