### PR TITLE
Report CLI CPU/memory usage with telemetry

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -210,7 +210,7 @@ func (a *apidump) SendPacketTelemetry(observedDuration int) {
 		req.PacketCountSummary = a.dumpSummary.FilterSummary.Summary(topNForSummary)
 	}
 
-	// Get CPU and memory usage.  Failure is nonblocking.
+	// Get CPU and memory usage. Failure is not fatal.
 	if stats, err := usage.Get(); err == nil {
 		req.AgentUsage = stats
 	}

--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -35,6 +35,7 @@ import (
 	"github.com/akitasoftware/akita-cli/telemetry"
 	"github.com/akitasoftware/akita-cli/tls_conn_tracker"
 	"github.com/akitasoftware/akita-cli/trace"
+	"github.com/akitasoftware/akita-cli/usage"
 	"github.com/akitasoftware/akita-cli/util"
 )
 
@@ -208,6 +209,12 @@ func (a *apidump) SendPacketTelemetry(observedDuration int) {
 	if a.dumpSummary != nil {
 		req.PacketCountSummary = a.dumpSummary.FilterSummary.Summary(topNForSummary)
 	}
+
+	// Get CPU and memory usage.  Failure is nonblocking.
+	if stats, err := usage.Get(); err == nil {
+		req.AgentUsage = stats
+	}
+
 	a.SendTelemetry(req)
 }
 

