### PR TITLE
Count oversized witnesses and report to back end

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -608,13 +608,13 @@ func (a *apidump) Run() error {
 
 				var backendCollector trace.Collector
 				if args.Out.AkitaURI != nil && args.Out.LocalPath != nil {
-					backendCollector = trace.NewBackendCollector(a.backendSvc, backendLrn, a.learnClient, optionals.Some(a.MaxWitnessSize_bytes), args.Plugins)
+					backendCollector = trace.NewBackendCollector(a.backendSvc, backendLrn, a.learnClient, optionals.Some(a.MaxWitnessSize_bytes), summary, args.Plugins)
 					collector = trace.TeeCollector{
 						Dst1: backendCollector,
 						Dst2: localCollector,
 					}
 				} else if args.Out.AkitaURI != nil {
-					backendCollector = trace.NewBackendCollector(a.backendSvc, backendLrn, a.learnClient, optionals.Some(a.MaxWitnessSize_bytes), args.Plugins)
+					backendCollector = trace.NewBackendCollector(a.backendSvc, backendLrn, a.learnClient, optionals.Some(a.MaxWitnessSize_bytes), summary, args.Plugins)
 					collector = backendCollector
 				} else if args.Out.LocalPath != nil {
 					collector = localCollector

--- a/apidump/summary.go
+++ b/apidump/summary.go
@@ -12,10 +12,13 @@ import (
 
 // Captures apidump progress.
 type Summary struct {
+	// Indicates whether this summary includes information about packets that did
+	// not meet the BPF filters specified by the user.
 	CapturingNegation bool
-	Interfaces        map[string]interfaceInfo
-	NegationFilters   map[string]string
-	NumUserFilters    int
+
+	Interfaces      map[string]interfaceInfo
+	NegationFilters map[string]string
+	NumUserFilters  int
 
 	// Values that change over the course of apidump are pointers.
 	FilterSummary    *trace.PacketCounter

--- a/apispec/run.go
+++ b/apispec/run.go
@@ -465,6 +465,7 @@ func uploadLocalTraces(domain string, clientID akid.ClientID, svc akid.ServiceID
 			// The apispec command is deprecated. Not bothering with configurability
 			// here.
 			optionals.Some(DefaultMaxWitnessSize_bytes),
+			trace.NewPacketCounter(),
 			plugins,
 		)
 		if !includeTrackers {

--- a/daemon/internal/cloud_client/cloud_client.go
+++ b/daemon/internal/cloud_client/cloud_client.go
@@ -160,6 +160,7 @@ func collectTraces(traceEventChannel <-chan *TraceEvent, learnClient rest.LearnC
 		learnClient,
 		// TODO Make this configurable.
 		optionals.Some(apispec.DefaultMaxWitnessSize_bytes),
+		packetCountSummary,
 		plugins,
 	)
 	collector = &trace.PacketCountCollector{

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20221109004000-398d633dfd2e
+	github.com/akitasoftware/akita-libs v0.0.0-20221109182912-4d0a4a501d88
 	github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20221107222856-a90a0970b256
+	github.com/akitasoftware/akita-libs v0.0.0-20221109004000-398d633dfd2e
 	github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/akitasoftware/akita-ir v0.0.0-20211020161529-944af4d11d6e/go.mod h1:W
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe h1:0BeBDjLDFPwv2bkk6YuRAPf1r6U4Wby98NHI9+Lddvs=
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-libs v0.0.0-20211020162041-fe02207174fb/go.mod h1:YLFCjhwQ0ZFfYWSUD2c9KYKEeBn+R+Cz+A5SitXvJz8=
-github.com/akitasoftware/akita-libs v0.0.0-20221109004000-398d633dfd2e h1:hHNyFsdncajGxiE1P6R5J4aVl5dgIvLfT9YYuewX7sY=
-github.com/akitasoftware/akita-libs v0.0.0-20221109004000-398d633dfd2e/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
+github.com/akitasoftware/akita-libs v0.0.0-20221109182912-4d0a4a501d88 h1:6Z3JL6cihEM5gvnTdd9ramKTtZ5YFFUkrWvM4WvjNmA=
+github.com/akitasoftware/akita-libs v0.0.0-20221109182912-4d0a4a501d88/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/akitasoftware/akita-ir v0.0.0-20211020161529-944af4d11d6e/go.mod h1:W
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe h1:0BeBDjLDFPwv2bkk6YuRAPf1r6U4Wby98NHI9+Lddvs=
 github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-libs v0.0.0-20211020162041-fe02207174fb/go.mod h1:YLFCjhwQ0ZFfYWSUD2c9KYKEeBn+R+Cz+A5SitXvJz8=
-github.com/akitasoftware/akita-libs v0.0.0-20221107222856-a90a0970b256 h1:vbeTOKy9t9qcRZ04F8NjhDejX2XxhIMtkrmxQkerGOI=
-github.com/akitasoftware/akita-libs v0.0.0-20221107222856-a90a0970b256/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
+github.com/akitasoftware/akita-libs v0.0.0-20221109004000-398d633dfd2e h1:hHNyFsdncajGxiE1P6R5J4aVl5dgIvLfT9YYuewX7sY=
+github.com/akitasoftware/akita-libs v0.0.0-20221109004000-398d633dfd2e/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -92,7 +92,7 @@ func TestObfuscate(t *testing.T) {
 		},
 	}
 
-	col := NewBackendCollector(fakeSvc, fakeLrn, mockClient, optionals.None[int](), nil)
+	col := NewBackendCollector(fakeSvc, fakeLrn, mockClient, optionals.None[int](), NewPacketCounter(), nil)
 	assert.NoError(t, col.Process(req))
 	assert.NoError(t, col.Process(resp))
 	assert.NoError(t, col.Close())
@@ -228,7 +228,7 @@ func TestTiming(t *testing.T) {
 		FinalPacketTime: startTime.Add(13 * time.Millisecond),
 	}
 
-	col := NewBackendCollector(fakeSvc, fakeLrn, mockClient, optionals.None[int](), nil)
+	col := NewBackendCollector(fakeSvc, fakeLrn, mockClient, optionals.None[int](), NewPacketCounter(), nil)
 	assert.NoError(t, col.Process(req))
 	assert.NoError(t, col.Process(resp))
 	assert.NoError(t, col.Close())
@@ -250,7 +250,7 @@ func TestMultipleInterfaces(t *testing.T) {
 		AnyTimes().
 		Return(nil)
 
-	bc := NewBackendCollector(fakeSvc, fakeLrn, mockClient, optionals.None[int](), nil)
+	bc := NewBackendCollector(fakeSvc, fakeLrn, mockClient, optionals.None[int](), NewPacketCounter(), nil)
 
 	var wg sync.WaitGroup
 	fakeTrace := func(count int, start_seq int) {
@@ -300,7 +300,7 @@ func TestMultipleInterfaces(t *testing.T) {
 func TestFlushExit(t *testing.T) {
 	b := &BackendCollector{}
 	b.uploadReportBatch = batcher.NewInMemory[rawReport](
-		newReportBuffer(b, uploadBatchMaxSize_bytes, optionals.None[int]()),
+		newReportBuffer(b, NewPacketCounter(), uploadBatchMaxSize_bytes, optionals.None[int]()),
 		uploadBatchFlushDuration,
 	)
 	b.flushDone = make(chan struct{})

--- a/upload/run.go
+++ b/upload/run.go
@@ -133,6 +133,7 @@ func uploadTraces(learnClient rest.LearnClient, args Args, serviceID akid.Servic
 		// The upload command is deprecated. Not bothering with configurability
 		// here.
 		optionals.Some(apispec.DefaultMaxWitnessSize_bytes),
+		inboundCount,
 		args.Plugins,
 	)
 	defer inboundCollector.Close()


### PR DESCRIPTION
Add and maintain a count of oversized witnesses in `client_telemetry.PacketCounts`. This is not reported to the user, but is reported to the back end as part of packet telemetry.