### PR TITLE
Detect when packet capture fails from architecture mismatch

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -20,6 +20,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
+	"github.com/akitasoftware/akita-libs/akid"
+	"github.com/akitasoftware/akita-libs/akiuri"
+	"github.com/akitasoftware/akita-libs/tags"
+
 	"github.com/akitasoftware/akita-cli/ci"
 	"github.com/akitasoftware/akita-cli/deployment"
 	"github.com/akitasoftware/akita-cli/location"
@@ -32,9 +36,6 @@ import (
 	"github.com/akitasoftware/akita-cli/tls_conn_tracker"
 	"github.com/akitasoftware/akita-cli/trace"
 	"github.com/akitasoftware/akita-cli/util"
-	"github.com/akitasoftware/akita-libs/akid"
-	"github.com/akitasoftware/akita-libs/akiuri"
-	"github.com/akitasoftware/akita-libs/tags"
 )
 
 // TODO(kku): make pcap timings more robust (e.g. inject a sentinel packet to
@@ -431,7 +432,7 @@ func (a *apidump) Run() error {
 	// Get the interfaces to listen on.
 	interfaces, err := getEligibleInterfaces(args.Interfaces)
 	if err != nil {
-		a.SendErrorTelemetry(api_schema.ApidumpError_PCAPPermission, err)
+		a.SendErrorTelemetry(GetErrorTypeWithDefault(err, api_schema.ApidumpError_PCAPInterfaceOther), err)
 		return errors.Wrap(err, "No network interfaces could be used")
 	}
 

--- a/apidump/error.go
+++ b/apidump/error.go
@@ -1,0 +1,46 @@
+package apidump
+
+import (
+	"github.com/akitasoftware/akita-libs/api_schema"
+	"github.com/pkg/errors"
+)
+
+type ApidumpError struct {
+	err error
+
+	// Type of error to be reported as part of error telemetry.
+	errType api_schema.ApidumpErrorType
+}
+
+func NewApidumpError(errType api_schema.ApidumpErrorType, msg string) ApidumpError {
+	return ApidumpError{
+		err:     errors.New(msg),
+		errType: errType,
+	}
+}
+
+func NewApidumpErrorf(errType api_schema.ApidumpErrorType, format string, args ...interface{}) ApidumpError {
+	return ApidumpError{
+		err:     errors.Errorf(format, args...),
+		errType: errType,
+	}
+}
+
+func (e ApidumpError) Error() string {
+	return e.err.Error()
+}
+
+// Returns the error type if err contains an ApidumpError, or ApidumpError_Other
+// otherwise.
+func GetErrorType(err error) api_schema.ApidumpErrorType {
+	return GetErrorTypeWithDefault(err, api_schema.ApidumpError_Other)
+}
+
+// Returns the error type if err contains an ApidumpError, or def otherwise.
+func GetErrorTypeWithDefault(err error, def api_schema.ApidumpErrorType) api_schema.ApidumpErrorType {
+	var apidumpErr ApidumpError
+	if ok := errors.As(err, &apidumpErr); ok {
+		return apidumpErr.errType
+	}
+	return def
+}

--- a/apidump/error_test.go
+++ b/apidump/error_test.go
@@ -1,0 +1,57 @@
+package apidump
+
+import (
+	"testing"
+
+	"github.com/akitasoftware/akita-libs/api_schema"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewApidumpError(t *testing.T) {
+	err := NewApidumpError(api_schema.ApidumpError_PCAPPermission, "test")
+	assert.Error(t, err)
+	assert.Equal(t, api_schema.ApidumpError_PCAPPermission, GetErrorType(err))
+	assert.Equal(t, err.Error(), "test")
+}
+
+func TestNewApidumpErrorf(t *testing.T) {
+	err := NewApidumpErrorf(api_schema.ApidumpError_PCAPPermission, "test %d", 1)
+	assert.Error(t, err)
+	assert.Equal(t, api_schema.ApidumpError_PCAPPermission, GetErrorType(err))
+	assert.Equal(t, err.Error(), "test 1")
+}
+
+func TestGetErrorType(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected api_schema.ApidumpErrorType
+	}{
+		{
+			name:     "nil",
+			err:      nil,
+			expected: api_schema.ApidumpError_Other,
+		},
+		{
+			name:     "other error",
+			err:      errors.New("other error"),
+			expected: api_schema.ApidumpError_Other,
+		},
+		{
+			name:     "pcap permission error",
+			err:      NewApidumpError(api_schema.ApidumpError_PCAPPermission, "test"),
+			expected: api_schema.ApidumpError_PCAPPermission,
+		},
+		{
+			name:     "wrapped",
+			err:      errors.Wrap(NewApidumpError(api_schema.ApidumpError_PCAPPermission, "test"), "wrapped"),
+			expected: api_schema.ApidumpError_PCAPPermission,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expected, GetErrorType(tc.err), "["+tc.name+"] GetErrorType")
+		assert.Equal(t, tc.expected, GetErrorTypeWithDefault(tc.err, api_schema.ApidumpError_Other), "["+tc.name+"] GetErrorTypeWithDefault")
+	}
+}

--- a/apidump/net.go
+++ b/apidump/net.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -13,6 +12,7 @@ import (
 	"github.com/google/gopacket/pcap"
 	"github.com/pkg/errors"
 
+	"github.com/akitasoftware/akita-cli/architecture"
 	"github.com/akitasoftware/akita-cli/env"
 	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-cli/telemetry"
@@ -58,17 +58,7 @@ func showPermissionErrors(sampleError error) error {
 	} else if strings.Contains(sampleError.Error(), "SIOCETHTOOL(ETHTOOL_GET_TS_INFO) ioctl failed: Function not implemented") {
 		// This happens when the binary was built for a different architecture, e.g.
 		// if the user pulled the amd64 Docker image on arm64.
-
-		// Use architecture names consistent with our CLI releases.
-		var arch string
-		switch runtime.GOARCH {
-		case "x86_64", "amd64":
-			arch = "amd64"
-		case "aarch64", "arm64":
-			arch = "arm64"
-		default:
-			arch = runtime.GOARCH
-		}
+		arch := architecture.GetCanonicalArch()
 
 		printer.Warningf(
 			"The agent received \"Function not implemented\" when trying to read from your network interfaces. "+

--- a/apidump/net.go
+++ b/apidump/net.go
@@ -69,7 +69,8 @@ func showPermissionErrors(sampleError error) error {
 		)
 
 		if env.InDocker() {
-			return errors.Errorf(
+			return NewApidumpErrorf(
+				api_schema.ApidumpError_PCAPInterfaceNotImplemented,
 				"Unable to read network interfaces. If your host architecture is not %s, try using "+
 					"`docker pull --platform $YOUR_ARCHITECTURE akitasoftware/cli:latest` to pull an Akita agent "+
 					"built for your architecture.",

--- a/apidump/net.go
+++ b/apidump/net.go
@@ -67,16 +67,16 @@ func showPermissionErrors(sampleError error) error {
 			arch,
 		)
 
-		if os.Getenv("__X_AKITA_CLI_DOCKER") == "true" {
+		if env.InDocker() {
 			return errors.Errorf(
 				"Unable to read network interfaces. If your host architecture is not %s, try using "+
-					"`docker pull --platform $YOUR_ARCHITECTURE akitasoftware/cli:latest` to pull an Akita agent "+""+
+					"`docker pull --platform $YOUR_ARCHITECTURE akitasoftware/cli:latest` to pull an Akita agent "+
 					"built for your architecture.",
 				arch,
 			)
 		} else {
 			return errors.Errorf(
-				"Unable to read network interfaces. If your host architecture is not %s, try downloading an Akita agent built for your architecture from https://github.com/akitasoftware/akita-cli/releases.",
+				"Unable to read network interfaces. If your host architecture is not %s, try using the Akita install script: `bash -c \"$(curl -L https://releases.akita.software/scripts/install_akita.sh)\"`",
 				arch,
 			)
 		}

--- a/apidump/net.go
+++ b/apidump/net.go
@@ -71,22 +71,22 @@ func showPermissionErrors(sampleError error) error {
 		}
 
 		printer.Warningf(
-			"The agent received \"Function not implemented\" when trying to read from your network interfaces.  "+
-				"This often indicates that the Akita agent was built for a different architecture than your host architecture."+
+			"The agent received \"Function not implemented\" when trying to read from your network interfaces. "+
+				"This often indicates that the Akita agent was built for a different architecture than your host architecture. "+
 				"This Akita agent binary was built for %s.\n",
 			arch,
 		)
 
-		if os.Getenv("__X_AKITA_CLI_DOCKER") != "true" {
+		if os.Getenv("__X_AKITA_CLI_DOCKER") == "true" {
 			return errors.Errorf(
-				"Unable to read network interfaces.  If your host architecture is not %s, try using "+
+				"Unable to read network interfaces. If your host architecture is not %s, try using "+
 					"`docker pull --platform $YOUR_ARCHITECTURE akitasoftware/cli:latest` to pull an Akita agent "+""+
 					"built for your architecture.",
 				arch,
 			)
 		} else {
 			return errors.Errorf(
-				"Unable to read network interfaces.  If your host architecture is not %s, try downloading an Akita agent built for your architecture from https://github.com/akitasoftware/akita-cli/releases.",
+				"Unable to read network interfaces. If your host architecture is not %s, try downloading an Akita agent built for your architecture from https://github.com/akitasoftware/akita-cli/releases.",
 				arch,
 			)
 		}

--- a/architecture/architecture.go
+++ b/architecture/architecture.go
@@ -1,0 +1,19 @@
+package architecture
+
+import "runtime"
+
+// Returns the target architecture (from runtime.GOARCH) formatted to be
+// consistent with the architecture names we use in CLI releases.
+func GetCanonicalArch() string {
+	var arch string
+	switch runtime.GOARCH {
+	case "x86_64", "amd64":
+		arch = "amd64"
+	case "aarch64", "arm64":
+		arch = "arm64"
+	default:
+		arch = runtime.GOARCH
+	}
+
+	return arch
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20221107222856-a90a0970b256
+	github.com/akitasoftware/akita-libs v0.0.0-20221109215053-bb7c4fbe2f9c
 	github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe/go.mod h1:W
 github.com/akitasoftware/akita-libs v0.0.0-20211020162041-fe02207174fb/go.mod h1:YLFCjhwQ0ZFfYWSUD2c9KYKEeBn+R+Cz+A5SitXvJz8=
 github.com/akitasoftware/akita-libs v0.0.0-20221107222856-a90a0970b256 h1:vbeTOKy9t9qcRZ04F8NjhDejX2XxhIMtkrmxQkerGOI=
 github.com/akitasoftware/akita-libs v0.0.0-20221107222856-a90a0970b256/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
+github.com/akitasoftware/akita-libs v0.0.0-20221109215053-bb7c4fbe2f9c h1:ZysezWqeqISAkxzW5AhG+AHGDuaVOF1nrg0Vms1BT7Q=
+github.com/akitasoftware/akita-libs v0.0.0-20221109215053-bb7c4fbe2f9c/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/version/version.go
+++ b/version/version.go
@@ -1,11 +1,13 @@
 package version
 
 import (
+	"bytes"
 	"fmt"
 	"runtime"
 	"strings"
 
 	ver "github.com/hashicorp/go-version"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -28,5 +30,14 @@ func GitVersion() string {
 }
 
 func CLIDisplayString() string {
-	return fmt.Sprintf("%s (%s, %s)", releaseVersion.String(), gitVersion, runtime.GOARCH)
+	var utsname unix.Utsname
+	_ = unix.Uname(&utsname)
+
+	archMsg := runtime.GOARCH
+	machineArch := string(bytes.Trim(utsname.Machine[:], "\x00"))
+	if runtime.GOARCH != machineArch {
+		archMsg = fmt.Sprintf("built for %s, running on %s", runtime.GOARCH, machineArch)
+	}
+
+	return fmt.Sprintf("%s (%s, %s)", releaseVersion.String(), gitVersion, archMsg)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -2,10 +2,11 @@ package version
 
 import (
 	"fmt"
-	"runtime"
 	"strings"
 
 	ver "github.com/hashicorp/go-version"
+
+	"github.com/akitasoftware/akita-cli/architecture"
 )
 
 var (
@@ -28,5 +29,5 @@ func GitVersion() string {
 }
 
 func CLIDisplayString() string {
-	return fmt.Sprintf("%s (%s, %s)", releaseVersion.String(), gitVersion, runtime.GOARCH)
+	return fmt.Sprintf("%s (%s, %s)", releaseVersion.String(), gitVersion, architecture.GetCanonicalArch())
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,13 +1,11 @@
 package version
 
 import (
-	"bytes"
 	"fmt"
 	"runtime"
 	"strings"
 
 	ver "github.com/hashicorp/go-version"
-	"golang.org/x/sys/unix"
 )
 
 var (
@@ -30,14 +28,5 @@ func GitVersion() string {
 }
 
 func CLIDisplayString() string {
-	var utsname unix.Utsname
-	_ = unix.Uname(&utsname)
-
-	archMsg := runtime.GOARCH
-	machineArch := string(bytes.Trim(utsname.Machine[:], "\x00"))
-	if runtime.GOARCH != machineArch {
-		archMsg = fmt.Sprintf("built for %s, running on %s", runtime.GOARCH, machineArch)
-	}
-
-	return fmt.Sprintf("%s (%s, %s)", releaseVersion.String(), gitVersion, archMsg)
+	return fmt.Sprintf("%s (%s, %s)", releaseVersion.String(), gitVersion, runtime.GOARCH)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 
 	ver "github.com/hashicorp/go-version"
@@ -27,5 +28,5 @@ func GitVersion() string {
 }
 
 func CLIDisplayString() string {
-	return fmt.Sprintf("%s (%s)", releaseVersion.String(), gitVersion)
+	return fmt.Sprintf("%s (%s, %s)", releaseVersion.String(), gitVersion, runtime.GOARCH)
 }


### PR DESCRIPTION
When running the Akita agent in a Docker container built for a different architecture than the host (e.g. built for amd64 but running on arm64), the agent fails to read any network interfaces with error messages of the form `SIOCETHTOOL(ETHTOOL_GET_TS_INFO) ioctl failed: Function not implemented`.

This PR extends the agent to detect these errors and print a nicer error message for the user that indicates the underlying problem.  It also adds the target architecture to the `akita --version` output, e.g. `akita version 0.21.18 (09c7847085262f10ea9e2cd4bae280383970e5c1-dirty, arm64)`.

When running in Docker, the CLI output will look like this:
```
> docker run -e AKITA_API_KEY_ID -e AKITA_API_KEY_SECRET akitasoftware/cli:latest apidump --project akibox

WARNING: The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64) and no specific platform was requested
[INFO] Akita Agent 0.21.18-rc4
[WARNING] Skipping interface eth0 for collecting packets because of error: failed to read packets from interface eth0: eth0: SIOCETHTOOL(ETHTOOL_GET_TS_INFO) ioctl failed: Function not implemented
[WARNING] Skipping interface lo for collecting packets because of error: failed to read packets from interface lo: lo: SIOCETHTOOL(ETHTOOL_GET_TS_INFO) ioctl failed: Function not implemented
[WARNING] The agent received "Function not implemented" when trying to read from your network interfaces. This often indicates that the Akita agent was built for a different architecture than your host architecture. This Akita agent binary was built for arm64.
[ERROR] No network interfaces could be used: Unable to read network interfaces. If your host architecture is not arm64, try using `docker pull --platform $YOUR_ARCHITECTURE akitasoftware/cli:latest` to pull an Akita agent built for your architecture.
```

When not in Docker, the last error message will instead read:
```
[ERROR] No network interfaces could be used: Unable to read network interfaces.  If your host architecture is not arm64, try downloading an Akita agent built for your architecture from https://github.com/akitasoftware/akita-cli/releases.
```

### Testing
I tested this by building a CLI docker image on arm64 and running it on an amd64 macOS laptop.