--- a/apispec/defaults.go
+++ b/apispec/defaults.go
@@ -29,6 +29,9 @@ const (
 	// How often to upload client telemetry.
 	DefaultTelemetryInterval_seconds = 5 * 60 // 5 minutes
 
+	// How often to upload client telemetry.
+	DefaultProcFSPollingInterval_seconds = 5 * 60 // 5 minutes
+
 	// How often to rotate traces in the back end.
 	DefaultTraceRotateInterval = time.Hour
 )

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -56,9 +56,8 @@ var Cmd = &cobra.Command{
 	SilenceUsage: true,
 	Args:         cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		// Initialize state for computing CPU usage.  Fails if /proc files are not
-		// available, in which case usage won't be included in telemetry stats.
-		_ = usage.Init()
+		// Initialize state for computing CPU usage for telemetry.
+		usage.Init()
 
 		traceTags, err := util.ParseTagsAndWarn(tagsFlag)
 		if err != nil {

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -7,6 +7,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/akitasoftware/akita-libs/akiuri"
+
 	"github.com/akitasoftware/akita-cli/apidump"
 	"github.com/akitasoftware/akita-cli/apispec"
 	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
@@ -15,8 +17,8 @@ import (
 	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-cli/rest"
 	"github.com/akitasoftware/akita-cli/telemetry"
+	"github.com/akitasoftware/akita-cli/usage"
 	"github.com/akitasoftware/akita-cli/util"
-	"github.com/akitasoftware/akita-libs/akiuri"
 )
 
 var (
@@ -54,6 +56,10 @@ var Cmd = &cobra.Command{
 	SilenceUsage: true,
 	Args:         cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		// Initialize state for computing CPU usage.  Fails if /proc files are not
+		// available, in which case usage won't be included in telemetry stats.
+		_ = usage.Init()
+
 		traceTags, err := util.ParseTagsAndWarn(tagsFlag)
 		if err != nil {
 			return err

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -17,7 +17,6 @@ import (
 	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-cli/rest"
 	"github.com/akitasoftware/akita-cli/telemetry"
-	"github.com/akitasoftware/akita-cli/usage"
 	"github.com/akitasoftware/akita-cli/util"
 )
 
@@ -42,6 +41,7 @@ var (
 	deploymentFlag          string
 	statsLogDelay           int
 	telemetryInterval       int
+	procFSPollingInterval   int
 	collectTCPAndTLSReports bool
 	parseTLSHandshakes      bool
 	maxWitnessSize_bytes    int
@@ -56,9 +56,6 @@ var Cmd = &cobra.Command{
 	SilenceUsage: true,
 	Args:         cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		// Initialize state for computing CPU usage for telemetry.
-		usage.Init()
-
 		traceTags, err := util.ParseTagsAndWarn(tagsFlag)
 		if err != nil {
 			return err
@@ -178,6 +175,7 @@ var Cmd = &cobra.Command{
 			Deployment:              deploymentFlag,
 			StatsLogDelay:           statsLogDelay,
 			TelemetryInterval:       telemetryInterval,
+			ProcFSPollingInterval:   procFSPollingInterval,
 			CollectTCPAndTLSReports: collectTCPAndTLSReports,
 			ParseTLSHandshakes:      parseTLSHandshakes,
 			MaxWitnessSize_bytes:    maxWitnessSize_bytes,
@@ -340,6 +338,14 @@ func init() {
 		"Upload client telemetry every N seconds.",
 	)
 	Cmd.Flags().MarkHidden("telemetry-interval")
+
+	Cmd.Flags().IntVar(
+		&procFSPollingInterval,
+		"proc-polling-interval",
+		apispec.DefaultProcFSPollingInterval_seconds,
+		"Collect agent resource usage from the /proc filesystem (if available) every N seconds.",
+	)
+	Cmd.Flags().MarkHidden("proc-polling-interval")
 
 	Cmd.Flags().BoolVar(
 		&collectTCPAndTLSReports,

--- a/cmd/internal/learn/cmd.go
+++ b/cmd/internal/learn/cmd.go
@@ -184,6 +184,7 @@ func runAPIDump(clientID akid.ClientID, projectName string, tagsMap map[tags.Key
 		Deployment:              apispec.DefaultDeployment,
 		StatsLogDelay:           statsLogDelay,
 		TelemetryInterval:       apispec.DefaultTelemetryInterval_seconds,
+		ProcFSPollingInterval:   apispec.DefaultProcFSPollingInterval_seconds,
 		CollectTCPAndTLSReports: apispec.DefaultCollectTCPAndTLSReports,
 		ParseTLSHandshakes:      apispec.DefaultParseTLSHandshakes,
 		MaxWitnessSize_bytes:    apispec.DefaultMaxWitnessSize_bytes,

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20221118194953-250f9c828eac
+	github.com/akitasoftware/akita-libs v0.0.0-20221202002331-5e4ef518e1d7
 	github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1
@@ -96,7 +96,6 @@ require (
 )
 
 replace (
-    github.com/akitasoftware/akita-libs => ../akita-libs
 	// Merging google/gopacket into akitasoftware/gopacket does not
 	// bring along any tags, such as the v1.1.19 release.
 	github.com/google/gopacket v1.1.19 => github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20221202015537-6b87f1edcf0d
-	github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7
+	github.com/akitasoftware/akita-libs v0.0.0-20221203001258-9a50cbd4827f
+	github.com/akitasoftware/go-utils v0.0.0-20221205195911-6b0a8503ff17
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1
 	github.com/aws/aws-sdk-go-v2 v1.17.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20221202002331-5e4ef518e1d7
+	github.com/akitasoftware/akita-libs v0.0.0-20221202015537-6b87f1edcf0d
 	github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20221203001258-9a50cbd4827f
+	github.com/akitasoftware/akita-libs v0.0.0-20221207183400-30284cda72af
 	github.com/akitasoftware/go-utils v0.0.0-20221207014235-6f4c9079488d
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.11.25 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.17.1 // indirect
+	github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dukex/mixpanel v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
@@ -95,6 +96,7 @@ require (
 )
 
 replace (
+    github.com/akitasoftware/akita-libs => ../akita-libs
 	// Merging google/gopacket into akitasoftware/gopacket does not
 	// bring along any tags, such as the v1.1.19 release.
 	github.com/google/gopacket v1.1.19 => github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
 	github.com/akitasoftware/akita-libs v0.0.0-20221203001258-9a50cbd4827f
-	github.com/akitasoftware/go-utils v0.0.0-20221205195911-6b0a8503ff17
+	github.com/akitasoftware/go-utils v0.0.0-20221207014235-6f4c9079488d
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1
 	github.com/aws/aws-sdk-go-v2 v1.17.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20221207183400-30284cda72af
+	github.com/akitasoftware/akita-libs v0.0.0-20221207213550-831712c54d01
 	github.com/akitasoftware/go-utils v0.0.0-20221207014235-6f4c9079488d
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,12 @@ github.com/akitasoftware/akita-libs v0.0.0-20221202002331-5e4ef518e1d7 h1:stEgi7
 github.com/akitasoftware/akita-libs v0.0.0-20221202002331-5e4ef518e1d7/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/akita-libs v0.0.0-20221202015537-6b87f1edcf0d h1:Y7jci2CrFGl1Y2V570WB6ncfYJwQQgQ3VKkQc2Uz3Lo=
 github.com/akitasoftware/akita-libs v0.0.0-20221202015537-6b87f1edcf0d/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
+github.com/akitasoftware/akita-libs v0.0.0-20221203001258-9a50cbd4827f h1:Ru+vxR/eZKZdN+gJNFxLHiT6oFUvXkLvXWXquyv8Quc=
+github.com/akitasoftware/akita-libs v0.0.0-20221203001258-9a50cbd4827f/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
+github.com/akitasoftware/go-utils v0.0.0-20221205195911-6b0a8503ff17 h1:xJVqL/FORz6feTl9qecyi84ikNATGjUGWfltbtCXc3c=
+github.com/akitasoftware/go-utils v0.0.0-20221205195911-6b0a8503ff17/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b/go.mod h1:wteInquxIdgWpGJEJmJEMJVtqM2i2vFZJ4W7B8G9ex8=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210608174341-829c1134e9de h1:rWkji88f/EWUY+qGc6pEyhpjgFbpsXwrnlTDTu5mLjY=

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20221111205551-61b8b17a6799 h1:RN9jZ7
 github.com/akitasoftware/akita-libs v0.0.0-20221111205551-61b8b17a6799/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/akita-libs v0.0.0-20221118194953-250f9c828eac h1:rttQSDF0hQ/mSHIUlmdBNTpHvQ487qHjMMJjC2caSSE=
 github.com/akitasoftware/akita-libs v0.0.0-20221118194953-250f9c828eac/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
+github.com/akitasoftware/akita-libs v0.0.0-20221202002331-5e4ef518e1d7 h1:stEgi7xcnOUh7g5+amIH/f4i9tBVP2Oq+8DEkSnRvQQ=
+github.com/akitasoftware/akita-libs v0.0.0-20221202002331-5e4ef518e1d7/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20221203001258-9a50cbd4827f h1:Ru+vxR
 github.com/akitasoftware/akita-libs v0.0.0-20221203001258-9a50cbd4827f/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/akita-libs v0.0.0-20221207183400-30284cda72af h1:Vi8n2PjBxLrQFthDX3edo+rxtutbV44zfZV1uAdy9d4=
 github.com/akitasoftware/akita-libs v0.0.0-20221207183400-30284cda72af/go.mod h1:qufiDcBb7r0oemPbxlXk9HUSyDt5rLO0PQGFOWRx3y4=
+github.com/akitasoftware/akita-libs v0.0.0-20221207213550-831712c54d01 h1:8sBM/cct9k54z6uPQNTFbVdcJ/DzKekJvjE7EAbe4U0=
+github.com/akitasoftware/akita-libs v0.0.0-20221207213550-831712c54d01/go.mod h1:qufiDcBb7r0oemPbxlXk9HUSyDt5rLO0PQGFOWRx3y4=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/go-utils v0.0.0-20221205195911-6b0a8503ff17 h1:xJVqL/FORz6feTl9qecyi84ikNATGjUGWfltbtCXc3c=

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9B
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/go-utils v0.0.0-20221205195911-6b0a8503ff17 h1:xJVqL/FORz6feTl9qecyi84ikNATGjUGWfltbtCXc3c=
 github.com/akitasoftware/go-utils v0.0.0-20221205195911-6b0a8503ff17/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
+github.com/akitasoftware/go-utils v0.0.0-20221207014235-6f4c9079488d h1:pN1dbNacZ/mvlU1NcJVDxqmKnrDQDTVaN6iKOarfdYM=
+github.com/akitasoftware/go-utils v0.0.0-20221207014235-6f4c9079488d/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b/go.mod h1:wteInquxIdgWpGJEJmJEMJVtqM2i2vFZJ4W7B8G9ex8=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210608174341-829c1134e9de h1:rWkji88f/EWUY+qGc6pEyhpjgFbpsXwrnlTDTu5mLjY=

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20221118194953-250f9c828eac h1:rttQSD
 github.com/akitasoftware/akita-libs v0.0.0-20221118194953-250f9c828eac/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/akita-libs v0.0.0-20221202002331-5e4ef518e1d7 h1:stEgi7xcnOUh7g5+amIH/f4i9tBVP2Oq+8DEkSnRvQQ=
 github.com/akitasoftware/akita-libs v0.0.0-20221202002331-5e4ef518e1d7/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
+github.com/akitasoftware/akita-libs v0.0.0-20221202015537-6b87f1edcf0d h1:Y7jci2CrFGl1Y2V570WB6ncfYJwQQgQ3VKkQc2Uz3Lo=
+github.com/akitasoftware/akita-libs v0.0.0-20221202015537-6b87f1edcf0d/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=
+github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8 h1:SjZ2GvvOononHOpK84APFuMvxqsk3tEIaKH/z4Rpu3g=
+github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8/go.mod h1:uEyr4WpAH4hio6LFriaPkL938XnrvLpNPmQHBdrmbIE=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/charmbracelet/glamour v0.2.0/go.mod h1:UA27Kwj3QHialP74iU6C+Gpc8Y7IOAKupeKMLLBURWM=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20221202015537-6b87f1edcf0d h1:Y7jci2
 github.com/akitasoftware/akita-libs v0.0.0-20221202015537-6b87f1edcf0d/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
 github.com/akitasoftware/akita-libs v0.0.0-20221203001258-9a50cbd4827f h1:Ru+vxR/eZKZdN+gJNFxLHiT6oFUvXkLvXWXquyv8Quc=
 github.com/akitasoftware/akita-libs v0.0.0-20221203001258-9a50cbd4827f/go.mod h1:Sjt1jp10Tvhpi/TcDAOmqABRpbcvp9uFz07M+bjvJzA=
+github.com/akitasoftware/akita-libs v0.0.0-20221207183400-30284cda72af h1:Vi8n2PjBxLrQFthDX3edo+rxtutbV44zfZV1uAdy9d4=
+github.com/akitasoftware/akita-libs v0.0.0-20221207183400-30284cda72af/go.mod h1:qufiDcBb7r0oemPbxlXk9HUSyDt5rLO0PQGFOWRx3y4=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7 h1:v2iX9e9Bv6e3hUQz3zCkqpO9SQkMpLPu5gWJG12J5Zs=
 github.com/akitasoftware/go-utils v0.0.0-20220606224752-aad0f81bb9e7/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/go-utils v0.0.0-20221205195911-6b0a8503ff17 h1:xJVqL/FORz6feTl9qecyi84ikNATGjUGWfltbtCXc3c=

--- a/main.go
+++ b/main.go
@@ -2,8 +2,13 @@ package main
 
 import (
 	"github.com/akitasoftware/akita-cli/cmd"
+	"github.com/akitasoftware/akita-cli/usage"
 )
 
 func main() {
+	// Initialize state for computing CPU usage.  Fails if /proc files are not
+	// available, in which case usage won't be included in telemetry stats.
+	_ = usage.Init()
+
 	cmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -2,13 +2,8 @@ package main
 
 import (
 	"github.com/akitasoftware/akita-cli/cmd"
-	"github.com/akitasoftware/akita-cli/usage"
 )
 
 func main() {
-	// Initialize state for computing CPU usage.  Fails if /proc files are not
-	// available, in which case usage won't be included in telemetry stats.
-	_ = usage.Init()
-
 	cmd.Execute()
 }

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -1,57 +1,131 @@
 package usage
 
 import (
+	"os"
+	"sync"
+	"time"
+
 	"github.com/akitasoftware/akita-libs/api_schema"
+	"github.com/akitasoftware/go-utils/math"
+	"github.com/akitasoftware/go-utils/queues"
 	"github.com/c9s/goprocinfo/linux"
 	"github.com/pkg/errors"
+
+	"github.com/akitasoftware/akita-cli/printer"
 )
 
 const (
 	selfStatusFile = "/proc/self/status"
 	selfStatFile   = "/proc/self/stat"
 	allStatFile    = "/proc/stat"
+
+	clearRefsFile = "/proc/self/clear_refs"
+	clearRefsCode = "5"
+)
+
+type statHistory struct {
+	stat    *linux.ProcessStat
+	status  *linux.ProcessStatus
+	allStat *linux.Stat
+}
+
+// Compute a 1-hour sliding window.
+const (
+	slidingWindowSize = time.Hour
 )
 
 var (
-	lastStat    *linux.ProcessStat
-	lastAllStat *linux.Stat
+	agentResourceUsage      *api_schema.AgentResourceUsage
+	agentResourceUsageMutex sync.Mutex
+
+	// Contains up to N samples, one per polling interval, where
+	// N * pollingInterval = slidingWindowSize.
+	history queues.Queue[statHistory]
+
+	// Only report errors during the first polling operation.
+	finishedFirstPoll bool
+
+	// Ensure at most one worker is polling.
+	isPolling      bool
+	isPollingMutex sync.Mutex
 )
 
-// Initialize state for computing CPU/memory usage for telemetry.
-func Init() {
-	// No need to check errors here. If /proc files aren't available,
-	// subsequent calls to Get() will return nil.
-	lastAllStat, _ = linux.ReadStat(allStatFile)
-	lastStat, _ = linux.ReadProcessStat(selfStatFile)
+// Returns a 1-hour sliding window reflecting this Akita agent's CPU and
+// memory usage, updated every 5 minutes, or nil if resource usage is
+// unavailable.
+func Get() *api_schema.AgentResourceUsage {
+	agentResourceUsageMutex.Lock()
+	defer agentResourceUsageMutex.Unlock()
+
+	return agentResourceUsage
 }
 
-// Computes the CPU usage of this process relative to all processes scheduled
-// since Get() or Init() was last called.  Also returns the peak virtual memory
-// usage of the Akita agent.
-//
-// Returns nil, nil if proc files are not available.  Fails if Init() has not
-// been called.
-func Get() (*api_schema.AgentUsage, error) {
-	status, err := linux.ReadProcessStatus(selfStatusFile)
-	if err != nil {
-		return nil, nil
+// Starts polling resource usage every N seconds.  Use Get() to get the latest
+// usage data.
+func Poll(done <-chan struct{}, pollingInterval time.Duration) {
+	// Check if polling is disabled.
+	if pollingInterval <= 0 {
+		return
 	}
 
-	stat, err := linux.ReadProcessStat(selfStatFile)
+	// Ensure only one thread is polling.
+	if !shouldStartPolling() {
+		return
+	}
+	setIsPolling(true)
+	defer setIsPolling(false)
+
+	history = queues.NewLinkedListQueue[statHistory]()
+
+	stat, status, allStat, err := readProcFS()
 	if err != nil {
-		return nil, nil
+		printer.Infof("Unable to poll for agent resource usage: %s\n", err)
+		return
 	}
 
-	allStat, err := linux.ReadStat(allStatFile)
-	if err != nil {
-		return nil, nil
+	history.Enqueue(statHistory{
+		stat:    stat,
+		status:  status,
+		allStat: allStat,
+	})
+
+	ticker := time.NewTicker(pollingInterval)
+
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			if err := poll(pollingInterval); err != nil {
+				printer.Infof("Unable to poll for agent resource usage: %s\n", err)
+				return
+			}
+		}
+	}
+}
+
+func poll(pollingInterval time.Duration) error {
+	log := func(msg string, args ...any) {
+		if finishedFirstPoll {
+			return
+		}
+		printer.Infof(msg, args...)
 	}
 
-	if lastAllStat == nil || lastStat == nil {
-		// If we get this far, it means proc files are available but Init()
-		// wasn't called.
-		return nil, errors.Errorf("called usage.Get() without usage.Init()")
+	observedAt := time.Now()
+	stat, status, allStat, err := readProcFS()
+	if err != nil {
+		return err
 	}
+
+	oldestStats, exist := history.Peek().Get()
+	if !exist {
+		// Should never happen.
+		return errors.Errorf("Internal error: missing resource usage history.")
+	}
+
+	lastStat := oldestStats.stat
+	lastAllStat := oldestStats.allStat
 
 	// Compute the processing time for this process vs. all processes since
 	// the last time Get() or Init() was called.
@@ -59,9 +133,85 @@ func Get() (*api_schema.AgentUsage, error) {
 	allCPU := float64(allStat.CPUStatAll.User-lastAllStat.CPUStatAll.User) +
 		float64(allStat.CPUStatAll.System-lastAllStat.CPUStatAll.System) +
 		float64(allStat.CPUStatAll.Idle-lastAllStat.CPUStatAll.Idle)
+	relativeCPU := selfCPU / allCPU
+	coresUsed := relativeCPU * float64(len(allStat.CPUStats))
 
-	return &api_schema.AgentUsage{
-		RelativeCPU: selfCPU / allCPU,
-		VMPeak:      status.VmPeak,
-	}, nil
+	// Get highest recorded VM high water mark.
+	vmHWM := status.VmHWM
+	history.ForEach(func(h statHistory) {
+		vmHWM = math.Max(vmHWM, h.status.VmHWM)
+	})
+
+	// Update history.
+	if history.Size() >= int(slidingWindowSize/pollingInterval) {
+		history.Dequeue()
+		history.Enqueue(statHistory{
+			stat:    stat,
+			status:  status,
+			allStat: allStat,
+		})
+	}
+
+	// Clear VM high-water mark.
+	if f, err := os.Open(clearRefsFile); err != nil {
+		log("Failed to clear VmHWM.  Memory usage telemetry will report the high-water mark as computed by /proc/self/status.\n")
+	} else {
+		defer f.Close()
+		if _, err := f.Write([]byte(clearRefsCode)); err != nil {
+			log("Failed to clear VmHWM.  Memory usage telemetry will report the high-water mark as computed by /proc/self/status.\n")
+		}
+	}
+
+	observedDuration := time.Duration(history.Size()) * pollingInterval
+	observedStartingAt := observedAt.Add(-observedDuration)
+
+	// Update the usage data.
+	agentResourceUsageMutex.Lock()
+	defer agentResourceUsageMutex.Unlock()
+
+	agentResourceUsage = &api_schema.AgentResourceUsage{
+		CoresUsed:                 coresUsed,
+		RelativeCPU:               relativeCPU,
+		VmHWM:                     vmHWM,
+		ObservedStartingAt:        observedStartingAt,
+		ObservedDurationInSeconds: int(observedDuration.Seconds()),
+	}
+
+	finishedFirstPoll = true
+	return nil
+}
+
+func readProcFS() (stat *linux.ProcessStat, status *linux.ProcessStatus, allStat *linux.Stat, err error) {
+	status, err = linux.ReadProcessStatus(selfStatusFile)
+	if err != nil {
+		return nil, nil, nil, errors.Errorf("Failed to load %s.  Resource usage telemetry will not be available.", selfStatusFile)
+	}
+
+	stat, err = linux.ReadProcessStat(selfStatFile)
+	if err != nil {
+		return nil, nil, nil, errors.Errorf("Failed to load %s.  Resource usage telemetry will not be available.", selfStatFile)
+	}
+
+	allStat, err = linux.ReadStat(allStatFile)
+	if err != nil {
+		return nil, nil, nil, errors.Errorf("Failed to load %s.  Resource usage telemetry will not be available.", allStatFile)
+	}
+
+	return stat, status, allStat, nil
+}
+
+// Returns true if polling has not already started.
+func shouldStartPolling() bool {
+	isPollingMutex.Lock()
+	defer isPollingMutex.Unlock()
+
+	return !isPolling
+}
+
+// Sets the isPolling variable, guarded by isPollingMutex.
+func setIsPolling(v bool) {
+	isPollingMutex.Lock()
+	defer isPollingMutex.Unlock()
+
+	isPolling = v
 }

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -33,27 +33,28 @@ func Init() error {
 // since the Akita agent started.  Also returns the peak virtual memory usage
 // of the Akita agent.
 //
-// Fails if proc files are not present or Init() has not yet been called.
+// Returns nil, nil if proc files are not available.  Fails if Init() has not
+// been called.
 func Get() (*api_schema.AgentUsage, error) {
 	status, err := linux.ReadProcessStatus(selfStatusFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to load %s", selfStatusFile)
+		return nil, nil
 	}
 
 	stat, err := linux.ReadProcessStat("/proc/self/stat")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to load %s", selfStatFile)
+		return nil, nil
 	}
 
 	allStat, err := linux.ReadStat(allStatFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to load %s", allStatFile)
+		return nil, nil
 	}
 
 	if allStatAtProcessStart == nil {
 		// If we get this far, it means proc files are available but Init()
 		// wasn't called.
-		return nil, errors.Wrap(err, "called GetUsage() without Init()")
+		return nil, errors.Errorf("called GetUsage() without Init()")
 	}
 
 	// Compute the processing time for this process vs. all processes since

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -17,22 +17,12 @@ var (
 	lastAllStat *linux.Stat
 )
 
-// Records CPU processing time statistics at the start of the Akita agent.
-// Fails if proc files are not present.
-func Init() error {
-	var err error
-
-	lastAllStat, err = linux.ReadStat(allStatFile)
-	if err != nil {
-		return errors.Wrapf(err, "usage init: failed to load %s", allStatFile)
-	}
-
-	lastStat, err = linux.ReadProcessStat(selfStatFile)
-	if err != nil {
-		return errors.Wrapf(err, "usage init: failed to load %s", selfStatFile)
-	}
-
-	return nil
+// Initialize state for computing CPU/memory usage for telemetry.
+func Init() {
+	// No need to check errors here. If /proc files aren't available,
+	// subsequent calls to Get() will return nil.
+	lastAllStat, _ = linux.ReadStat(allStatFile)
+	lastStat, _ = linux.ReadProcessStat(selfStatFile)
 }
 
 // Computes the CPU usage of this process relative to all processes scheduled

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -67,7 +67,8 @@ func Get() (*api_schema.AgentUsage, error) {
 	// the last time Get() or Init() was called.
 	selfCPU := float64(stat.Utime-lastStat.Utime) + float64(stat.Stime-lastStat.Stime)
 	allCPU := float64(allStat.CPUStatAll.User-lastAllStat.CPUStatAll.User) +
-		float64(allStat.CPUStatAll.System-lastAllStat.CPUStatAll.System)
+		float64(allStat.CPUStatAll.System-lastAllStat.CPUStatAll.System) +
+		float64(allStat.CPUStatAll.Idle-lastAllStat.CPUStatAll.Idle)
 
 	return &api_schema.AgentUsage{
 		RelativeCPU: selfCPU / allCPU,

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -1,0 +1,69 @@
+package usage
+
+import (
+	"github.com/akitasoftware/akita-libs/api_schema"
+	"github.com/c9s/goprocinfo/linux"
+	"github.com/pkg/errors"
+)
+
+const (
+	selfStatusFile = "/proc/self/status"
+	selfStatFile   = "/proc/self/stat"
+	allStatFile    = "/proc/stat"
+)
+
+var (
+	allStatAtProcessStart *linux.Stat
+)
+
+// Records CPU processing time statistics at the start of the Akita agent.
+// Fails if proc files are not present.
+func Init() error {
+	var err error
+
+	allStatAtProcessStart, err = linux.ReadStat(allStatFile)
+	if err != nil {
+		return errors.Wrapf(err, "usage init: failed to load %s", allStatFile)
+	}
+
+	return nil
+}
+
+// Computes the CPU usage of this process relative to all processes scheduled
+// since the Akita agent started.  Also returns the peak virtual memory usage
+// of the Akita agent.
+//
+// Fails if proc files are not present or Init() has not yet been called.
+func Get() (*api_schema.AgentUsage, error) {
+	status, err := linux.ReadProcessStatus(selfStatusFile)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to load %s", selfStatusFile)
+	}
+
+	stat, err := linux.ReadProcessStat("/proc/self/stat")
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to load %s", selfStatFile)
+	}
+
+	allStat, err := linux.ReadStat(allStatFile)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to load %s", allStatFile)
+	}
+
+	if allStatAtProcessStart == nil {
+		// If we get this far, it means proc files are available but Init()
+		// wasn't called.
+		return nil, errors.Wrap(err, "called GetUsage() without Init()")
+	}
+
+	// Compute the processing time for this process vs. all processes since
+	// the last time GetUsage or Init was called.
+	selfCPU := float64(stat.Utime) + float64(stat.Stime)
+	allCPUSinceProcessStart := float64(allStat.CPUStatAll.User-allStatAtProcessStart.CPUStatAll.User) +
+		float64(allStat.CPUStatAll.System-allStatAtProcessStart.CPUStatAll.System)
+
+	return &api_schema.AgentUsage{
+		RelativeCPU: selfCPU / allCPUSinceProcessStart,
+		VMPeak:      status.VmPeak,
+	}, nil
+}


### PR DESCRIPTION
When `/proc` files are available (e.g. most Linux flavors), include the Akita CLI's CPU and memory usage with packet capture telemetry.

Depends on https://github.com/akitasoftware/akita-libs/pull/181.