### PR TITLE
Move default definitions

### DIFF
--- a/apispec/defaults.go
+++ b/apispec/defaults.go
@@ -1,4 +1,4 @@
-package apidump
+package apispec
 
 import "time"
 

--- a/apispec/run.go
+++ b/apispec/run.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
-	"github.com/akitasoftware/akita-cli/apidump"
 	"github.com/akitasoftware/akita-cli/ci"
 	"github.com/akitasoftware/akita-cli/deployment"
 	"github.com/akitasoftware/akita-cli/location"
@@ -465,7 +464,7 @@ func uploadLocalTraces(domain string, clientID akid.ClientID, svc akid.ServiceID
 			learnClient,
 			// The apispec command is deprecated. Not bothering with configurability
 			// here.
-			optionals.Some(apidump.DefaultMaxWitnessSize_bytes),
+			optionals.Some(DefaultMaxWitnessSize_bytes),
 			plugins,
 		)
 		if !includeTrackers {

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/akitasoftware/akita-cli/apidump"
+	"github.com/akitasoftware/akita-cli/apispec"
 	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
 	"github.com/akitasoftware/akita-cli/cmd/internal/pluginloader"
 	"github.com/akitasoftware/akita-cli/location"
@@ -114,13 +115,13 @@ var Cmd = &cobra.Command{
 				}
 			} else {
 				if outFlag.AkitaURI.ObjectName == "" {
-					traceRotateInterval = apidump.DefaultTraceRotateInterval
+					traceRotateInterval = apispec.DefaultTraceRotateInterval
 				}
 			}
 		}
 
 		if deploymentFlag == "" {
-			deploymentFlag = apidump.DefaultDeployment
+			deploymentFlag = apispec.DefaultDeployment
 			if os.Getenv("AKITA_DEPLOYMENT") != "" {
 				deploymentFlag = os.Getenv("AKITA_DEPLOYMENT")
 			}
@@ -230,7 +231,7 @@ func init() {
 	Cmd.Flags().Float64Var(
 		&rateLimitFlag,
 		"rate-limit",
-		apidump.DefaultRateLimit,
+		apispec.DefaultRateLimit,
 		"Number of requests per minute to capture.",
 	)
 
@@ -319,14 +320,14 @@ func init() {
 	Cmd.Flags().IntVar(
 		&statsLogDelay,
 		"stats-log-delay",
-		apidump.DefaultStatsLogDelay_seconds,
+		apispec.DefaultStatsLogDelay_seconds,
 		"Print packet capture statistics after N seconds.",
 	)
 
 	Cmd.Flags().IntVar(
 		&telemetryInterval,
 		"telemetry-interval",
-		apidump.DefaultTelemetryInterval_seconds,
+		apispec.DefaultTelemetryInterval_seconds,
 		"Upload client telemetry every N seconds.",
 	)
 	Cmd.Flags().MarkHidden("telemetry-interval")
@@ -334,7 +335,7 @@ func init() {
 	Cmd.Flags().BoolVar(
 		&collectTCPAndTLSReports,
 		"report-tcp-and-tls",
-		apidump.DefaultCollectTCPAndTLSReports,
+		apispec.DefaultCollectTCPAndTLSReports,
 		"Collect TCP and TLS reports.",
 	)
 	Cmd.Flags().MarkHidden("report-tcp-and-tls")
@@ -342,7 +343,7 @@ func init() {
 	Cmd.Flags().BoolVar(
 		&parseTLSHandshakes,
 		"parse-tls-handshakes",
-		apidump.DefaultParseTLSHandshakes,
+		apispec.DefaultParseTLSHandshakes,
 		"Parse TLS handshake packets.",
 	)
 	Cmd.Flags().MarkHidden("parse-tls-handshakes")
@@ -350,7 +351,7 @@ func init() {
 	Cmd.Flags().IntVar(
 		&maxWitnessSize_bytes,
 		"max-witness-size-bytes",
-		apidump.DefaultMaxWitnessSize_bytes,
+		apispec.DefaultMaxWitnessSize_bytes,
 		"Don't send witnesses larger than this.",
 	)
 	Cmd.Flags().MarkHidden("max-witness-size-bytes")

--- a/cmd/internal/learn/cmd.go
+++ b/cmd/internal/learn/cmd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/akitasoftware/akita-libs/tags"
 
 	"github.com/akitasoftware/akita-cli/apidump"
+	"github.com/akitasoftware/akita-cli/apispec"
 	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
 	"github.com/akitasoftware/akita-cli/cmd/internal/pluginloader"
 	"github.com/akitasoftware/akita-cli/location"
@@ -179,13 +180,13 @@ func runAPIDump(clientID akid.ClientID, projectName string, tagsMap map[tags.Key
 		ExecCommand:             execCommandFlag,
 		ExecCommandUser:         execCommandUserFlag,
 		Plugins:                 plugins,
-		LearnSessionLifetime:    apidump.DefaultTraceRotateInterval,
-		Deployment:              apidump.DefaultDeployment,
+		LearnSessionLifetime:    apispec.DefaultTraceRotateInterval,
+		Deployment:              apispec.DefaultDeployment,
 		StatsLogDelay:           statsLogDelay,
-		TelemetryInterval:       apidump.DefaultTelemetryInterval_seconds,
-		CollectTCPAndTLSReports: apidump.DefaultCollectTCPAndTLSReports,
-		ParseTLSHandshakes:      apidump.DefaultParseTLSHandshakes,
-		MaxWitnessSize_bytes:    apidump.DefaultMaxWitnessSize_bytes,
+		TelemetryInterval:       apispec.DefaultTelemetryInterval_seconds,
+		CollectTCPAndTLSReports: apispec.DefaultCollectTCPAndTLSReports,
+		ParseTLSHandshakes:      apispec.DefaultParseTLSHandshakes,
+		MaxWitnessSize_bytes:    apispec.DefaultMaxWitnessSize_bytes,
 	}
 
 	return traceOut.AkitaURI, apidump.Run(args)

--- a/cmd/internal/learn/flags.go
+++ b/cmd/internal/learn/flags.go
@@ -1,7 +1,7 @@
 package learn
 
 import (
-	"github.com/akitasoftware/akita-cli/apidump"
+	"github.com/akitasoftware/akita-cli/apispec"
 	"github.com/akitasoftware/akita-cli/cmd/internal/akiflag"
 	"github.com/akitasoftware/akita-cli/location"
 )
@@ -126,7 +126,7 @@ You may specify multiple interfaces by using a comma-separated list (e.g.
 	Cmd.Flags().Float64Var(
 		&rateLimitFlag,
 		"rate-limit",
-		apidump.DefaultRateLimit,
+		apispec.DefaultRateLimit,
 		"Number of requests per minute to capture.",
 	)
 
@@ -167,7 +167,7 @@ You may specify multiple interfaces by using a comma-separated list (e.g.
 	Cmd.Flags().IntVar(
 		&statsLogDelay,
 		"stats-log-delay",
-		apidump.DefaultStatsLogDelay_seconds,
+		apispec.DefaultStatsLogDelay_seconds,
 		"Print packet capture statistics after N seconds.",
 	)
 	// GitHub integration flags.

--- a/daemon/internal/cloud_client/cloud_client.go
+++ b/daemon/internal/cloud_client/cloud_client.go
@@ -3,7 +3,6 @@ package cloud_client
 import (
 	"fmt"
 
-	"github.com/akitasoftware/akita-cli/apidump"
 	"github.com/akitasoftware/akita-cli/apispec"
 	"github.com/akitasoftware/akita-cli/plugin"
 	"github.com/akitasoftware/akita-cli/printer"
@@ -160,7 +159,7 @@ func collectTraces(traceEventChannel <-chan *TraceEvent, learnClient rest.LearnC
 		loggingOptions.TraceID,
 		learnClient,
 		// TODO Make this configurable.
-		optionals.Some(apidump.DefaultMaxWitnessSize_bytes),
+		optionals.Some(apispec.DefaultMaxWitnessSize_bytes),
 		plugins,
 	)
 	collector = &trace.PacketCountCollector{

--- a/upload/run.go
+++ b/upload/run.go
@@ -13,7 +13,6 @@ import (
 	"github.com/akitasoftware/akita-libs/tags"
 	"github.com/akitasoftware/go-utils/optionals"
 
-	"github.com/akitasoftware/akita-cli/apidump"
 	"github.com/akitasoftware/akita-cli/apispec"
 	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-cli/rest"
@@ -133,7 +132,7 @@ func uploadTraces(learnClient rest.LearnClient, args Args, serviceID akid.Servic
 		learnClient,
 		// The upload command is deprecated. Not bothering with configurability
 		// here.
-		optionals.Some(apidump.DefaultMaxWitnessSize_bytes),
+		optionals.Some(apispec.DefaultMaxWitnessSize_bytes),
 		args.Plugins,
 	)
 	defer inboundCollector.Close()


### PR DESCRIPTION
Moved the definitions of default command-line parameter values out of `apidump` and into `apispec`, to avoid having `apispec` depend on `apidump`. This allows client code to import `apispec` without having to also pull in pcap.