### PR TITLE
Report packet-capture statistics by host

### DIFF
--- a/apidump/summary.go
+++ b/apidump/summary.go
@@ -217,7 +217,11 @@ func (s *Summary) printHostHighlights(top *client_telemetry.PacketCountSummary) 
 
 	for _, h := range hosts[:printUpTo] {
 		thisHost := top.TopByHost[h]
-		label := fmt.Sprintf("Host %-*s", longestHostLength, h)
+		labelPreamble := "Host "
+		label := fmt.Sprintf("%s%-*s", labelPreamble, longestHostLength, h)
+		if h == trace.HostnameUnavailable {
+			label = fmt.Sprintf("%-*s", longestHostLength+len(labelPreamble), h)
+		}
 
 		// If we saw any HTTP traffic, report that.  But, if there's a high
 		// percentage of TLS handshakes, note that too.  Hosts don't have

--- a/apidump/summary.go
+++ b/apidump/summary.go
@@ -183,12 +183,17 @@ func (s *Summary) printHostHighlights(top *client_telemetry.PacketCountSummary) 
 		left := top.TopByHost[hosts[i]]
 		right := top.TopByHost[hosts[j]]
 
-		if left.HTTPRequests != right.HTTPRequests {
+		leftCount := left.HTTPRequests + left.TLSHello
+		rightCount := right.HTTPRequests + right.TLSHello
+
+		if leftCount != rightCount {
+			return leftCount > rightCount
+		} else if left.HTTPRequests != right.HTTPRequests {
 			return left.HTTPRequests > right.HTTPRequests
-		} else if left.HTTPResponses != right.HTTPResponses {
-			return left.HTTPResponses > right.HTTPResponses
-		} else {
+		} else if left.TLSHello != right.TLSHello {
 			return left.TLSHello > right.TLSHello
+		} else {
+			return hosts[i] < hosts[j]
 		}
 	})
 

--- a/apidump/summary.go
+++ b/apidump/summary.go
@@ -70,9 +70,6 @@ func (s *Summary) PrintPacketCounts() {
 
 // Summarize the top sources of traffic seen in a log-friendly format.
 // This appears before PrintWarnings, and should highlight the raw data.
-//
-// TODO: it would be nice to show hostnames if we have them? To more clearly
-// identify the traffic.
 func (s *Summary) PrintPacketCountHighlights() {
 	summaryLimit := 20
 	top := s.FilterSummary.Summary(summaryLimit)
@@ -92,7 +89,10 @@ func (s *Summary) PrintPacketCountHighlights() {
 		)
 	}
 
+	printer.Stderr.Infof("Top ports by traffic volume:\n")
 	s.printPortHighlights(top)
+
+	printer.Stderr.Infof("Top hosts by traffic volume:\n")
 	s.printHostHighlights(top)
 }
 

--- a/apidump/summary.go
+++ b/apidump/summary.go
@@ -197,17 +197,21 @@ func (s *Summary) printHostHighlights(top *client_telemetry.PacketCountSummary) 
 		}
 	})
 
