### PR TITLE
Help when running in Docker Desktop

### DIFF
--- a/apidump/summary.go
+++ b/apidump/summary.go
@@ -300,7 +300,7 @@ func (s *Summary) PrintWarnings() {
 				s.PrefilterSummary.Total().HTTPRequests)
 		}
 		if env.InDocker() && env.HasDockerInternalHostAddress() {
-			printer.Stderr.Infof("If you're using macOS and your service is not running in a Docker container, try using the native Akita agent with `brew install akita-cli`.  See docs.akita.software/docs/macos-local for details.")
+			printer.Stderr.Infof("If you're using macOS and your service is not running in a Docker container, try using the native Akita agent with `brew install akita-cli`.  See docs.akita.software/docs/macos-local for details.\n")
 		}
 		printer.Stderr.Errorf("%s 🛑\n\n", printer.Color.Red("No HTTP calls captured!"))
 		return

--- a/apidump/summary.go
+++ b/apidump/summary.go
@@ -8,6 +8,7 @@ import (
 	"github.com/akitasoftware/go-utils/math"
 	"github.com/spf13/viper"
 
+	"github.com/akitasoftware/akita-cli/env"
 	"github.com/akitasoftware/akita-cli/pcap"
 	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-cli/trace"
@@ -297,6 +298,9 @@ func (s *Summary) PrintWarnings() {
 		} else if s.NumUserFilters > 0 && s.PrefilterSummary.Total().HTTPRequests != 0 {
 			printer.Stderr.Infof("Captured %d HTTP requests before allow and exclude rules, but all were filtered.\n",
 				s.PrefilterSummary.Total().HTTPRequests)
+		}
+		if env.InDocker() && env.HasDockerInternalHostAddress() {
+			printer.Stderr.Infof("If you're using macOS and your service is not running in a Docker container, try using the native Akita agent with `brew install akita-cli`.  See docs.akita.software/docs/macos-local for details.")
 		}
 		printer.Stderr.Errorf("%s 🛑\n\n", printer.Color.Red("No HTTP calls captured!"))
 		return

--- a/env/docker.go
+++ b/env/docker.go
@@ -1,6 +1,7 @@
 package env
 
 import (
+	"net"
 	"os"
 )
 
@@ -8,4 +9,15 @@ import (
 func InDocker() bool {
 	_, inDocker := os.LookupEnv("__X_AKITA_CLI_DOCKER")
 	return inDocker
+}
+
+const dockerInternalHostname = "host.docker.internal"
+
+// Docker exposes an internal address for containers to communicate with the
+// host.  It is only available on Docker Desktop and indicates the container
+// is being run by Docker Desktop on macOS or Windows.
+// https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
+func HasDockerInternalHostAddress() bool {
+	ips, err := net.LookupIP(dockerInternalHostname)
+	return err == nil && len(ips) > 0
 }


### PR DESCRIPTION
Running the Akita agent in Docker Desktop (macOS or Windows) will fail to capture traffic to services running on the host – rather than sharing the host networking stack, Docker Desktop runs the daemon in a VM.  Docker users are instructed to use host.internal.docker to communicate with the host.

We can use the presence of that DNS name to detect if we're running in a container with Docker Desktop.  If so, suggest using the native macOS binary if the agent fails to capture traffic.

I'll add this to the telemetry in a future PR.

Here's the output when running the Akita agent in a Docker container on Docker Desktop.  The last INFO line is not present when running the Docker container on a Linux host.
```
[INFO] Send SIGINT (Ctrl-C) to stop...
[INFO] Printing packet capture statistics after 60 seconds of capture.
[INFO] Top ports by traffic volume:
[INFO] TCP port   443:    19 packets (100% of total), no HTTP requests or responses; the data to this service could not be parsed.
[INFO] Top hosts by traffic volume:
[INFO] Captured 19 TCP packets total; 8 unparsed TCP segments. No TLS headers were found, so this may represent a network protocol that the agent does not know how to parse.
[INFO] If you're using macOS and your service is not running in a Docker container, try using the native Akita agent with `brew install akita-cli`.  See docs.akita.software/docs/macos-local for details.
[ERROR] No HTTP calls captured!
```