### PR TITLE
Upload metadata with initial client telemetry

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -178,9 +178,9 @@ func (a *apidump) SendInitialTelemetry() {
 		return
 	}
 
-	// The observed duration serves as a key for upsert, so
-	// it should be the same on the initial empty report indicating
-	// successful startup, and the one sixty seconds later.
+	// XXX(cns):  The observed duration serves as a key for upserting packet
+	//    telemetry, so it needs to be the same here as in the packet
+	//    telemetry sent sixty seconds after startup.
 	req := kgxapi.PostInitialClientTelemetryRequest{
 		ClientID:                  a.ClientID,
 		ObservedStartingAt:        a.startTime,
@@ -196,7 +196,7 @@ func (a *apidump) SendInitialTelemetry() {
 	err := a.learnClient.PostInitialClientTelemetry(ctx, a.backendSvc, a.Deployment, req)
 	if err != nil {
 		// Log an error and continue.
-		printer.Stderr.Errorf("Failed to send telemetry statistics: %s\n", err)
+		printer.Stderr.Errorf("Failed to send initial telemetry statistics: %s\n", err)
 		telemetry.Error("telemetry", err)
 	}
 }

--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -181,7 +181,7 @@ func (a *apidump) SendInitialTelemetry() {
 	// The observed duration serves as a key for upsert, so
 	// it should be the same on the initial empty report indicating
 	// successful startup, and the one sixty seconds later.
-	req := kgxapi.PostInitialClientTelemetry{
+	req := kgxapi.PostInitialClientTelemetryRequest{
 		ClientID:                  a.ClientID,
 		ObservedStartingAt:        a.startTime,
 		ObservedDurationInSeconds: a.StatsLogDelay,

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20221111205551-61b8b17a6799
+	github.com/akitasoftware/akita-libs v0.0.0-20221114031251-faccb1a40a3a
 	github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20221114031251-faccb1a40a3a
+	github.com/akitasoftware/akita-libs v0.0.0-20221114052158-f58fbe41430c
 	github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20221111065205-44d39e355784 h1:se8iYb
 github.com/akitasoftware/akita-libs v0.0.0-20221111065205-44d39e355784/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/akita-libs v0.0.0-20221111205551-61b8b17a6799 h1:RN9jZ7iKPPev53c/dPdtIwT/qZwOTAS1RNKwZzZ9Qfs=
 github.com/akitasoftware/akita-libs v0.0.0-20221111205551-61b8b17a6799/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
+github.com/akitasoftware/akita-libs v0.0.0-20221114031251-faccb1a40a3a h1:Tj2piWObWVrHlz3c9BvWvlMcfp1HyVLEP22PELh2jp0=
+github.com/akitasoftware/akita-libs v0.0.0-20221114031251-faccb1a40a3a/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20221111205551-61b8b17a6799 h1:RN9jZ7
 github.com/akitasoftware/akita-libs v0.0.0-20221111205551-61b8b17a6799/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/akita-libs v0.0.0-20221114031251-faccb1a40a3a h1:Tj2piWObWVrHlz3c9BvWvlMcfp1HyVLEP22PELh2jp0=
 github.com/akitasoftware/akita-libs v0.0.0-20221114031251-faccb1a40a3a/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
+github.com/akitasoftware/akita-libs v0.0.0-20221114052158-f58fbe41430c h1:cR6/yGWwZVoSBPH9BMbX9nEA1B7KXjdAjpIAsCQMHYo=
+github.com/akitasoftware/akita-libs v0.0.0-20221114052158-f58fbe41430c/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/rest/interface.go
+++ b/rest/interface.go
@@ -54,6 +54,7 @@ type LearnClient interface {
 
 	// Telemetry
 	PostClientPacketCaptureStats(context.Context, akid.ServiceID, string, kgxapi.PostClientPacketCaptureStatsRequest) error
+	PostInitialClientTelemetry(context.Context, akid.ServiceID, string, kgxapi.PostInitialClientTelemetry) error
 }
 
 type FrontClient interface {

--- a/rest/interface.go
+++ b/rest/interface.go
@@ -54,7 +54,7 @@ type LearnClient interface {
 
 	// Telemetry
 	PostClientPacketCaptureStats(context.Context, akid.ServiceID, string, kgxapi.PostClientPacketCaptureStatsRequest) error
-	PostInitialClientTelemetry(context.Context, akid.ServiceID, string, kgxapi.PostInitialClientTelemetry) error
+	PostInitialClientTelemetry(context.Context, akid.ServiceID, string, kgxapi.PostInitialClientTelemetryRequest) error
 }
 
 type FrontClient interface {

--- a/rest/learn_client.go
+++ b/rest/learn_client.go
@@ -201,7 +201,7 @@ func (c *learnClientImpl) PostClientPacketCaptureStats(ctx context.Context, serv
 	return c.post(ctx, path, req, &resp)
 }
 
-func (c *learnClientImpl) PostInitialClientTelemetry(ctx context.Context, serviceID akid.ServiceID, deployment string, req kgxapi.PostInitialClientTelemetry) error {
+func (c *learnClientImpl) PostInitialClientTelemetry(ctx context.Context, serviceID akid.ServiceID, deployment string, req kgxapi.PostInitialClientTelemetryRequest) error {
 	if deployment == "" {
 		return errors.Errorf("missing deployment tag")
 	}

--- a/rest/learn_client.go
+++ b/rest/learn_client.go
@@ -201,6 +201,16 @@ func (c *learnClientImpl) PostClientPacketCaptureStats(ctx context.Context, serv
 	return c.post(ctx, path, req, &resp)
 }
 
+func (c *learnClientImpl) PostInitialClientTelemetry(ctx context.Context, serviceID akid.ServiceID, deployment string, req kgxapi.PostInitialClientTelemetry) error {
+	if deployment == "" {
+		return errors.Errorf("missing deployment tag")
+	}
+
+	path := fmt.Sprintf("/v1/services/%s/telemetry/client/deployment/%s/start", serviceID, deployment)
+	var resp struct{}
+	return c.post(ctx, path, req, &resp)
+}
+
 func (c *learnClientImpl) SetSpecVersion(ctx context.Context, specID akid.APISpecID, versionName string) error {
 	resp := struct {
 	}{}


### PR DESCRIPTION
Call a new backend API to report initial client telemetry, and include the following additional metadata:
* CLI version
* CLI target architecture
* Whether the CLI was running in a Docker container distributed by Akita
* Whether the CLI was running in a Docker container running on Docker Desktop

The main goal is to detect when customers are running the Akita CLI in Docker Desktop with their service running on the host.  Because Docker Desktop (e.g. on macOS) doesn't support `--network host`, users in this case won't capture any service traffic.  Collecting this metadata lets us display a nicer error in the Akita app.

Depends on https://github.com/akitasoftware/akita-libs/pull/175.