### PR TITLE
Add health check utility for Docker Extension

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -125,6 +125,11 @@ type Args struct {
 
 	// The maximum witness size to upload. Anything larger is dropped.
 	MaxWitnessSize_bytes int
+
+	// Whether to run the command with additional functionality to support the Docker Extension
+	DockerExtensionMode bool
+	// The port to be used by the Docker Extension for health checks
+	HealthCheckPort int
 }
 
 // TODO: either remove write-to-local-HAR-file completely,

--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -426,8 +426,6 @@ func run(args Args) error {
 // Starts a health check server and runs the main packet capture loop.
 // This is used by the Docker extension to ensure that the running CLI container is healthy
 func runWithHealthCheck(args Args) error {
-	args.lint()
-
 	errChan := make(chan error)
 
 	go func() {

--- a/apidump/health_check.go
+++ b/apidump/health_check.go
@@ -8,13 +8,15 @@ import (
 
 // Handles health check requests for the Docker Extension.
 // Returns 200 OK by default.
-func handleHealthCheck(w http.ResponseWriter, r *http.Request) {
+func handleHealthCheck(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte(`{"status": "ok"}`))
 }
 
 func startHealthCheckServer(port int) error {
 	router := mux.NewRouter()
-	router.HandleFunc("/health", handleHealthCheck)
+
+	router.HandleFunc("/health", handleHealthCheck).Methods("GET")
+
 	return http.ListenAndServe(fmt.Sprintf(":%d", port), router)
 }

--- a/apidump/health_check.go
+++ b/apidump/health_check.go
@@ -1,0 +1,20 @@
+package apidump
+
+import (
+	"fmt"
+	"github.com/gorilla/mux"
+	"net/http"
+)
+
+// Handles health check requests for the Docker Extension.
+// Returns 200 OK by default.
+func handleHealthCheck(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status": "ok"}`))
+}
+
+func startHealthCheckServer(port int) error {
+	router := mux.NewRouter()
+	router.HandleFunc("/health", handleHealthCheck)
+	return http.ListenAndServe(fmt.Sprintf(":%d", port), router)
+}

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -21,28 +21,30 @@ import (
 
 var (
 	// Optional flags
-	outFlag                 location.Location
-	serviceFlag             string
-	interfacesFlag          []string
-	filterFlag              string
-	sampleRateFlag          float64
-	rateLimitFlag           float64
-	tagsFlag                []string
-	appendByTagFlag         bool
-	pathExclusionsFlag      []string
-	hostExclusionsFlag      []string
-	pathAllowlistFlag       []string
-	hostAllowlistFlag       []string
-	execCommandFlag         string
-	execCommandUserFlag     string
-	pluginsFlag             []string
-	traceRotateFlag         string
-	deploymentFlag          string
-	statsLogDelay           int
-	telemetryInterval       int
-	collectTCPAndTLSReports bool
-	parseTLSHandshakes      bool
-	maxWitnessSize_bytes    int
+	outFlag                  location.Location
+	serviceFlag              string
+	interfacesFlag           []string
+	filterFlag               string
+	sampleRateFlag           float64
+	rateLimitFlag            float64
+	tagsFlag                 []string
+	appendByTagFlag          bool
+	pathExclusionsFlag       []string
+	hostExclusionsFlag       []string
+	pathAllowlistFlag        []string
+	hostAllowlistFlag        []string
+	execCommandFlag          string
+	execCommandUserFlag      string
+	pluginsFlag              []string
+	traceRotateFlag          string
+	deploymentFlag           string
+	statsLogDelay            int
+	telemetryInterval        int
+	collectTCPAndTLSReports  bool
+	parseTLSHandshakes       bool
+	maxWitnessSize_bytes     int
+	dockerExtMode            bool
+	dockerExtHealthCheckPort int
 )
 
 var Cmd = &cobra.Command{
@@ -355,4 +357,20 @@ func init() {
 		"Don't send witnesses larger than this.",
 	)
 	Cmd.Flags().MarkHidden("max-witness-size-bytes")
+
+	Cmd.Flags().BoolVar(
+		&dockerExtMode,
+		"docker-ext-mode",
+		false,
+		"Enables Docker extension mode. This is an internal flag used by the Akita Docker extension.",
+	)
+	_ = Cmd.Flags().MarkHidden("docker-ext-mode")
+
+	Cmd.Flags().IntVar(
+		&dockerExtHealthCheckPort,
+		"docker-ext-health-check-port",
+		50343,
+		"Port to listen on for Docker extension health checks. This is an internal flag used by the Akita Docker extension.",
+	)
+	_ = Cmd.Flags().MarkHidden("docker-ext-health-check-port")
 }

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -374,5 +374,5 @@ func init() {
 		50343,
 		"Port to listen on for Docker extension health checks. This is an internal flag used by the Akita Docker extension.",
 	)
-	_ = Cmd.Flags().MarkHidden("docker-ext-health-check-port")
+	_ = Cmd.Flags().MarkHidden("health-check-port")
 }

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -21,30 +21,30 @@ import (
 
 var (
 	// Optional flags
-	outFlag                  location.Location
-	serviceFlag              string
-	interfacesFlag           []string
-	filterFlag               string
-	sampleRateFlag           float64
-	rateLimitFlag            float64
-	tagsFlag                 []string
-	appendByTagFlag          bool
-	pathExclusionsFlag       []string
-	hostExclusionsFlag       []string
-	pathAllowlistFlag        []string
-	hostAllowlistFlag        []string
-	execCommandFlag          string
-	execCommandUserFlag      string
-	pluginsFlag              []string
-	traceRotateFlag          string
-	deploymentFlag           string
-	statsLogDelay            int
-	telemetryInterval        int
-	collectTCPAndTLSReports  bool
-	parseTLSHandshakes       bool
-	maxWitnessSize_bytes     int
-	dockerExtMode            bool
-	dockerExtHealthCheckPort int
+	outFlag                 location.Location
+	serviceFlag             string
+	interfacesFlag          []string
+	filterFlag              string
+	sampleRateFlag          float64
+	rateLimitFlag           float64
+	tagsFlag                []string
+	appendByTagFlag         bool
+	pathExclusionsFlag      []string
+	hostExclusionsFlag      []string
+	pathAllowlistFlag       []string
+	hostAllowlistFlag       []string
+	execCommandFlag         string
+	execCommandUserFlag     string
+	pluginsFlag             []string
+	traceRotateFlag         string
+	deploymentFlag          string
+	statsLogDelay           int
+	telemetryInterval       int
+	collectTCPAndTLSReports bool
+	parseTLSHandshakes      bool
+	maxWitnessSize_bytes    int
+	dockerExtensionMode     bool
+	healthCheckPort         int
 )
 
 var Cmd = &cobra.Command{
@@ -176,6 +176,8 @@ var Cmd = &cobra.Command{
 			CollectTCPAndTLSReports: collectTCPAndTLSReports,
 			ParseTLSHandshakes:      parseTLSHandshakes,
 			MaxWitnessSize_bytes:    maxWitnessSize_bytes,
+			DockerExtensionMode:     dockerExtensionMode,
+			HealthCheckPort:         healthCheckPort,
 		}
 		if err := apidump.Run(args); err != nil {
 			return cmderr.AkitaErr{Err: err}
@@ -359,7 +361,7 @@ func init() {
 	Cmd.Flags().MarkHidden("max-witness-size-bytes")
 
 	Cmd.Flags().BoolVar(
-		&dockerExtMode,
+		&dockerExtensionMode,
 		"docker-ext-mode",
 		false,
 		"Enables Docker extension mode. This is an internal flag used by the Akita Docker extension.",
@@ -367,8 +369,8 @@ func init() {
 	_ = Cmd.Flags().MarkHidden("docker-ext-mode")
 
 	Cmd.Flags().IntVar(
-		&dockerExtHealthCheckPort,
-		"docker-ext-health-check-port",
+		&healthCheckPort,
+		"health-check-port",
 		50343,
 		"Port to listen on for Docker extension health checks. This is an internal flag used by the Akita Docker extension.",
 	)


### PR DESCRIPTION
This adds a server to the `apidump` command which responds to health check requests sent from the Docker extension.