### PR TITLE
Select task definition to modify and service to update.

### DIFF
--- a/cmd/internal/ecs/add.go
+++ b/cmd/internal/ecs/add.go
@@ -587,7 +587,7 @@ func confirmState(wf *AddWorkflow) (nextState optionals.Optional[AddWorkflowStat
 	wf.showPlannedChanges()
 
 	if dryRunFlag {
-		printer.Infof("Not making any changes due to -dry-run flag.\n")
+		printer.Infof("Not making any changes due to --dry-run flag.\n")
 		return awf_done()
 	}
 

--- a/cmd/internal/ecs/add.go
+++ b/cmd/internal/ecs/add.go
@@ -550,7 +550,7 @@ func getServiceState(wf *AddWorkflow) (nextState optionals.Optional[AddWorkflowS
 	var serviceAnswer string
 	err = survey.AskOne(
 		&survey.Select{
-			Message: "Which service should be restarted to use the modified task?",
+			Message: "Which service should be restarted to use the modified task definition?",
 			Help:    "Select ECS service that will be updated with the modified definition, so it can be monitored by Akita.",
 			Options: choices,
 			Description: func(value string, _ int) string {

--- a/cmd/internal/ecs/add.go
+++ b/cmd/internal/ecs/add.go
@@ -532,7 +532,7 @@ func getServiceState(wf *AddWorkflow) (nextState optionals.Optional[AddWorkflowS
 	}
 
 	if len(services) == 0 {
-		printer.Errorf("Could not find any ECS tasks in cluster %q that use task %q. Please select a different task or hit Ctrl+C to exit.\n",
+		printer.Errorf("Could not find any ECS services in cluster %q that use task definition %q. Please select a different task definition or hit Ctrl+C to exit.\n",
 			wf.ecsCluster, wf.ecsTaskDefinitionFamily)
 		return awf_next(getTaskState)
 	}

--- a/cmd/internal/ecs/add.go
+++ b/cmd/internal/ecs/add.go
@@ -582,6 +582,8 @@ func (wf *AddWorkflow) showPlannedChanges() {
 }
 
 func confirmState(wf *AddWorkflow) (nextState optionals.Optional[AddWorkflowState], err error) {
+	reportStep("Confirm Changes")
+
 	wf.showPlannedChanges()
 
 	if dryRunFlag {
@@ -600,6 +602,7 @@ func confirmState(wf *AddWorkflow) (nextState optionals.Optional[AddWorkflowStat
 		// (I realized one problem with this is if the last step had a flag, they are just
 		// stucke anyway.)
 		printer.Infof("No changes applied; exiting.\n")
+		reportStep("Changes Rejected")
 		return awf_done()
 	}
 

--- a/cmd/internal/ecs/add.go
+++ b/cmd/internal/ecs/add.go
@@ -550,8 +550,8 @@ func getServiceState(wf *AddWorkflow) (nextState optionals.Optional[AddWorkflowS
 	var serviceAnswer string
 	err = survey.AskOne(
 		&survey.Select{
-			Message: "Which service should be restarted to use the modified task definition?",
-			Help:    "Select ECS service that will be updated with the modified definition, so it can be monitored by Akita.",
+			Message: "Which service should be updated to use the modified task definition?",
+			Help:    "Select the ECS service that will be updated with the modified task definition, so it can be monitored by Akita.",
 			Options: choices,
 			Description: func(value string, _ int) string {
 				return services[arn(value)]
@@ -588,6 +588,7 @@ func confirmState(wf *AddWorkflow) (nextState optionals.Optional[AddWorkflowStat
 
 	if dryRunFlag {
 		printer.Infof("Not making any changes due to --dry-run flag.\n")
+		reportStep("Dry Run Completed")
 		return awf_done()
 	}
 

--- a/cmd/internal/ecs/aws_api.go
+++ b/cmd/internal/ecs/aws_api.go
@@ -291,6 +291,7 @@ func (wf *AddWorkflow) getLatestECSTaskDefinition(family string) (*types.TaskDef
 
 	output, err := wf.ecsClient.DescribeTaskDefinition(wf.ctx, input)
 	if err != nil {
+		telemetry.Error("AWS ECS DescribeTaskDefinition", err)
 		return nil, err
 	}
 	return output.TaskDefinition, nil
@@ -319,6 +320,7 @@ func (wf *AddWorkflow) listECSServices() (map[arn]string, error) {
 		}
 		output, err := wf.ecsClient.DescribeTaskDefinition(wf.ctx, input)
 		if err != nil {
+			telemetry.Error("AWS ECS DescribeTaskDefinition", err)
 			if uoe, unauth := isUnauthorized(err); unauth {
 				printer.Warningf("Skipping service %q, because the provided credentials are unauthorized for %s on %q.\n",
 					serviceARN, uoe.OperationName, taskARN)
@@ -382,6 +384,7 @@ func (wf *AddWorkflow) getService(serviceARN arn) (*types.Service, error) {
 
 	output, err := wf.ecsClient.DescribeServices(wf.ctx, input)
 	if err != nil {
+		telemetry.Error("AWS ECS DescribeServices", err)
 		return nil, wrapUnauthorizedFor(err, serviceARN)
 	}
 	if len(output.Services) == 0 {
@@ -395,6 +398,7 @@ func (wf *AddWorkflow) getService(serviceARN arn) (*types.Service, error) {
 	}
 	taskOutput, err := wf.ecsClient.DescribeTaskDefinition(wf.ctx, taskInput)
 	if err != nil {
+		telemetry.Error("AWS ECS DescribeTaskDefinition", err)
 		return nil, wrapUnauthorizedFor(err, taskARN)
 	}
 

--- a/cmd/internal/ecs/aws_api.go
+++ b/cmd/internal/ecs/aws_api.go
@@ -1,6 +1,7 @@
 package ecs
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	smithy "github.com/aws/smithy-go"
 )
 
@@ -20,6 +22,7 @@ import (
 // Error indicating profile is absent.
 // TODO: stop mixing error.Is and error.As usage?
 var NoSuchProfileError = errors.New("No such profile")
+var NoSuchClusterError = errors.New("No such cluster")
 
 // Error indicating the user was unauthorized.
 type UnauthorizedOperationError struct {
@@ -67,6 +70,14 @@ func isUnauthorizedFor(err error, arn arn) (UnauthorizedOperationError, bool) {
 
 func wrapUnauthorized(err error) error {
 	uoe, ok := isUnauthorized(err)
+	if ok {
+		return uoe
+	}
+	return err
+}
+
+func wrapUnauthorizedFor(err error, arn arn) error {
+	uoe, ok := isUnauthorizedFor(err, arn)
 	if ok {
 		return uoe
 	}
@@ -181,45 +192,218 @@ func (wf *AddWorkflow) listAWSRegions() (result []string) {
 // List all clusters for the current region, by arn and user-assigned name
 func (wf *AddWorkflow) listECSClusters() (map[arn]string, error) {
 	input := &ecs.ListClustersInput{}
+	return ListAWSObjectsByName[
+		*ecs.ListClustersOutput,
+		*ecs.DescribeClustersInput,
+		*ecs.DescribeClustersOutput,
+		types.Cluster](
+		wf.ctx,
+		"Clusters",
+		ecs.NewListClustersPaginator(wf.ecsClient, input),
+		func(output *ecs.ListClustersOutput) []arn {
+			return stringsToArns(output.ClusterArns)
+		},
+		func(arns []arn) *ecs.DescribeClustersInput {
+			return &ecs.DescribeClustersInput{
+				Clusters: arnsToStrings(arns),
+			}
+		},
+		func(ctx context.Context, input *ecs.DescribeClustersInput) (*ecs.DescribeClustersOutput, error) {
+			return wf.ecsClient.DescribeClusters(ctx, input)
+		},
+		func(output *ecs.DescribeClustersOutput) []types.Cluster {
+			return output.Clusters
+		},
+		func(t types.Cluster) (arn, string) {
+			return arn(aws.ToString(t.ClusterArn)), aws.ToString(t.ClusterName)
+		},
+	)
+}
 
-	result, err := wf.ecsClient.ListClusters(wf.ctx, input)
+// Verify that a cluster exists with the given ARN.
+// Returns its name, or else NoSuchClusterError if search is empty.
+func (wf *AddWorkflow) getClusterName(cluster arn) (string, error) {
+	describeInput := &ecs.DescribeClustersInput{
+		Clusters: []string{string(cluster)},
+	}
+	describeResult, err := wf.ecsClient.DescribeClusters(wf.ctx, describeInput)
 	if err != nil {
-		telemetry.Error("AWS ECS ListClusters", err)
-		return nil, wrapUnauthorized(err)
+		telemetry.Error("AWS ECS DescribeClusters", err)
+		if uoe, ok := isUnauthorizedFor(err, cluster); ok {
+			return "", uoe
+		}
+		return "", err
 	}
 
-	if len(result.ClusterArns) == 0 {
-		return nil, nil
+	if len(describeResult.Clusters) == 0 {
+		return "", NoSuchClusterError
 	}
 
-	numArns := len(result.ClusterArns)
-	ret := make(map[arn]string, numArns)
+	for _, c := range describeResult.Clusters {
+		if c.ClusterName != nil {
+			return *c.ClusterName, nil
+		}
+	}
+	return "", nil
+}
 
-	// Have to handle these in batches of 100.
-	for start := 0; start < numArns; start += 100 {
-		end := start + 100
-		if end > numArns {
-			end = numArns
-		}
-		describeInput := &ecs.DescribeClustersInput{
-			Clusters: result.ClusterArns[start:end],
-		}
-		describeResult, err := wf.ecsClient.DescribeClusters(wf.ctx, describeInput)
+func arnsToStrings(arns []arn) []string {
+	ret := make([]string, len(arns))
+	for i, a := range arns {
+		ret[i] = string(a)
+	}
+	return ret
+}
+
+func stringsToArns(arns []string) []arn {
+	ret := make([]arn, len(arns))
+	for i, a := range arns {
+		ret[i] = arn(a)
+	}
+	return ret
+}
+
+// List all tasks definition families, by name
+func (wf *AddWorkflow) listECSTaskDefinitionFamilies() ([]string, error) {
+	// TODO: Lists only active tasks, should we permit inactive ones too?
+	input := &ecs.ListTaskDefinitionFamiliesInput{
+		Status: types.TaskDefinitionFamilyStatusActive,
+	}
+
+	families := make([]string, 0)
+	paginator := ecs.NewListTaskDefinitionFamiliesPaginator(wf.ecsClient, input)
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(wf.ctx)
 		if err != nil {
-			telemetry.Error("AWS ECS DescribeClusters", err)
+			telemetry.Error("AWS ECS ListTaskDefinitionFamilies", err)
 			return nil, wrapUnauthorized(err)
 		}
+		families = append(families, output.Families...)
+	}
+	return families, nil
+}
 
-		// TODO: can we do anything about the Failures in the result?
-		for _, c := range describeResult.Clusters {
-			if c.ClusterArn != nil {
-				if c.ClusterName != nil {
-					ret[arn(*c.ClusterArn)] = *c.ClusterName
-				} else {
-					ret[arn(*c.ClusterArn)] = ""
-				}
+// Look up the most recent version of a task definition
+func (wf *AddWorkflow) getLatestECSTaskDefinition(family string) (*types.TaskDefinition, error) {
+	input := &ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String(family),
+	}
+
+	output, err := wf.ecsClient.DescribeTaskDefinition(wf.ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return output.TaskDefinition, nil
+}
+
+// List all services for the current cluster, by arn and user-assigned name
+// Filter to only those using the task family we identified!
+func (wf *AddWorkflow) listECSServices() (map[arn]string, error) {
+	// Lists both Fargate and ECS services
+	input := &ecs.ListServicesInput{
+		Cluster: aws.String(string(wf.ecsClusterARN)),
+	}
+
+	// Cache of ARN to family
+	arnToFamily := map[arn]string{
+		wf.ecsTaskDefinitionARN: wf.ecsTaskDefinitionFamily,
+	}
+
+	// Check whether the given Task ARN has Family equal to that of the chosen task definition.
+	taskInFamily := func(serviceARN arn, taskARN arn) bool {
+		if family, cached := arnToFamily[taskARN]; cached {
+			return family == wf.ecsTaskDefinitionFamily
+		}
+		input := &ecs.DescribeTaskDefinitionInput{
+			TaskDefinition: aws.String(string(taskARN)),
+		}
+		output, err := wf.ecsClient.DescribeTaskDefinition(wf.ctx, input)
+		if err != nil {
+			if uoe, unauth := isUnauthorized(err); unauth {
+				printer.Warningf("Skipping service %q, because the provided credentials are unauthorized for %s on %q.\n",
+					serviceARN, uoe.OperationName, taskARN)
+			} else {
+				printer.Warningf("Skipping service %q, because of an error checking its type definition: %v\n", err)
+			}
+			return false
+		}
+		family := aws.ToString(output.TaskDefinition.Family)
+		arnToFamily[taskARN] = family
+		return family == wf.ecsTaskDefinitionFamily
+	}
+
+	// Include only those services sharing the correct family.
+	filterFunc := func(output *ecs.DescribeServicesOutput) []types.Service {
+		filtered := make([]types.Service, 0)
+		for _, s := range output.Services {
+			// s.TaskDefinition is an ARN, but we want to match by family.
+			// We could try parsing the ARN? But I think the correct route is
+			// to look up the task definition, if unknown.
+			if taskInFamily(arn(aws.ToString(s.ServiceArn)), arn(aws.ToString(s.TaskDefinition))) {
+				filtered = append(filtered, s)
 			}
 		}
+		return filtered
 	}
-	return ret, nil
+
+	return ListAWSObjectsByName[
+		*ecs.ListServicesOutput,
+		*ecs.DescribeServicesInput,
+		*ecs.DescribeServicesOutput,
+		types.Service](
+		wf.ctx,
+		"Services",
+		ecs.NewListServicesPaginator(wf.ecsClient, input),
+		func(output *ecs.ListServicesOutput) []arn {
+			return stringsToArns(output.ServiceArns)
+		},
+		func(arns []arn) *ecs.DescribeServicesInput {
+			return &ecs.DescribeServicesInput{
+				Cluster:  aws.String(string(wf.ecsClusterARN)),
+				Services: arnsToStrings(arns),
+			}
+		},
+		func(ctx context.Context, input *ecs.DescribeServicesInput) (*ecs.DescribeServicesOutput, error) {
+			return wf.ecsClient.DescribeServices(ctx, input)
+		},
+		filterFunc,
+		func(t types.Service) (arn, string) {
+			return arn(aws.ToString(t.ServiceArn)), aws.ToString(t.ServiceName)
+		},
+	)
+}
+
+// Look up a service and check that its task definition matches.
+func (wf *AddWorkflow) getService(serviceARN arn) (*types.Service, error) {
+	input := &ecs.DescribeServicesInput{
+		Services: []string{string(serviceARN)},
+		Cluster:  aws.String(string(wf.ecsClusterARN)),
+	}
+
+	output, err := wf.ecsClient.DescribeServices(wf.ctx, input)
+	if err != nil {
+		return nil, wrapUnauthorizedFor(err, serviceARN)
+	}
+	if len(output.Services) == 0 {
+		return nil, fmt.Errorf("No service with ARN %q", serviceARN)
+	}
+	svc := output.Services[0]
+
+	taskARN := arn(aws.ToString(svc.TaskDefinition))
+	taskInput := &ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String(string(taskARN)),
+	}
+	taskOutput, err := wf.ecsClient.DescribeTaskDefinition(wf.ctx, taskInput)
+	if err != nil {
+		return nil, wrapUnauthorizedFor(err, taskARN)
+	}
+
+	family := aws.ToString(taskOutput.TaskDefinition.Family)
+	if family != wf.ecsTaskDefinitionFamily {
+		printer.Warningf("Service %q has task definition %q, which does not match family %q.",
+			serviceARN, taskARN, wf.ecsTaskDefinitionFamily)
+		return nil, fmt.Errorf("Mismatch between service and task definition; please choose a different task or service.")
+	}
+
+	return &svc, nil
 }

--- a/cmd/internal/ecs/aws_api.go
+++ b/cmd/internal/ecs/aws_api.go
@@ -322,7 +322,7 @@ func (wf *AddWorkflow) listECSServices() (map[arn]string, error) {
 		if err != nil {
 			telemetry.Error("AWS ECS DescribeTaskDefinition", err)
 			if uoe, unauth := isUnauthorized(err); unauth {
-				printer.Warningf("Skipping service %q, because the provided credentials are unauthorized for %s on %q.\n",
+				printer.Warningf("Skipping service %q because the provided credentials are unauthorized for %s on %q.\n",
 					serviceARN, uoe.OperationName, taskARN)
 			} else {
 				printer.Warningf("Skipping service %q, because of an error checking its type definition: %v\n", err)

--- a/cmd/internal/ecs/aws_api.go
+++ b/cmd/internal/ecs/aws_api.go
@@ -325,7 +325,7 @@ func (wf *AddWorkflow) listECSServices() (map[arn]string, error) {
 				printer.Warningf("Skipping service %q because the provided credentials are unauthorized for %s on %q.\n",
 					serviceARN, uoe.OperationName, taskARN)
 			} else {
-				printer.Warningf("Skipping service %q, because of an error checking its type definition: %v\n", err)
+				printer.Warningf("Skipping service %q because of an error checking its task definition: %v\n", serviceARN, err)
 			}
 			return false
 		}

--- a/cmd/internal/ecs/aws_api_names.go
+++ b/cmd/internal/ecs/aws_api_names.go
@@ -32,7 +32,7 @@ func ListAWSObjectsByName[
 	getArns func(ListOutput) []arn, // Convert list output to list of ARNs
 	inputFactory func([]arn) DescribeInput, // Convert list of ARNs to an input to the describe function
 	describe func(context.Context, DescribeInput) (DescribeOutput, error), // SDK function to call Describe<Object>
-	extract func(DescribeOutput) []NamedItem, // Extract a list of ARN/name pairs from the Describe output
+	extract func(DescribeOutput) []NamedItem, // Extract a list of objects containing ARN/name pairs from the Describe output
 	convert func(NamedItem) (arn, string), // Convert the ARN/name pair to a usable form, return "" if not present
 ) (map[arn]string, error) {
 

--- a/cmd/internal/ecs/aws_api_names.go
+++ b/cmd/internal/ecs/aws_api_names.go
@@ -1,0 +1,78 @@
+package ecs
+
+import (
+	"context"
+
+	"github.com/akitasoftware/akita-cli/telemetry"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+)
+
+// Utility method for: listing a bunch of ARNs, and then looking up their names.
+//
+// Example: in a region, list all clusters.
+// Example: in a cluster, list all services.
+//
+
+// Interface of the Paginator returned by the ECS package.  TODO: should we make
+// this take the Options type as an extra parameter, so it can be used with other packages?
+type AWSPaginator[ListOutput any] interface {
+	HasMorePages() bool
+	NextPage(context.Context, ...func(*ecs.Options)) (ListOutput, error)
+}
+
+func ListAWSObjectsByName[
+	ListOutput any, // an SDK output type for the List operation
+	DescribeInput any, // an SDK input type for the Describe operation
+	DescribeOutput any, // an SDK output type for the Describe operation
+	NamedItem any, // The type of the field within the Describe output
+](
+	ctx context.Context,
+	objectName string, // "Task" or "Cluster" etc. for debugging
+	paginator AWSPaginator[ListOutput], // Paginator for the List<Object> call
+	getArns func(ListOutput) []arn, // Convert list output to list of ARNs
+	inputFactory func([]arn) DescribeInput, // Convert list of ARNs to an input to the describe function
+	describe func(context.Context, DescribeInput) (DescribeOutput, error), // SDK function to call Describe<Object>
+	extract func(DescribeOutput) []NamedItem, // Extract a list of ARN/name pairs from the Describe output
+	convert func(NamedItem) (arn, string), // Convert the ARN/name pair to a usable form, return "" if not present
+) (map[arn]string, error) {
+
+	arns := make([]arn, 0)
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			telemetry.Error("AWS ECS List"+objectName, err)
+			return nil, wrapUnauthorized(err)
+		}
+		arns = append(arns, getArns(output)...)
+	}
+
+	if len(arns) == 0 {
+		return nil, nil
+	}
+
+	numARNs := len(arns)
+	ret := make(map[arn]string, numARNs)
+
+	// Handle in batches of 100; all existing use cases support this as a maximum.
+	for start := 0; start < numARNs; start += 100 {
+		end := start + 100
+		if end > numARNs {
+			end = numARNs
+		}
+		describeInput := inputFactory(arns[start:end])
+		describeResult, err := describe(ctx, describeInput)
+		if err != nil {
+			telemetry.Error("AWS ECS Describe"+objectName, err)
+			return nil, wrapUnauthorized(err)
+		}
+
+		for _, c := range extract(describeResult) {
+			arn, name := convert(c)
+			if arn != "" {
+				ret[arn] = name
+			}
+		}
+	}
+
+	return ret, nil
+}

--- a/cmd/internal/ecs/ecs.go
+++ b/cmd/internal/ecs/ecs.go
@@ -9,11 +9,11 @@ import (
 var (
 	// Any of these will be interactively prompted if not given on the command line.
 	// On the other hand, to run non-interactively then all of them *must* be given.
-	awsProfileFlag string
-	awsRegionFlag  string
-	ecsClusterFlag string
-	ecsServiceFlag string
-	ecsTaskFlag    string
+	awsProfileFlag        string
+	awsRegionFlag         string
+	ecsClusterFlag        string
+	ecsServiceFlag        string
+	ecsTaskDefinitionFlag string
 
 	// Location of credentials file.
 	awsCredentialsFlag string
@@ -58,7 +58,7 @@ func init() {
 	Cmd.PersistentFlags().StringVar(&awsRegionFlag, "region", "", "The AWS region in which your ECS cluster resides.")
 	Cmd.PersistentFlags().StringVar(&ecsClusterFlag, "cluster", "", "The name or ARN of your ECS cluster.")
 	Cmd.PersistentFlags().StringVar(&ecsServiceFlag, "service", "", "The name or ARN of your ECS service.")
-	Cmd.PersistentFlags().StringVar(&ecsTaskFlag, "task", "", "The name or ARN of your ECS task to modify.")
+	Cmd.PersistentFlags().StringVar(&ecsTaskDefinitionFlag, "task", "", "The name of your ECS task definition to modify.")
 	Cmd.PersistentFlags().BoolVar(&dryRunFlag, "dry-run", false, "Perform a dry run: show what will be done, but do not modify ECS.")
 
 	// Support for credentials in a nonstandard location


### PR DESCRIPTION
Refactored calls to ListFoo/DescribeFoo into a template function.
All command line options are supported, for both interactive and non-interactive mode.
Display the selected objects at the end and prompt for confirmation.