### PR TITLE
Register a modified ECS task definition.

### DIFF
--- a/cmd/internal/ecs/add.go
+++ b/cmd/internal/ecs/add.go
@@ -839,7 +839,7 @@ func modifyTaskState(wf *AddWorkflow) (nextState optionals.Optional[AddWorkflowS
 		Environment: []types.KeyValuePair{
 			{Name: aws.String("AKITA_API_KEY_ID"), Value: &apiKey},
 			{Name: aws.String("AKITA_API_KEY_SECRET"), Value: &apiSecret},
-			
+
 			// Setting these environment variables will cause the traces to be tagged.
 			{Name: aws.String("AKITA_AWS_REGION"), Value: &wf.awsRegion},
 			{Name: aws.String("AKITA_ECS_SERVICE"), Value: &wf.ecsService},
@@ -847,7 +847,6 @@ func modifyTaskState(wf *AddWorkflow) (nextState optionals.Optional[AddWorkflowS
 		},
 		Essential: aws.Bool(false),
 		Image:     aws.String(akitaECRImage),
-		Secrets:   []types.Secret{},
 	})
 
 	output, err := wf.ecsClient.RegisterTaskDefinition(wf.ctx, input)

--- a/cmd/internal/ecs/aws_api.go
+++ b/cmd/internal/ecs/aws_api.go
@@ -284,7 +284,7 @@ func (wf *AddWorkflow) listECSTaskDefinitionFamilies() ([]string, error) {
 }
 
 // Look up the most recent version of a task definition
-func (wf *AddWorkflow) getLatestECSTaskDefinition(family string) (*types.TaskDefinition, error) {
+func (wf *AddWorkflow) getLatestECSTaskDefinition(family string) (*types.TaskDefinition, []types.Tag, error) {
 	input := &ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: aws.String(family),
 	}
@@ -292,9 +292,9 @@ func (wf *AddWorkflow) getLatestECSTaskDefinition(family string) (*types.TaskDef
 	output, err := wf.ecsClient.DescribeTaskDefinition(wf.ctx, input)
 	if err != nil {
 		telemetry.Error("AWS ECS DescribeTaskDefinition", err)
-		return nil, err
+		return nil, nil, err
 	}
-	return output.TaskDefinition, nil
+	return output.TaskDefinition, output.Tags, nil
 }
 
 // List all services for the current cluster, by arn and user-assigned name

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -18,6 +18,7 @@ const (
 	Any        Deployment = "any"
 	Unknown    Deployment = "unknown"
 	AWS        Deployment = "aws"
+	AWS_ECS    Deployment = "aws-ecs"
 	Kubernetes Deployment = "kubernetes"
 )
 
@@ -28,6 +29,11 @@ var environmentToTag map[Deployment]map[string]tags.Key = map[Deployment]map[str
 	},
 	AWS: {
 		"AKITA_AWS_REGION": tags.XAkitaAWSRegion,
+	},
+	AWS_ECS: {
+		"AKITA_AWS_REGION":  tags.XAkitaAWSRegion,
+		"AKITA_ECS_TASK":    tags.XAkitaECSTask,
+		"AKITA_ECS_SERVICE": tags.XAkitaECSService,
 	},
 	Kubernetes: {
 		"AKITA_K8S_NAMESPACE": tags.XAkitaKubernetesNamespace,
@@ -67,9 +73,14 @@ func GetDeploymentInfo() (Deployment, map[tags.Key]string) {
 		deploymentType = Unknown
 	}
 
-	if AWS.getTagsFromEnvironment(tagset) {
-		printer.Infof("Found AWS environment variables.\n")
-		deploymentType = AWS
+	if AWS_ECS.getTagsFromEnvironment(tagset) {
+		printer.Infof("Found AWS ECS environment variables.\n")
+		deploymentType = AWS_ECS
+	} else {
+		if AWS.getTagsFromEnvironment(tagset) {
+			printer.Infof("Found AWS environment variables.\n")
+			deploymentType = AWS
+		}
 	}
 
 	if Kubernetes.getTagsFromEnvironment(tagset) {

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -76,11 +76,9 @@ func GetDeploymentInfo() (Deployment, map[tags.Key]string) {
 	if AWS_ECS.getTagsFromEnvironment(tagset) {
 		printer.Infof("Found AWS ECS environment variables.\n")
 		deploymentType = AWS_ECS
-	} else {
-		if AWS.getTagsFromEnvironment(tagset) {
-			printer.Infof("Found AWS environment variables.\n")
-			deploymentType = AWS
-		}
+	} else if AWS.getTagsFromEnvironment(tagset) {
+		printer.Infof("Found AWS environment variables.\n")
+		deploymentType = AWS
 	}
 
 	if Kubernetes.getTagsFromEnvironment(tagset) {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20221111205551-61b8b17a6799
+	github.com/akitasoftware/akita-libs v0.0.0-20221118194953-250f9c828eac
 	github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20221111065205-44d39e355784 h1:se8iYb
 github.com/akitasoftware/akita-libs v0.0.0-20221111065205-44d39e355784/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/akita-libs v0.0.0-20221111205551-61b8b17a6799 h1:RN9jZ7iKPPev53c/dPdtIwT/qZwOTAS1RNKwZzZ9Qfs=
 github.com/akitasoftware/akita-libs v0.0.0-20221111205551-61b8b17a6799/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
+github.com/akitasoftware/akita-libs v0.0.0-20221118194953-250f9c828eac h1:rttQSDF0hQ/mSHIUlmdBNTpHvQ487qHjMMJjC2caSSE=
+github.com/akitasoftware/akita-libs v0.0.0-20221118194953-250f9c828eac/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=


### PR DESCRIPTION
Check whether the task definition already contains an Akita container, or the tag we will add.
The code to create an AWS secret is disabled for now, because using the secret requires changes to the assigned role.
Recognize ECS-specific environment variables and tag the trace.

Depends on https://github.com/akitasoftware/akita-libs/pull/177 for the new tags.

Verified that the new task definition works by upgrading the service in the ECS console.