-	// Take the first N hosts capturing at least 97% of the data.  This avoids
-	// a long tail of hosts with very few TLS handshakes.
+	// Take up to the first N hosts capturing at least 80% of the data. Until
+	// that limit, show at least two hosts but stop when the traffic per host
+	// drops below 3%. This avoids a long tail of hosts with very few TLS
+	// handshakes.
 	printUpTo := 0
 	longestHostLength := 0
 	countSoFar := 0
 	for i, h := range hosts {
 		thisHost := top.TopByHost[h]
-		countSoFar += thisHost.HTTPRequests + thisHost.HTTPResponses + thisHost.TLSHello
+		thisCount := thisHost.HTTPRequests + thisHost.HTTPResponses + thisHost.TLSHello
+		pct := thisCount * 100 / totalCountForHosts
+		countSoFar += thisCount
 		pctSoFar := countSoFar * 100 / totalCountForHosts
 
-		if 97 < pctSoFar && i >= 2 {
+		if 80 < pctSoFar || (pct < 3 && i >= 2) {
 			break
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20221109215053-bb7c4fbe2f9c
+	github.com/akitasoftware/akita-libs v0.0.0-20221111053102-849d2e280045
 	github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20221111053102-849d2e280045
+	github.com/akitasoftware/akita-libs v0.0.0-20221111205551-61b8b17a6799
 	github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,10 @@ github.com/akitasoftware/akita-libs v0.0.0-20221109215053-bb7c4fbe2f9c h1:ZysezW
 github.com/akitasoftware/akita-libs v0.0.0-20221109215053-bb7c4fbe2f9c/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/akita-libs v0.0.0-20221111053102-849d2e280045 h1:vMWr6ePyXocxbYs6AtlI0M8gobnCgJAys37nJS84i6c=
 github.com/akitasoftware/akita-libs v0.0.0-20221111053102-849d2e280045/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
+github.com/akitasoftware/akita-libs v0.0.0-20221111065205-44d39e355784 h1:se8iYbOz00bYSKJvd3hrfHindwI787uskDZhMHQWkms=
+github.com/akitasoftware/akita-libs v0.0.0-20221111065205-44d39e355784/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
+github.com/akitasoftware/akita-libs v0.0.0-20221111205551-61b8b17a6799 h1:RN9jZ7iKPPev53c/dPdtIwT/qZwOTAS1RNKwZzZ9Qfs=
+github.com/akitasoftware/akita-libs v0.0.0-20221111205551-61b8b17a6799/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20221107222856-a90a0970b256 h1:vbeTOK
 github.com/akitasoftware/akita-libs v0.0.0-20221107222856-a90a0970b256/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/akita-libs v0.0.0-20221109215053-bb7c4fbe2f9c h1:ZysezWqeqISAkxzW5AhG+AHGDuaVOF1nrg0Vms1BT7Q=
 github.com/akitasoftware/akita-libs v0.0.0-20221109215053-bb7c4fbe2f9c/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
+github.com/akitasoftware/akita-libs v0.0.0-20221111053102-849d2e280045 h1:vMWr6ePyXocxbYs6AtlI0M8gobnCgJAys37nJS84i6c=
+github.com/akitasoftware/akita-libs v0.0.0-20221111053102-849d2e280045/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/trace/collector.go
+++ b/trace/collector.go
@@ -123,7 +123,7 @@ func (pc *PacketCountCollector) Process(t akinet.ParsedNetworkTraffic) error {
 			HTTPResponses: 1,
 		})
 	case akinet.TLSClientHello:
-		var dstHost string
+		dstHost := HostnameUnavailable
 		if c.Hostname != nil {
 			dstHost = *c.Hostname
 		}
@@ -140,7 +140,7 @@ func (pc *PacketCountCollector) Process(t akinet.ParsedNetworkTraffic) error {
 		// Client Hello, but we don't pair those messages.  Barring that, any
 		// of the DNS names will serve as a reasonable identifier.  Pick the
 		// largest, which avoids "*" prefixes when possible.
-		var dstHost string
+		dstHost := HostnameUnavailable
 		if 0 < len(c.DNSNames) {
 			sort.Strings(c.DNSNames)
 			dstHost = c.DNSNames[len(c.DNSNames)-1]

--- a/trace/stats.go
+++ b/trace/stats.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/akitasoftware/akita-libs/client_telemetry"
 	"github.com/akitasoftware/go-utils/math"
+	"github.com/akitasoftware/go-utils/optionals"
 	"golang.org/x/exp/constraints"
 	"golang.org/x/exp/slices"
 )
@@ -27,18 +28,25 @@ func (d *PacketCountDiscard) Update(_ PacketCounts) {
 // In the future, this could put counters on a pipe and do the increments
 // in a separate goroutine, but we would *still* need a mutex to read the
 // totals out.
-// TODO: limit maximum size
 type PacketCounter struct {
 	total       PacketCounts
-	byPort      map[int]*PacketCounts
-	byInterface map[string]*PacketCounts
+	byPort      *BoundedPacketCounter[int]
+	byInterface *BoundedPacketCounter[string]
 	mutex       sync.RWMutex
+
+	// XXX(cns): Just TLS handshakes to start.
+	// TODO(cns):
+	// byHost BoundedPacketCounter[string]
 }
+
+// The maximum number (each) of ports, interfaces, or hosts that we track.
+// const maxKeys = 10_000
+const maxKeys = 10
 
 func NewPacketCounter() *PacketCounter {
 	return &PacketCounter{
-		byPort:      make(map[int]*PacketCounts),
-		byInterface: make(map[string]*PacketCounts),
+		byPort:      NewBoundedPacketCounter[int](maxKeys),
+		byInterface: NewBoundedPacketCounter[string](maxKeys),
 	}
 }
 
@@ -46,21 +54,17 @@ func (s *PacketCounter) Update(c PacketCounts) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	if prev, ok := s.byPort[c.SrcPort]; ok {
-		prev.Add(c)
-	} else {
+	s.byPort.AddOrInsert(c.SrcPort, c, func(c PacketCounts) *PacketCounts {
 		new := &PacketCounts{
 			Interface: "*",
 			SrcPort:   c.SrcPort,
 			DstPort:   0,
 		}
 		new.Add(c)
-		s.byPort[new.SrcPort] = new
-	}
+		return new
+	})
 
-	if prev, ok := s.byPort[c.DstPort]; ok {
-		prev.Add(c)
-	} else {
+	s.byPort.AddOrInsert(c.DstPort, c, func(c PacketCounts) *PacketCounts {
 		// Use SrcPort as the identifier in the
 		// accumulated counter
 		new := &PacketCounts{
@@ -69,20 +73,18 @@ func (s *PacketCounter) Update(c PacketCounts) {
 			DstPort:   0,
 		}
 		new.Add(c)
-		s.byPort[new.SrcPort] = new
-	}
+		return new
+	})
 
-	if prev, ok := s.byInterface[c.Interface]; ok {
-		prev.Add(c)
-	} else {
+	s.byInterface.AddOrInsert(c.Interface, c, func(c PacketCounts) *PacketCounts {
 		new := &PacketCounts{
 			Interface: c.Interface,
 			SrcPort:   0,
 			DstPort:   0,
 		}
 		new.Add(c)
-		s.byInterface[new.Interface] = new
-	}
+		return new
+	})
 
 	s.total.Add(c)
 }
@@ -97,7 +99,7 @@ func (s *PacketCounter) Total() PacketCounts {
 func (s *PacketCounter) TotalOnInterface(name string) PacketCounts {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
-	if count, ok := s.byInterface[name]; ok {
+	if count, ok := s.byInterface.Get(name); ok {
 		return *count
 	}
 
@@ -108,7 +110,7 @@ func (s *PacketCounter) TotalOnInterface(name string) PacketCounts {
 func (s *PacketCounter) TotalOnPort(port int) PacketCounts {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
-	if count, ok := s.byPort[port]; ok {
+	if count, ok := s.byPort.Get(port); ok {
 		return *count
 	}
 	return PacketCounts{Interface: "*", SrcPort: port}
@@ -118,8 +120,8 @@ func (s *PacketCounter) TotalOnPort(port int) PacketCounts {
 func (s *PacketCounter) AllPorts() []PacketCounts {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
-	ret := make([]PacketCounts, 0, len(s.byPort))
-	for _, v := range s.byPort {
+	ret := make([]PacketCounts, 0, s.byPort.Len())
+	for _, v := range s.byPort.RawMap() {
 		ret = append(ret, *v)
 	}
 	return ret
@@ -131,11 +133,30 @@ func (s *PacketCounter) Summary(n int) *PacketCountSummary {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
+	topByPort, byPortOverflow := s.byPort.TopN(n, func(c *PacketCounts) int { return c.TCPPackets })
+	topByInterface, byInterfaceOverflow := s.byInterface.TopN(n, func(c *PacketCounts) int { return c.TCPPackets })
+
+	var byPortOverflowPtr *PacketCounts
+	if overflow, exists := byPortOverflow.Get(); exists {
+		byPortOverflowPtr = &overflow
+	}
+
+	var byInterfaceOverflowPtr *PacketCounts
+	if overflow, exists := byInterfaceOverflow.Get(); exists {
+		byInterfaceOverflowPtr = &overflow
+	}
+
 	return &PacketCountSummary{
 		Version:        Version,
 		Total:          s.total,
-		TopByPort:      topNByTcpPacketCount(s.byPort, n),
-		TopByInterface: topNByTcpPacketCount(s.byInterface, n),
+		TopByPort:      topByPort,
+		TopByInterface: topByInterface,
+
+		ByPortOverflowLimit:      maxKeys,
+		ByInterfaceOverflowLimit: maxKeys,
+
+		ByPortOverflow:      byPortOverflowPtr,
+		ByInterfaceOverflow: byInterfaceOverflowPtr,
 	}
 }
 
@@ -144,21 +165,86 @@ type pair[T constraints.Ordered] struct {
 	v *PacketCounts
 }
 
+type BoundedPacketCounter[T constraints.Ordered] struct {
+	// Maximum entries allowed in m.
+	limit int
+
+	// Counts extras beyond limit.
+	overflow PacketCounts
+
+	m map[T]*PacketCounts
+}
+
+// Creates a bounded packet counter limited to `limit` entries.
+func NewBoundedPacketCounter[T constraints.Ordered](limit int) *BoundedPacketCounter[T] {
+	return &BoundedPacketCounter[T]{
+		limit: limit,
+		m:     make(map[T]*PacketCounts),
+
+		// Accumulate across all interfaces and ports.
+		overflow: PacketCounts{
+			Interface: "*",
+			SrcPort:   0,
+			DstPort:   0,
+		},
+	}
+}
+
+// Adds c to m[key]. Inserts makeNew(c) when adding a new key. Adds to
+// overflow instead if the limit has been reached.
+//
+// Use makeNew() to control the contents of the first PacketCount inserted for
+// each new key, e.g. to set Interface = "*" when counting by port.
+func (bc *BoundedPacketCounter[T]) AddOrInsert(key T, c PacketCounts, makeNew func(PacketCounts) *PacketCounts) {
+	if prev, ok := bc.m[key]; ok {
+		prev.Add(c)
+	} else if bc.HasReachedLimit() {
+		bc.overflow.Add(c)
+	} else {
+		bc.m[key] = makeNew(c)
+	}
+}
+
+func (bc *BoundedPacketCounter[T]) Get(key T) (*PacketCounts, bool) {
+	v, ok := bc.m[key]
+	return v, ok
+}
+
+// Return the overflow if the size hit the limit or None otherwise.
+func (bc *BoundedPacketCounter[T]) GetOverflow() optionals.Optional[PacketCounts] {
+	if bc.HasReachedLimit() {
+		return optionals.Some(bc.overflow)
+	}
+	return optionals.None[PacketCounts]()
+}
+
+func (bc *BoundedPacketCounter[T]) Len() int {
+	return len(bc.m)
+}
+
+func (bc *BoundedPacketCounter[T]) RawMap() map[T]*PacketCounts {
+	return bc.m
+}
+
 // Return a new map with the N entries in counts with the highest TCP packet
 // counts.  In the case of a tie for the Nth position, the entry with the
 // smallest key is selected.
-func topNByTcpPacketCount[T constraints.Ordered](counts map[T]*PacketCounts, n int) map[T]*PacketCounts {
-	rv := make(map[T]*PacketCounts, math.Min(len(counts), n))
+//
+// Returns the overflow count in overflow, or nil if there is no overflow.
+func (bc *BoundedPacketCounter[T]) TopN(n int, project func(*PacketCounts) int) (rv map[T]*PacketCounts, overflow optionals.Optional[PacketCounts]) {
+	rv = make(map[T]*PacketCounts, math.Min(len(bc.m), n))
 
-	pairs := make([]pair[T], 0, len(counts))
-	for k, v := range counts {
+	pairs := make([]pair[T], 0, len(bc.m))
+	for k, v := range bc.m {
 		pairs = append(pairs, pair[T]{k: k, v: v})
 	}
 
-	// Sort descending by TCPPackets.
+	// Sort descending.
 	slices.SortFunc(pairs, func(a, b pair[T]) bool {
-		if a.v.TCPPackets != b.v.TCPPackets {
-			return b.v.TCPPackets < a.v.TCPPackets
+		av := project(a.v)
+		bv := project(b.v)
+		if av != bv {
+			return bv < av
 		}
 		return a.k < b.k
 	})
@@ -168,5 +254,9 @@ func topNByTcpPacketCount[T constraints.Ordered](counts map[T]*PacketCounts, n i
 		rv[pairs[i].k] = pairs[i].v
 	}
 
-	return rv
+	return rv, bc.GetOverflow()
+}
+
+func (bc *BoundedPacketCounter[T]) HasReachedLimit() bool {
+	return bc.limit <= len(bc.m)
 }

--- a/trace/stats.go
+++ b/trace/stats.go
@@ -47,6 +47,10 @@ type PacketCounter struct {
 // The maximum number (each) of ports, interfaces, or hosts that we track.
 const maxKeys = 10_000
 
+// Special host name indicating that no host information was available, e.g.
+// because TLS 1.3 encrypts SNI data.
+const HostnameUnavailable = "(hosts without available names)"
+
 func NewPacketCounter() *PacketCounter {
 	return &PacketCounter{
 		byPort:      NewBoundedPacketCounter[int](maxKeys),

--- a/trace/stats_test.go
+++ b/trace/stats_test.go
@@ -4,14 +4,36 @@ import (
 	"testing"
 
 	. "github.com/akitasoftware/akita-libs/client_telemetry"
+	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCountByPort(t *testing.T) {
+	// Make enough ports to exceed the limit.
+	limitPlus1Inputs := make([]PacketCounts, maxKeys+1)
+	limitPlus1Expected := make(map[int]*PacketCounts, maxKeys)
+	for i := range limitPlus1Inputs {
+		limitPlus1Inputs[i] = PacketCounts{
+			Interface:  "*",
+			SrcPort:    i,
+			DstPort:    i,
+			TCPPackets: 1,
+		}
+		if i < maxKeys {
+			limitPlus1Expected[i] = &PacketCounts{
+				Interface:  "*",
+				SrcPort:    i,
+				TCPPackets: 2,
+			}
+		}
+	}
+
 	tests := []struct {
-		name     string
-		input    []PacketCounts
-		expected map[int]*PacketCounts
+		name             string
+		input            []PacketCounts
+		limit            int
+		expected         map[int]*PacketCounts
+		expectedOverflow optionals.Optional[PacketCounts]
 	}{
 		{
 			name: "init",
@@ -21,6 +43,7 @@ func TestCountByPort(t *testing.T) {
 				DstPort:    2,
 				TCPPackets: 3,
 			}},
+			limit: 100,
 			expected: map[int]*PacketCounts{
 				1: {
 					Interface:  "*",
@@ -34,6 +57,15 @@ func TestCountByPort(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "limit + 1",
+			input:    limitPlus1Inputs,
+			expected: limitPlus1Expected,
+			expectedOverflow: optionals.Some(PacketCounts{
+				Interface:  "*",
+				TCPPackets: 2,
+			}),
+		},
 	}
 
 	for _, tc := range tests {
@@ -42,7 +74,9 @@ func TestCountByPort(t *testing.T) {
 			c.Update(counts)
 		}
 
-		assert.Equal(t, tc.expected, c.byPort, tc.name)
+		// Set a summary above the limit to ensure we get all the ports.
+		assert.Equal(t, tc.expected, c.byPort.RawMap(), "["+tc.name+"] raw map")
+		assert.Equal(t, tc.expectedOverflow, c.byPort.GetOverflow(), "["+tc.name+"] overflow")
 	}
 }
 
@@ -109,7 +143,11 @@ func TestTopNTCP(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		actual := topNByTcpPacketCount(tc.from, tc.take)
+		bc := &BoundedPacketCounter[int]{
+			limit: 100,
+			m:     tc.from,
+		}
+		actual, _ := bc.TopN(tc.take, func(c *PacketCounts) int { return c.TCPPackets })
 		assert.Equal(t, tc.expected, actual, tc.name)
 	}
 }

--- a/trace/stats_test.go
+++ b/trace/stats_test.go
@@ -7,6 +7,45 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCountByPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []PacketCounts
+		expected map[int]*PacketCounts
+	}{
+		{
+			name: "init",
+			input: []PacketCounts{{
+				Interface:  "lo0",
+				SrcPort:    1,
+				DstPort:    2,
+				TCPPackets: 3,
+			}},
+			expected: map[int]*PacketCounts{
+				1: {
+					Interface:  "*",
+					SrcPort:    1,
+					TCPPackets: 3,
+				},
+				2: {
+					Interface:  "*",
+					SrcPort:    2,
+					TCPPackets: 3,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		c := NewPacketCounter()
+		for _, counts := range tc.input {
+			c.Update(counts)
+		}
+
+		assert.Equal(t, tc.expected, c.byPort, tc.name)
+	}
+}
+
 func TestTopNTCP(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
This PR adds per-host packet capture statistics for TLS handshakes and HTTP requests, which readily have the host available.  Per-host stats are uploaded with telemetry data and summarized as CLI output alongside per-port statistics.

This also adds hard limits on the number of ports, interfaces, and hosts that the CLI tracks for telemetry data.  The CLI is a long-running process, and our telemetry data monotonically increases.  We should consider capturing telemetry data in rolling windows in the future.  For now, I chose a limit of 10,000 each for ports, interfaces, and hosts; if we assume hosts and interfaces are ~10 bytes, then that maxes out at ~2Mb.  These are most useful in the first 60 seconds of running the CLI, so 10K should be more than enough.

Depends on https://github.com/akitasoftware/akita-libs/pull/174.

Here's what the CLI packet capture summary looks like with hosts:
```
[INFO] Created new trace on Akita Cloud: akita://akibox:trace:mud-fisher-74a4bce9
[INFO] Running learn mode on interfaces awdl0, llw0, utun4, en0, utun3, lo0, anpi2, utun5, utun2, utun6, anpi1, anpi0, utun0, utun1
[INFO] --filter flag is not set; capturing all network traffic to and from your services.
[INFO] Send SIGINT (Ctrl-C) to stop...
[INFO] Printing packet capture statistics after 60 seconds of capture.
[INFO] TCP port  8000:  1386 packets (50% of total), 99 HTTP requests, 99 HTTP responses, 0 TLS handshakes, 18 unparsed packets.
[INFO] TCP port   443:  1226 packets (44% of total), no HTTP requests or responses, 18 TLS handshakes indicating encrypted traffic.
[INFO] TCP port 64791:   136 packets (4% of total), no HTTP requests or responses; the data to this service could not be parsed.
[INFO] Host localhost:8000                                                   99 HTTP requests, 0 TLS handshakes.
[INFO] Host 560E52A873D46C9D31B9710C15766566.gr7.us-east-1.eks.amazonaws.com no HTTP requests, 4 TLS handshakes indicating encrypted traffic.
[INFO] Host sqs.us-west-1.amazonaws.com                                      no HTTP requests, 4 TLS handshakes indicating encrypted traffic.
```