### PR TITLE
Add command to generate Kubernetes Secrets

### DIFF
--- a/cmd/internal/cmderr/checks.go
+++ b/cmd/internal/cmderr/checks.go
@@ -1,0 +1,26 @@
+package cmderr
+
+import (
+	"errors"
+	"github.com/akitasoftware/akita-cli/cfg"
+	"github.com/akitasoftware/akita-cli/env"
+	"github.com/akitasoftware/akita-cli/printer"
+)
+
+// Checks that a user has configured their API key and secret and returned them.
+// If the user has not configured their API key, a user-friendly error message is printed and an error is returned.
+func RequireAPICredentials(explanation string) (string, string, error) {
+	key, secret := cfg.GetAPIKeyAndSecret()
+	if key == "" || secret == "" {
+		printer.Errorf("No Akita API key configured. %s\n", explanation)
+		if env.InDocker() {
+			printer.Infof("Please set the AKITA_API_KEY_ID and AKITA_API_KEY_SECRET environment variables on the Docker command line.\n")
+		} else {
+			printer.Infof("Use the AKITA_API_KEY_ID and AKITA_API_KEY_SECRET environment variables, or run 'akita login'.\n")
+		}
+
+		return "", "", AkitaErr{Err: errors.New("could not find an Akita API key to use")}
+	}
+
+	return key, secret, nil
+}

--- a/cmd/internal/ecs/ecs.go
+++ b/cmd/internal/ecs/ecs.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 
 	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
-	"github.com/akitasoftware/akita-cli/env"
-	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-cli/rest"
 	"github.com/akitasoftware/akita-cli/telemetry"
 	"github.com/akitasoftware/akita-cli/util"
