### PR TITLE
Add a source tag indicating the trace comes from the NGINX integration

### DIFF
--- a/integrations/nginx/backend.go
+++ b/integrations/nginx/backend.go
@@ -167,7 +167,9 @@ func NewNginxBackend(args *Args) (*NginxBackend, error) {
 	b.backendSvc = backendSvc
 	b.learnClient = rest.NewLearnClient(args.Domain, args.ClientID, backendSvc)
 
-	traceTags := map[tags.Key]string{}
+	traceTags := map[tags.Key]string{
+		tags.XAkitaSource: "nginx",
+	}
 	traceName := util.RandomLearnSessionName()
 	backendLrn, err := util.NewLearnSession(args.Domain, args.ClientID, b.backendSvc, traceName, traceTags, nil)
 	if err != nil {


### PR DESCRIPTION
I did not edit akita-libs to add this as a source type.

