### PR TITLE
Allow user to use a proxy, an alternate server name, or skip TLS

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -178,10 +178,10 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&rest.Domain, "domain", defaultDomain, "Your assigned Akita domain (e.g. company.akita.software)")
 	rootCmd.PersistentFlags().MarkHidden("domain")
 
-	// Use a proxy or permit an unknown certificate.
-	rootCmd.PersistentFlags().StringVar(&rest.UseProxy, "proxy", "", "The domain name or IP address of an HTTP proxy server to use")
-	rootCmd.PersistentFlags().BoolVar(&rest.PermitInvalidCertificate, "skip-validate", false, "Skip TLS validation on the connection to api.akita.software")
-	rootCmd.PersistentFlags().MarkHidden("skip-validate")
+	// Use a proxy or permit a mismatched certificate.
+	rootCmd.PersistentFlags().StringVar(&rest.ProxyAddress, "proxy", "", "The domain name, IP address, or URL of an HTTP proxy server to use")
+	rootCmd.PersistentFlags().BoolVar(&rest.PermitInvalidCertificate, "skip-tls-validate", false, "Skip TLS validation on the connection to api.akita.software")
+	rootCmd.PersistentFlags().MarkHidden("skip-tls-validate")
 	rootCmd.PersistentFlags().StringVar(&rest.ExpectedServerName, "server-tls-name", "", "Provide an alternate TLS server name to accept instead of api.akita.software")
 	rootCmd.PersistentFlags().MarkHidden("server-tls-name")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -178,6 +178,13 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&rest.Domain, "domain", defaultDomain, "Your assigned Akita domain (e.g. company.akita.software)")
 	rootCmd.PersistentFlags().MarkHidden("domain")
 
+	// Use a proxy or permit an unknown certificate.
+	rootCmd.PersistentFlags().StringVar(&rest.UseProxy, "proxy", "", "The domain name or IP address of an HTTP proxy server to use")
+	rootCmd.PersistentFlags().BoolVar(&rest.PermitInvalidCertificate, "skip-validate", false, "Skip TLS validation on the connection to api.akita.software")
+	rootCmd.PersistentFlags().MarkHidden("skip-validate")
+	rootCmd.PersistentFlags().StringVar(&rest.ExpectedServerName, "server-tls-name", "", "Provide an alternate TLS server name to accept instead of api.akita.software")
+	rootCmd.PersistentFlags().MarkHidden("server-tls-name")
+
 	// Semi-secret somewhat-safe flags
 	rootCmd.PersistentFlags().Int64Var(&http.MaximumHTTPLength, "max-http-length", 10*1024*1024, "Maximum size of HTTP body to capture")
 	rootCmd.PersistentFlags().MarkHidden("max-http-length")

--- a/rest/base_client.go
+++ b/rest/base_client.go
@@ -22,6 +22,15 @@ import (
 // was buried in the "internal" package where we couldn't use it.
 var Domain string
 
+// Use a proxy, "" is none. (This is because the flags package doesn't support Optional)
+var UseProxy string
+
+// Connect even if the certificate does not validate.
+var PermitInvalidCertificate bool
+
+// Accept a server name other than the expected one in the TLS handshake
+var ExpectedServerName string
+
 // Error handling (to call into the telemetry library without
 // creating a circular dependency.)
 type APIErrorHandler = func(method string, path string, e error)

--- a/rest/base_client.go
+++ b/rest/base_client.go
@@ -23,7 +23,9 @@ import (
 var Domain string
 
 // Use a proxy, "" is none. (This is because the flags package doesn't support Optional)
-var UseProxy string
+// May be a URL, a domain name, or an IP address.  HTTP is assumed as the protocol if
+// none is provided.
+var ProxyAddress string
 
 // Connect even if the certificate does not validate.
 var PermitInvalidCertificate bool

--- a/rest/http.go
+++ b/rest/http.go
@@ -90,6 +90,7 @@ func initHTTPClient() {
 	}
 	transport.TLSClientConfig = &tls.Config{}
 	if PermitInvalidCertificate {
+		printer.Warningf("Disabling TLS checking; sending traffic without verifying identity of Akita servers.\n")
 		transport.TLSClientConfig.InsecureSkipVerify = true
 	}
 	if ExpectedServerName != "" {

--- a/rest/http.go
+++ b/rest/http.go
@@ -73,11 +73,11 @@ func initHTTPClient() {
 		MaxIdleConns:    3,
 		IdleConnTimeout: 60 * time.Second,
 	}
-	if UseProxy != "" {
-		proxyURL, err := url.Parse(UseProxy)
+	if ProxyAddress != "" {
+		proxyURL, err := url.Parse(ProxyAddress)
 		if err != nil {
 			proxyURL = &url.URL{
-				Host: UseProxy,
+				Host: ProxyAddress,
 			}
 		}
 		if proxyURL.Scheme == "" {


### PR DESCRIPTION
Would like to have a user who is blocked try this out.

Adds ability to specify an alternate server name, negative and positive testing:
```
mark@ubuntu:~/akita-cli$ sudo -E bin/akita apidump --server-tls-name api.akitasoftare.com --project mgg-test --debug
[INFO] Akita Agent 0.0.0
[ERROR]  request failed [error Get "https://api.akita.software/v1/services": x509: certificate is valid for api.akita.software, not api.akitasoftare.com method GET url https://api.akita.software/v1/services]

mark@ubuntu:~/akita-cli$ sudo -E bin/akita apidump --server-tls-name api.akita.software --project mgg-test --debug.
[INFO] Akita Agent 0.0.0
[DEBUG] Project name "mgg-test" is "svc_14kS9tQ5U2gS98De4TZIwc"
...
```

Adds configuration flag for proxy, accepts either URL or host:port.
```
mark@ubuntu:~/akita-cli$ sudo -E bin/akita apidump --proxy 173.243.116.9:55555 --project mgg-test --debug
[INFO] Telemetry unavailable; no Segment key configured.
[INFO] This is caused by building from source rather than using an official build.
[INFO] Akita Agent 0.0.0
[DEBUG] Using ID "apk_774YdN0HsvbPiwUtfpuPyR" for telemetry
[DEBUG]  CI not detected: `CI` is not set to `TRUE` in the environment (currently unset)
[DEBUG] Using proxy http://173.243.116.9:55555
[DEBUG] Project name "mgg-test" is "svc_14kS9tQ5U2gS98De4TZIwc"
...
[INFO] Created new trace on Akita Cloud: akita://mgg-test:trace:bold-lantern-3bd9ecf6
```

Also adds --skip-validate flag for bypassing TLS checks.