@@ -70,8 +68,18 @@ func init() {
 	Cmd.PersistentFlags().StringVar(&awsRegionFlag, "region", "", "The AWS region in which your ECS cluster resides.")
 	Cmd.PersistentFlags().StringVar(&ecsClusterFlag, "cluster", "", "The name or ARN of your ECS cluster.")
 	Cmd.PersistentFlags().StringVar(&ecsServiceFlag, "service", "", "The name or ARN of your ECS service.")
-	Cmd.PersistentFlags().StringVar(&ecsTaskDefinitionFlag, "task", "", "The name of your ECS task definition to modify.")
-	Cmd.PersistentFlags().BoolVar(&dryRunFlag, "dry-run", false, "Perform a dry run: show what will be done, but do not modify ECS.")
+	Cmd.PersistentFlags().StringVar(
+		&ecsTaskDefinitionFlag,
+		"task",
+		"",
+		"The name of your ECS task definition to modify.",
+	)
+	Cmd.PersistentFlags().BoolVar(
+		&dryRunFlag,
+		"dry-run",
+		false,
+		"Perform a dry run: show what will be done, but do not modify ECS.",
+	)
 
 	// Support for credentials in a nonstandard location
 	Cmd.PersistentFlags().StringVar(&awsCredentialsFlag, "aws-credentials", "", "Location of AWS credentials file.")
@@ -83,18 +91,9 @@ func init() {
 
 func addAgentToECS(cmd *cobra.Command, args []string) error {
 	// Check for API key
-	key, secret, err := cmderr.RequireAPICredentials("The Akita agent must have an API key in order to capture traces.")
+	_, _, err := cmderr.RequireAPICredentials("The Akita agent must have an API key in order to capture traces.")
 	if err != nil {
 		return err
-	}
-	if key == "" || secret == "" {
-		printer.Errorf("No Akita API key configured. The Akita agent must have an API key in order to capture traces.\n")
-		if env.InDocker() {
-			printer.Infof("Please set the AKITA_API_KEY_ID and AKITA_API_KEY_SECRET environment variables on the Docker command line.\n")
-		} else {
-			printer.Infof("Use the AKITA_API_KEY_ID and AKITA_API_KEY_SECRET environment variables, or run 'akita login'.\n")
-		}
-		return cmderr.AkitaErr{Err: errors.New("Could not find an Akita API key to use.")}
 	}
 
 	// Check project's existence
@@ -106,9 +105,20 @@ func addAgentToECS(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		// TODO: we _could_ offer to create it, instead.
 		if strings.Contains(err.Error(), "cannot determine project ID") {
-			return cmderr.AkitaErr{Err: fmt.Errorf("Could not find the project %q in the Akita cloud. Please create it from the Akita web console before proceeding.", projectFlag)}
+			return cmderr.AkitaErr{
+				Err: fmt.Errorf(
+					"Could not find the project %q in the Akita cloud. Please create it from the Akita web console before proceeding.",
+					projectFlag,
+				),
+			}
 		} else {
-			return cmderr.AkitaErr{Err: errors.Wrapf(err, "Could not look up the project %q in the Akita cloud", projectFlag)}
+			return cmderr.AkitaErr{
+				Err: errors.Wrapf(
+					err,
+					"Could not look up the project %q in the Akita cloud",
+					projectFlag,
+				),
+			}
 		}
 	}
 

--- a/cmd/internal/ecs/ecs.go
+++ b/cmd/internal/ecs/ecs.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/akitasoftware/akita-cli/cfg"
 	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
 	"github.com/akitasoftware/akita-cli/env"
 	"github.com/akitasoftware/akita-cli/printer"
@@ -84,7 +83,10 @@ func init() {
 
 func addAgentToECS(cmd *cobra.Command, args []string) error {
 	// Check for API key
-	key, secret := cfg.GetAPIKeyAndSecret()
+	key, secret, err := cmderr.RequireAPICredentials("The Akita agent must have an API key in order to capture traces.")
+	if err != nil {
+		return err
+	}
 	if key == "" || secret == "" {
 		printer.Errorf("No Akita API key configured. The Akita agent must have an API key in order to capture traces.\n")
 		if env.InDocker() {
@@ -100,7 +102,7 @@ func addAgentToECS(cmd *cobra.Command, args []string) error {
 		return errors.New("Must specify the name of your Akita project with the --project flag.")
 	}
 	frontClient := rest.NewFrontClient(rest.Domain, telemetry.GetClientID())
-	_, err := util.GetServiceIDByName(frontClient, projectFlag)
+	_, err = util.GetServiceIDByName(frontClient, projectFlag)
 	if err != nil {
 		// TODO: we _could_ offer to create it, instead.
 		if strings.Contains(err.Error(), "cannot determine project ID") {

--- a/cmd/internal/kube/kube.go
+++ b/cmd/internal/kube/kube.go
@@ -8,7 +8,7 @@ import (
 
 var Cmd = &cobra.Command{
 	Use:   "kube",
-	Short: "Gateway to Kubernetes related utilities",
+	Short: "Install Akita in your Kubernetes cluster",
 	RunE: func(_ *cobra.Command, _ []string) error {
 		return cmderr.AkitaErr{Err: errors.New("no subcommand specified")}
 	},

--- a/cmd/internal/kube/kube.go
+++ b/cmd/internal/kube/kube.go
@@ -1,0 +1,15 @@
+package kube
+
+import (
+	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "kube",
+	Short: "Gateway to Kubernetes related utilities",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return cmderr.AkitaErr{Err: errors.New("no subcommand specified")}
+	},
+}

--- a/cmd/internal/kube/kube.go
+++ b/cmd/internal/kube/kube.go
@@ -9,6 +9,10 @@ import (
 var Cmd = &cobra.Command{
 	Use:   "kube",
 	Short: "Install Akita in your Kubernetes cluster",
+	Aliases: []string{
+		"k8s",
+		"kubernetes",
+	},
 	RunE: func(_ *cobra.Command, _ []string) error {
 		return cmderr.AkitaErr{Err: errors.New("no subcommand specified")}
 	},

--- a/cmd/internal/kube/secret.go
+++ b/cmd/internal/kube/secret.go
@@ -23,7 +23,7 @@ var (
 
 var secretCmd = &cobra.Command{
 	Use:   "secret",
-	Short: "Generate a Kubernetes secret config for Akita",
+	Short: "Generate a Kubernetes secret containing the Akita credentials",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		key, secret, err := cmderr.RequireAPICredentials("Akita API key is required for Kubernetes Secret generation")
 		if err != nil {
@@ -117,7 +117,7 @@ func init() {
 		"namespace",
 		"n",
 		"",
-		"The Kuberenetes namespace the secret should be applied to",
+		"The Kubernetes namespace the secret should be applied to",
 	)
 	_ = secretCmd.MarkFlagRequired("namespace")
 

--- a/cmd/internal/kube/secret.go
+++ b/cmd/internal/kube/secret.go
@@ -84,10 +84,9 @@ func handleSecretGeneration(namespace, key, secret, output string) (string, erro
 	if err != nil {
 		return "", cmderr.AkitaErr{Err: errors.Wrap(err, "failed to create output file")}
 	}
-
 	defer secretFile.Close()
 
-	buf := new(bytes.Buffer)
+	buf := bytes.NewBuffer([]byte{})
 
 	err = secretTemplate.Execute(buf, input)
 	if err != nil {

--- a/cmd/internal/kube/secret.go
+++ b/cmd/internal/kube/secret.go
@@ -1,0 +1,89 @@
+package kube
+
+import (
+	"encoding/base64"
+	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"log"
+	"os"
+	"text/template"
+)
+
+
+var (
+	output                string
+	namespace             string
+	// Store a parsed representation of /template/akita-secret.tmpl
+	secretTemplate        *template.Template
+)
+
+var secretCmd = &cobra.Command{
+	Use: "secret",
+	Short: "Generate a Kubernetes secret config for Akita",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if namespace == "" {
+			return cmderr.AkitaErr{Err: errors.New("namespace flag not set")}
+		}
+
+		key, secret, err := cmderr.RequireAPICredentials("Akita API key is required for Kubernetes Secret generation")
+		if err != nil {
+			return err
+		}
+
+		return handleSecretGeneration(namespace, key, secret, output)
+	},
+}
+
+// Represents the input used by secretTemplate
+type secretTemplateInput struct {
+	//
+	Namespace string
+	APIKey    string
+	APISecret string
+}
+
+func handleSecretGeneration(namespace, key, secret, output string) error {
+
+	input := secretTemplateInput{
+		Namespace: namespace,
+		APIKey:    base64.StdEncoding.EncodeToString([]byte(key)),
+		APISecret: base64.StdEncoding.EncodeToString([]byte(secret)),
+	}
+
+	file, err := os.Create(output)
+	if err != nil {
+		return cmderr.AkitaErr{Err: errors.Wrap(err, "failed to create output file")}
+	}
+
+	defer file.Close()
+
+	err = secretTemplate.Execute(file, input)
+	if err != nil {
+		return cmderr.AkitaErr{Err: errors.Wrap(err, "failed to generate template")}
+	}
+
+	return nil
+}
+
+func init() {
+	var err error
+
+	secretTemplate, err = template.ParseFS(templateFS, "template/akita-secret.tmpl")
+	if err != nil {
+		log.Fatalf("unable to parse kube secret template: %v", err)
+	}
+
+	// Create a flag on the root subcommand to avoid
+	secretCmd.Flags().StringVarP(
+		&namespace,
+		"namespace",
+		"n",
+		"",
+		"The Kuberenetes namespace the secret should be applied to",
+	)
+
+	secretCmd.Flags().StringVarP(&output, "output", "o", "akita-secret.yml", "File to output the generated secret.")
+
+	Cmd.AddCommand(secretCmd)
+}

--- a/cmd/internal/kube/secret.go
+++ b/cmd/internal/kube/secret.go
@@ -114,16 +114,15 @@ func createSecretFile(path string) (*os.File, error) {
 		return nil, errors.Wrapf(err, "failed to resolve the absolute path of the output directory")
 	}
 
+	// Check that the output directory exists
+	if _, statErr := os.Stat(absOutputDir); os.IsNotExist(statErr) {
+		return nil, errors.Errorf("output directory %s does not exist", absOutputDir)
+	}
+
 	// Check if the output file already exists
 	outputFilePath := filepath.Join(absOutputDir, outputName)
 	if _, statErr := os.Stat(outputFilePath); statErr == nil {
 		return nil, errors.Errorf("output file %s already exists", outputFilePath)
-	}
-
-	// Create the output directory if it doesn't exist
-	err = os.MkdirAll(absOutputDir, 0755)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create the output directory")
 	}
 
 	// Create the output file in the output directory

--- a/cmd/internal/kube/secret.go
+++ b/cmd/internal/kube/secret.go
@@ -48,7 +48,8 @@ var secretCmd = &cobra.Command{
 			return cmderr.AkitaErr{Err: errors.Wrapf(err, "Failed to write generated secret to %s", output)}
 		}
 
-		printer.Infof("Generated Kubernetes secret file to %s", secretFilePathFlag)
+		printer.Infof("Successfully generated a Kubernetes Secret file for Akita at %s\n", secretFilePathFlag)
+		printer.Infof("To apply, run: kubectl apply -f %s\n", secretFilePathFlag)
 		return nil
 	},
 	// Override the parent command's PersistentPreRun to prevent any logs from being printed.

--- a/cmd/internal/kube/secret.go
+++ b/cmd/internal/kube/secret.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	output    string
-	namespace string
+	outputFlag    string
+	namespaceFlag string
 	// Store a parsed representation of /template/akita-secret.tmpl
 	secretTemplate *template.Template
 )
@@ -30,12 +30,12 @@ var secretCmd = &cobra.Command{
 			return err
 		}
 
-		err = handleSecretGeneration(namespace, key, secret, output)
+		err = handleSecretGeneration(namespaceFlag, key, secret, outputFlag)
 		if err != nil {
 			return err
 		}
 
-		printer.Infoln("Generated Kubernetes secret config to ", output)
+		printer.Infoln("Generated Kubernetes secret config to ", outputFlag)
 		return nil
 	},
 }
@@ -106,14 +106,14 @@ func createSecretFile(path string) (*os.File, error) {
 
 func init() {
 	secretCmd.Flags().StringVarP(
-		&namespace,
+		&namespaceFlag,
 		"namespace",
 		"n",
 		"default",
 		"The Kubernetes namespace the secret should be applied to",
 	)
 
-	secretCmd.Flags().StringVarP(&output, "output", "o", "akita-secret.yml", "File to output the generated secret.")
+	secretCmd.Flags().StringVarP(&outputFlag, "output", "o", "akita-secret.yml", "File to output the generated secret.")
 
 	Cmd.AddCommand(secretCmd)
 }

--- a/cmd/internal/kube/secret.go
+++ b/cmd/internal/kube/secret.go
@@ -14,32 +14,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
 var (
-	output                string
-	namespace             string
+	output    string
+	namespace string
 	// Store a parsed representation of /template/akita-secret.tmpl
-	secretTemplate        *template.Template
+	secretTemplate *template.Template
 )
 
 var secretCmd = &cobra.Command{
-	Use: "secret",
+	Use:   "secret",
 	Short: "Generate a Kubernetes secret config for Akita",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if namespace == "" {
-			return cmderr.AkitaErr{Err: errors.New("namespace flag not set")}
-		}
-
 		key, secret, err := cmderr.RequireAPICredentials("Akita API key is required for Kubernetes Secret generation")
 		if err != nil {
 			return err
 		}
 
-		err = handleSecretGeneration(namespace, key, secret, output)	
+		err = handleSecretGeneration(namespace, key, secret, output)
 		if err != nil {
 			return err
 		}
-
 
 		printer.Infoln("Generated Kubernetes secret config to ", output)
 		return nil
@@ -125,6 +119,7 @@ func init() {
 		"",
 		"The Kuberenetes namespace the secret should be applied to",
 	)
+	_ = secretCmd.MarkFlagRequired("namespace")
 
 	secretCmd.Flags().StringVarP(&output, "output", "o", "akita-secret.yml", "File to output the generated secret.")
 

--- a/cmd/internal/kube/secret.go
+++ b/cmd/internal/kube/secret.go
@@ -2,12 +2,15 @@ package kube
 
 import (
 	"encoding/base64"
-	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 	"log"
 	"os"
 	"text/template"
+
+	"github.com/akitasoftware/akita-cli/printer"
+
+	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 
@@ -31,7 +34,14 @@ var secretCmd = &cobra.Command{
 			return err
 		}
 
-		return handleSecretGeneration(namespace, key, secret, output)
+		err = handleSecretGeneration(namespace, key, secret, output)	
+		if err != nil {
+			return err
+		}
+
+
+		printer.Infof("Generated Kubernetes secret config to %s", output)
+		return nil
 	},
 }
 

--- a/cmd/internal/kube/secret.go
+++ b/cmd/internal/kube/secret.go
@@ -125,7 +125,8 @@ func writeSecretFile(data []byte, filePath string) error {
 	return nil
 }
 
-// Creates a file at the give path to be used for storing of the generated Secret configuration
+// Creates a file at the given path to be used for storing of the generated Secret configuration
+// If the directory provided does not exist, an error will be returned and the file will not be created
 func createSecretFile(path string) (*os.File, error) {
 	// Split the output flag value into directory and filename
 	outputDir, outputName := filepath.Split(path)

--- a/cmd/internal/kube/secret.go
+++ b/cmd/internal/kube/secret.go
@@ -105,21 +105,13 @@ func createSecretFile(path string) (*os.File, error) {
 }
 
 func init() {
-	var err error
-
-	secretTemplate, err = template.ParseFS(templateFS, "template/akita-secret.tmpl")
-	if err != nil {
-		log.Fatalf("unable to parse kube secret template: %v", err)
-	}
-
 	secretCmd.Flags().StringVarP(
 		&namespace,
 		"namespace",
 		"n",
-		"",
+		"default",
 		"The Kubernetes namespace the secret should be applied to",
 	)
-	_ = secretCmd.MarkFlagRequired("namespace")
 
 	secretCmd.Flags().StringVarP(&output, "output", "o", "akita-secret.yml", "File to output the generated secret.")
 

--- a/cmd/internal/kube/secret.go
+++ b/cmd/internal/kube/secret.go
@@ -47,6 +47,7 @@ type secretTemplateInput struct {
 	APISecret string
 }
 
+// Generates a Kubernetes secret config file for Akita
 func handleSecretGeneration(namespace, key, secret, output string) error {
 
 	input := secretTemplateInput{
@@ -111,7 +112,6 @@ func init() {
 		log.Fatalf("unable to parse kube secret template: %v", err)
 	}
 
-	// Create a flag on the root subcommand to avoid
 	secretCmd.Flags().StringVarP(
 		&namespace,
 		"namespace",

--- a/cmd/internal/kube/secret_test.go
+++ b/cmd/internal/kube/secret_test.go
@@ -1,0 +1,38 @@
+package kube
+
+import (
+	_ "embed"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+//go:embed test_resource/akita-secret.yml
+var testAkitaSecretYAML []byte
+
+func Test_secretGeneration(t *testing.T) {
+	// GIVEN
+	const (
+		namespace = "default"
+		key       = "api-key"
+		secret    = "api-secret"
+	)
+
+	dir := t.TempDir()
+	actualOutput := filepath.Join(dir, "akita-secret.yml")
+
+	// WHEN
+	err := handleSecretGeneration(namespace, key, secret, actualOutput)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+
+	// THEN
+	actualFile, err := os.ReadFile(actualOutput)
+	if err != nil {
+		t.Errorf("Failed to read generated file: %v", err)
+	}
+
+	assert.Equal(t, string(testAkitaSecretYAML), string(actualFile))
+}

--- a/cmd/internal/kube/secret_test.go
+++ b/cmd/internal/kube/secret_test.go
@@ -23,7 +23,7 @@ func Test_secretGeneration(t *testing.T) {
 	actualOutput := filepath.Join(dir, "configurations", "akita-secret.yml")
 
 	// WHEN
-	err := handleSecretGeneration(namespace, key, secret, actualOutput)
+	actualContent, err := handleSecretGeneration(namespace, key, secret, actualOutput)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -35,4 +35,5 @@ func Test_secretGeneration(t *testing.T) {
 	}
 
 	assert.Equal(t, string(testAkitaSecretYAML), string(actualFile))
+	assert.Equal(t, string(testAkitaSecretYAML), actualContent)
 }

--- a/cmd/internal/kube/secret_test.go
+++ b/cmd/internal/kube/secret_test.go
@@ -20,7 +20,7 @@ func Test_secretGeneration(t *testing.T) {
 	)
 
 	dir := t.TempDir()
-	actualOutput := filepath.Join(dir, "configurations", "akita-secret.yml")
+	actualOutput := filepath.Join(dir, "akita-secret.yml")
 
 	// WHEN
 	actualContent, err := handleSecretGeneration(namespace, key, secret, actualOutput)

--- a/cmd/internal/kube/secret_test.go
+++ b/cmd/internal/kube/secret_test.go
@@ -20,7 +20,7 @@ func Test_secretGeneration(t *testing.T) {
 	)
 
 	dir := t.TempDir()
-	actualOutput := filepath.Join(dir, "akita-secret.yml")
+	actualOutput := filepath.Join(dir, "configurations", "akita-secret.yml")
 
 	// WHEN
 	err := handleSecretGeneration(namespace, key, secret, actualOutput)

--- a/cmd/internal/kube/secret_test.go
+++ b/cmd/internal/kube/secret_test.go
@@ -23,17 +23,17 @@ func Test_secretGeneration(t *testing.T) {
 	actualOutput := filepath.Join(dir, "akita-secret.yml")
 
 	// WHEN
-	actualContent, err := handleSecretGeneration(namespace, key, secret, actualOutput)
+	output, err := handleSecretGeneration(namespace, key, secret, actualOutput)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
 
-	// THEN
-	actualFile, err := os.ReadFile(actualOutput)
+	generatedFile, err := os.ReadFile(actualOutput)
 	if err != nil {
-		t.Errorf("Failed to read generated file: %v", err)
+		t.Errorf("Failed to read generated generatedFile: %v", err)
 	}
 
-	assert.Equal(t, string(testAkitaSecretYAML), string(actualFile))
-	assert.Equal(t, string(testAkitaSecretYAML), actualContent)
+	// THEN
+	assert.Equal(t, string(testAkitaSecretYAML), string(generatedFile))
+	assert.Equal(t, string(testAkitaSecretYAML), output)
 }

--- a/cmd/internal/kube/secret_test.go
+++ b/cmd/internal/kube/secret_test.go
@@ -3,8 +3,6 @@ package kube
 import (
 	_ "embed"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"path/filepath"
 	"testing"
 )
 
@@ -19,21 +17,12 @@ func Test_secretGeneration(t *testing.T) {
 		secret    = "api-secret"
 	)
 
-	dir := t.TempDir()
-	actualOutput := filepath.Join(dir, "akita-secret.yml")
-
 	// WHEN
-	output, err := handleSecretGeneration(namespace, key, secret, actualOutput)
+	output, err := handleSecretGeneration(namespace, key, secret)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
 
-	generatedFile, err := os.ReadFile(actualOutput)
-	if err != nil {
-		t.Errorf("Failed to read generated generatedFile: %v", err)
-	}
-
 	// THEN
-	assert.Equal(t, string(testAkitaSecretYAML), string(generatedFile))
-	assert.Equal(t, string(testAkitaSecretYAML), output)
+	assert.Equal(t, testAkitaSecretYAML, output)
 }

--- a/cmd/internal/kube/template.go
+++ b/cmd/internal/kube/template.go
@@ -1,0 +1,6 @@
+package kube
+
+import "embed"
+
+//go:embed template
+var templateFS embed.FS

--- a/cmd/internal/kube/template/akita-secret.tmpl
+++ b/cmd/internal/kube/template/akita-secret.tmpl
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: akita-secrets
+  namespace: {{.Namespace}}
+type: Opaque
+data:
+  akita-api-key: {{.APIKey}}
+  akita-api-secret: {{.APISecret}}

--- a/cmd/internal/kube/test_resource/akita-secret.yml
+++ b/cmd/internal/kube/test_resource/akita-secret.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: akita-secrets
+  namespace: default
+type: Opaque
+data:
+  akita-api-key: YXBpLWtleQ==
+  akita-api-secret: YXBpLXNlY3JldA==

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,6 +74,8 @@ var (
 )
 
 func preRun(cmd *cobra.Command, args []string) {
+	telemetry.Init(true)
+
 	switch logFormatFlag {
 	case "json":
 		printer.SwitchToJSON()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/akitasoftware/akita-cli/cmd/internal/daemon"
 	"github.com/akitasoftware/akita-cli/cmd/internal/ecs"
 	"github.com/akitasoftware/akita-cli/cmd/internal/get"
+	"github.com/akitasoftware/akita-cli/cmd/internal/kube"
 	"github.com/akitasoftware/akita-cli/cmd/internal/learn"
 	"github.com/akitasoftware/akita-cli/cmd/internal/legacy"
 	"github.com/akitasoftware/akita-cli/cmd/internal/login"
@@ -279,6 +280,7 @@ func init() {
 	rootCmd.AddCommand(ci_guard.GuardCommand(get.Cmd))
 	rootCmd.AddCommand(ecs.Cmd)
 	rootCmd.AddCommand(nginx.Cmd)
+	rootCmd.AddCommand(kube.Cmd)
 
 	// Legacy commands, included for backward compatibility but are hidden.
 	legacy.SessionsCmd.Hidden = true

--- a/learn/parse_http_test.go
+++ b/learn/parse_http_test.go
@@ -3,6 +3,7 @@ package learn
 import (
 	"bytes"
 	"compress/flate"
+	"github.com/akitasoftware/akita-cli/telemetry"
 	"net/http"
 	"strings"
 	"testing"
@@ -127,6 +128,7 @@ type parseTest struct {
 }
 
 func TestParseHTTPRequest(t *testing.T) {
+	telemetry.Init(false)
 	standardMethodMeta := &as.MethodMeta{
 		Meta: &as.MethodMeta_Http{
 			Http: &as.HTTPMethodMeta{

--- a/pcap/stream_test.go
+++ b/pcap/stream_test.go
@@ -2,6 +2,7 @@ package pcap
 
 import (
 	"fmt"
+	"github.com/akitasoftware/akita-cli/telemetry"
 	"net"
 	"testing"
 	"time"
@@ -127,6 +128,7 @@ func runTCPFlowTestCase(c tcpFlowTestCase) error {
 }
 
 func TestTCPFlow(t *testing.T) {
+	telemetry.Init(false)
 	testCases := []tcpFlowTestCase{
 		{
 			name:   "unparsable single byte",

--- a/pcap/stream_test.go
+++ b/pcap/stream_test.go
@@ -2,7 +2,6 @@ package pcap
 
 import (
 	"fmt"
-	"github.com/akitasoftware/akita-cli/telemetry"
 	"net"
 	"testing"
 	"time"
@@ -128,7 +127,6 @@ func runTCPFlowTestCase(c tcpFlowTestCase) error {
 }
 
 func TestTCPFlow(t *testing.T) {
-	telemetry.Init(false)
 	testCases := []tcpFlowTestCase{
 		{
 			name:   "unparsable single byte",

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	// Shared client object
-	analyticsClient analytics.Client
+	analyticsClient analytics.Client = nullClient{}
 
 	// Is analytics enabled?
 	analyticsEnabled bool


### PR DESCRIPTION
This adds a new command `akita kube secret` which generates a Kubernetes secret configuration file that stores a user's base-64 encoded Akita API credentials.

To simplify file generation, I've used go's built-in templating utilities; `akita-secret.tmpl` is used as the template for creating the secret.

Example usage:
```
% ./bin/akita kube secret -n test -o ./tmp/deployments/configs/akita-secrets.yml
[INFO] Akita Agent 0.0.0
[INFO] Generated Kubernetes secret config to ./tmp/deployments/configs/akita-secrets.yml                                                                                                               

% less ./tmp/deployments/configs/akita-secrets.yml 
apiVersion: v1
kind: Secret
metadata:
  name: akita-secrets
  namespace: test
type: Opaque
data:
  akita-api-key: YXBrXzN1Y2h6WDyiOdyMzg2NldiM3Y0Q2Y=
  akita-api-secret: YmUzMzY5OTllNzNjc2DY3MmI5OWQzMTVmAnGaKmYzN2NlNjc2NWRiZDY4MzNjMWRkMzA4YjFjZDFlNWZkZg==
./tmp/deployments/configs/akita-secrets.yml lines 1-9/9 (END)

