### PR TITLE
Refactor batching in backend collector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20221101223658-d0dd96f228c7
+	github.com/akitasoftware/akita-libs v0.0.0-20221105062113-b6e3449348d0
 	github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20221105062113-b6e3449348d0
+	github.com/akitasoftware/akita-libs v0.0.0-20221107222856-a90a0970b256
 	github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/akitasoftware/akita-ir v0.0.0-20211020161529-944af4d11d6e/go.mod h1:W
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe h1:0BeBDjLDFPwv2bkk6YuRAPf1r6U4Wby98NHI9+Lddvs=
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-libs v0.0.0-20211020162041-fe02207174fb/go.mod h1:YLFCjhwQ0ZFfYWSUD2c9KYKEeBn+R+Cz+A5SitXvJz8=
-github.com/akitasoftware/akita-libs v0.0.0-20221101223658-d0dd96f228c7 h1:CxMCPOaTpDYk/R8O2tROPRKJ0hzowD37ImZxOS1ozsQ=
-github.com/akitasoftware/akita-libs v0.0.0-20221101223658-d0dd96f228c7/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
+github.com/akitasoftware/akita-libs v0.0.0-20221105062113-b6e3449348d0 h1:UnpMXzX1ZtAgNIQ17rPnmSevhh/+CZvNQeiNc8JqMM8=
+github.com/akitasoftware/akita-libs v0.0.0-20221105062113-b6e3449348d0/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/akitasoftware/akita-ir v0.0.0-20211020161529-944af4d11d6e/go.mod h1:W
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe h1:0BeBDjLDFPwv2bkk6YuRAPf1r6U4Wby98NHI9+Lddvs=
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-libs v0.0.0-20211020162041-fe02207174fb/go.mod h1:YLFCjhwQ0ZFfYWSUD2c9KYKEeBn+R+Cz+A5SitXvJz8=
-github.com/akitasoftware/akita-libs v0.0.0-20221105062113-b6e3449348d0 h1:UnpMXzX1ZtAgNIQ17rPnmSevhh/+CZvNQeiNc8JqMM8=
-github.com/akitasoftware/akita-libs v0.0.0-20221105062113-b6e3449348d0/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
+github.com/akitasoftware/akita-libs v0.0.0-20221107222856-a90a0970b256 h1:vbeTOKy9t9qcRZ04F8NjhDejX2XxhIMtkrmxQkerGOI=
+github.com/akitasoftware/akita-libs v0.0.0-20221107222856-a90a0970b256/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -1,11 +1,8 @@
 package trace
 
 import (
-	"context"
 	"encoding/base64"
 	"net"
-	"net/http"
-	"reflect"
 	"sync"
 	"time"
 
@@ -34,7 +31,7 @@ const (
 	pairCacheCleanupInterval = 30 * time.Second
 
 	// Max size per upload batch.
-	uploadBatchMaxSize = 120
+	uploadBatchMaxSize_bytes = 60_000_000 // 60 MB
 
 	// How often to flush the upload batch.
 	uploadBatchFlushDuration = 30 * time.Second
@@ -129,7 +126,7 @@ type BackendCollector struct {
 	pairCache sync.Map
 
 	// Batch of reports (witnesses, TCP-connection reports, etc.) pending upload.
-	uploadReportBatch *batcher.InMemory
+	uploadReportBatch *batcher.InMemory[rawReport, *reportBuffer]
 
 	// Channel controlling periodic cache flush
 	flushDone chan struct{}
@@ -153,10 +150,10 @@ func NewBackendCollector(svc akid.ServiceID,
 		plugins:        plugins,
 	}
 
-	col.uploadReportBatch = batcher.NewInMemory(
-		col.uploadReports,
-		uploadBatchMaxSize,
-		uploadBatchFlushDuration)
+	col.uploadReportBatch = batcher.NewInMemory[rawReport](
+		newReportBuffer(col, uploadBatchMaxSize_bytes),
+		uploadBatchFlushDuration,
+	)
 
 	go col.periodicFlush()
 
@@ -235,28 +232,32 @@ func (c *BackendCollector) processTCPConnection(packet akinet.ParsedNetworkTraff
 		srcAddr, srcPort, dstAddr, dstPort = dstAddr, dstPort, srcAddr, srcPort
 	}
 
-	c.uploadReportBatch.Add(&kgxapi.TCPConnectionReport{
-		ID:             tcp.ConnectionID,
-		SrcAddr:        srcAddr,
-		SrcPort:        uint16(srcPort),
-		DestAddr:       dstAddr,
-		DestPort:       uint16(dstPort),
-		FirstObserved:  packet.ObservationTime,
-		LastObserved:   packet.FinalPacketTime,
-		InitiatorKnown: tcp.Initiator != akinet.UnknownTCPConnectionInitiator,
-		EndState:       tcp.EndState,
+	c.uploadReportBatch.Add(rawReport{
+		TCPReport: &kgxapi.TCPConnectionReport{
+			ID:             tcp.ConnectionID,
+			SrcAddr:        srcAddr,
+			SrcPort:        uint16(srcPort),
+			DestAddr:       dstAddr,
+			DestPort:       uint16(dstPort),
+			FirstObserved:  packet.ObservationTime,
+			LastObserved:   packet.FinalPacketTime,
+			InitiatorKnown: tcp.Initiator != akinet.UnknownTCPConnectionInitiator,
+			EndState:       tcp.EndState,
+		},
 	})
 	return nil
 }
 
 func (c *BackendCollector) processTLSHandshake(tls akinet.TLSHandshakeMetadata) error {
-	c.uploadReportBatch.Add(&kgxapi.TLSHandshakeReport{
-		ID:                      tls.ConnectionID,
-		Version:                 tls.Version,
-		SNIHostname:             tls.SNIHostname,
-		SupportedProtocols:      tls.SupportedProtocols,
-		SelectedProtocol:        tls.SelectedProtocol,
-		SubjectAlternativeNames: tls.SubjectAlternativeNames,
+	c.uploadReportBatch.Add(rawReport{
+		TLSHandshakeReport: &kgxapi.TLSHandshakeReport{
+			ID:                      tls.ConnectionID,
+			Version:                 tls.Version,
+			SNIHostname:             tls.SNIHostname,
+			SupportedProtocols:      tls.SupportedProtocols,
+			SelectedProtocol:        tls.SelectedProtocol,
+			SubjectAlternativeNames: tls.SubjectAlternativeNames,
+		},
 	})
 	return nil
 }
@@ -273,7 +274,9 @@ func (c *BackendCollector) queueUpload(w *witnessWithInfo) {
 	// Obfuscate the original value so type inference engine can use it on the
 	// backend without revealing the actual value.
 	obfuscate(w.witness.GetMethod())
-	c.uploadReportBatch.Add(w)
+	c.uploadReportBatch.Add(rawReport{
+		Witness: w,
+	})
 }
 
 func (c *BackendCollector) Close() error {
@@ -295,58 +298,10 @@ func (c *BackendCollector) getLearnSession() akid.LearnSessionID {
 	return c.learnSessionID
 }
 
-func (c *BackendCollector) uploadReports(in []interface{}) {
-	witnesses := make([]*kgxapi.WitnessReport, 0, len(in))
-	tcpConnections := make([]*kgxapi.TCPConnectionReport, 0, len(in))
-	tlsHandshakes := make([]*kgxapi.TLSHandshakeReport, 0, len(in))
-	for _, i := range in {
-		switch i := i.(type) {
-		case *witnessWithInfo:
-			r, err := i.toReport()
-			if err == nil {
-				witnesses = append(witnesses, r)
-			} else {
-				printer.Warningf("Failed to convert witness to report: %v\n", err)
-			}
-
-		case *kgxapi.TCPConnectionReport:
-			tcpConnections = append(tcpConnections, i)
-
-		case *kgxapi.TLSHandshakeReport:
-			tlsHandshakes = append(tlsHandshakes, i)
-
-		default:
-			printer.Warningf("Ignoring unknown report type %s. (This is an internal error.)\n", reflect.TypeOf(i).Name())
-		}
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	upload := kgxapi.UploadReportsRequest{
-		Witnesses:      witnesses,
-		TCPConnections: tcpConnections,
-		TLSHandshakes:  tlsHandshakes,
-	}
-	err := c.learnClient.AsyncReportsUpload(ctx, c.getLearnSession(), &upload)
-	if err != nil {
-		switch e := err.(type) {
-		case rest.HTTPError:
-			if e.StatusCode == http.StatusTooManyRequests {
-				// XXX Not all commands that call into this code have a --rate-limit
-				// option.
-				err = errors.Wrap(err, "your witness uploads are being throttled. Akita will generate partial results. Try reducing the --rate-limit value to avoid this.")
-			}
-		}
-		printer.Warningf("Failed to upload to Akita Cloud: %v\n", err)
-	}
-	printer.Debugf("Uploaded %d witnesses and %d TCP connection reports\n", len(witnesses), len(tcpConnections))
-}
-
 func (c *BackendCollector) periodicFlush() {
 	ticker := time.NewTicker(pairCacheCleanupInterval)
 
-	for true {
+	for {
 		select {
 		case <-ticker.C:
 			c.flushPairCache(time.Now().Add(-1 * pairCacheExpiration))

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -126,7 +126,7 @@ type BackendCollector struct {
 	pairCache sync.Map
 
 	// Batch of reports (witnesses, TCP-connection reports, etc.) pending upload.
-	uploadReportBatch *batcher.InMemory[rawReport, *reportBuffer]
+	uploadReportBatch *batcher.InMemory[rawReport]
 
 	// Channel controlling periodic cache flush
 	flushDone chan struct{}

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -97,7 +97,7 @@ func TestObfuscate(t *testing.T) {
 	assert.NoError(t, col.Close())
 
 	expectedWitnesses := []*pb.Witness{
-		&pb.Witness{
+		{
 			Method: &pb.Method{
 				Id: &pb.MethodID{
 					ApiType: pb.ApiType_HTTP_REST,
@@ -298,9 +298,8 @@ func TestMultipleInterfaces(t *testing.T) {
 // Demonstrate that periodic flush exits
 func TestFlushExit(t *testing.T) {
 	b := &BackendCollector{}
-	b.uploadReportBatch = batcher.NewInMemory(
-		func(_ []interface{}) {},
-		uploadBatchMaxSize,
+	b.uploadReportBatch = batcher.NewInMemory[rawReport](
+		newReportBuffer(b, uploadBatchMaxSize_bytes),
 		uploadBatchFlushDuration,
 	)
 	b.flushDone = make(chan struct{})

--- a/trace/report_buffer.go
+++ b/trace/report_buffer.go
@@ -1,0 +1,91 @@
+package trace
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/akitasoftware/akita-cli/printer"
+	"github.com/akitasoftware/akita-cli/rest"
+	kgxapi "github.com/akitasoftware/akita-libs/api_schema"
+	"github.com/akitasoftware/akita-libs/batcher"
+	"github.com/pkg/errors"
+)
+
+// A report that hasn't yet been processed for upload.
+type rawReport struct {
+	Witness            *witnessWithInfo
+	TCPReport          *kgxapi.TCPConnectionReport
+	TLSHandshakeReport *kgxapi.TLSHandshakeReport
+}
+
+type reportBuffer struct {
+	collector *BackendCollector
+	kgxapi.UploadReportsRequest
+	maxSize_bytes int
+}
+
+var _ batcher.Buffer[rawReport] = (*reportBuffer)(nil)
+
+func newReportBuffer(collector *BackendCollector, maxSize_bytes int) *reportBuffer {
+	return &reportBuffer{
+		collector:     collector,
+		maxSize_bytes: maxSize_bytes,
+	}
+}
+
+func (buf *reportBuffer) Add(raw rawReport) (bool, error) {
+	if raw.Witness != nil {
+		witnessReport, err := raw.Witness.toReport()
+		if err != nil {
+			printer.Warningf("Failed to convert witness to report: %v\n", err)
+		} else {
+			buf.UploadReportsRequest.AddWitnessReport(witnessReport)
+		}
+	}
+
+	if raw.TCPReport != nil {
+		buf.UploadReportsRequest.AddTCPConnectionReport(raw.TCPReport)
+	}
+
+	if raw.TLSHandshakeReport != nil {
+		buf.UploadReportsRequest.AddTLSHandshakeReport(raw.TLSHandshakeReport)
+	}
+
+	return buf.isFull(), nil
+}
+
+func (buf *reportBuffer) Flush() error {
+	if buf.UploadReportsRequest.IsEmpty() {
+		return nil
+	}
+
+	// Ensure the buffer is empty when we return.
+	defer buf.UploadReportsRequest.Clear()
+
+	// Upload to the back end.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := buf.collector.learnClient.AsyncReportsUpload(ctx, buf.collector.getLearnSession(), &buf.UploadReportsRequest)
+	if err != nil {
+		switch e := err.(type) {
+		case rest.HTTPError:
+			if e.StatusCode == http.StatusTooManyRequests {
+				// XXX Not all commands that call into this code have a --rate-limit
+				// option.
+				err = errors.Wrap(err, "your witness uploads are being throttled. Akita will generate partial results. Try reducing the --rate-limit value to avoid this.")
+			}
+		}
+
+		printer.Warningf("Failed to upload to Akita Cloud: %v\n", err)
+	}
+	printer.Debugf("Uploaded %d witnesses, %d TCP connection reports, and %d TLS handshake reports\n", len(buf.Witnesses), len(buf.TCPConnections), len(buf.TLSHandshakes))
+
+	return nil
+}
+
+// Determines whether the buffer is at or beyond capacity.
+func (buf *reportBuffer) isFull() bool {
+	return buf.UploadReportsRequest.SizeInBytes() >= buf.maxSize_bytes
+}


### PR DESCRIPTION
Processing of witnesses now occurs when they are enqueued for upload. Additionally, the size of the buffer is now based on memory usage, rather than number of items.