### PR TITLE
Fix bugs discovered during permissions testing:

### DIFF
--- a/cmd/internal/ecs/add.go
+++ b/cmd/internal/ecs/add.go
@@ -495,7 +495,7 @@ func getTaskState(wf *AddWorkflow) (nextState optionals.Optional[AddWorkflowStat
 	}
 
 	if taskAnswer == goBackOption {
-		return awf_next(getRegionState)
+		return awf_next(getClusterState)
 	}
 	wf.ecsTaskDefinitionFamily = taskAnswer
 
@@ -923,7 +923,7 @@ func updateServiceState(wf *AddWorkflow) (nextState optionals.Optional[AddWorkfl
 	if tagErr == nil {
 		printer.Infof("Tagged service %q with %q.\n", wf.ecsService, akitaModificationTagKey)
 	} else {
-		telemetry.Error("AWS ECS TagResource", err)
+		telemetry.Error("AWS ECS TagResource", tagErr)
 		if uoe, unauth := isUnauthorized(tagErr); unauth {
 			printer.Warningf("The provided credentials do not have permission to tag the ECS service %q (operation %s).\n",
 				wf.ecsServiceARN, uoe.OperationName)

--- a/cmd/internal/ecs/aws_api.go
+++ b/cmd/internal/ecs/aws_api.go
@@ -305,7 +305,7 @@ func (wf *AddWorkflow) getLatestECSTaskDefinition(family string) (*types.TaskDef
 	output, err := wf.ecsClient.DescribeTaskDefinition(wf.ctx, input)
 	if err != nil {
 		telemetry.Error("AWS ECS DescribeTaskDefinition", err)
-		return nil, nil, err
+		return nil, nil, wrapUnauthorized(err)
 	}
 	return output.TaskDefinition, output.Tags, nil
 }


### PR DESCRIPTION
Add permission handling to DescribeTaskDefinition error.
Previous step from getTask should be getCluster.
Report on correct error when tagging.
