### PR TITLE
Fix help messages for kube commands

### DIFF
--- a/cmd/internal/kube/kube.go
+++ b/cmd/internal/kube/kube.go
@@ -1,8 +1,6 @@
 package kube
 
 import (
-	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -12,8 +10,5 @@ var Cmd = &cobra.Command{
 	Aliases: []string{
 		"k8s",
 		"kubernetes",
-	},
-	RunE: func(_ *cobra.Command, _ []string) error {
-		return cmderr.AkitaErr{Err: errors.New("no subcommand specified")}
 	},
 }

--- a/cmd/internal/kube/secret.go
+++ b/cmd/internal/kube/secret.go
@@ -23,7 +23,7 @@ var (
 var secretCmd = &cobra.Command{
 	Use:   "secret",
 	Short: "Generate a Kubernetes Secret manifest containing your Akita API credentials",
-	Long: "Generate a Kubernetes Secret manfiest containing your Akita API credentials and output the result to standard output or a file",
+	Long: "Generate a Kubernetes Secret manifest containing your Akita API credentials and output the result to standard output or a file",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		key, secret, err := cmderr.RequireAPICredentials("Akita API key is required for Kubernetes Secret generation")
 		if err != nil {

--- a/cmd/internal/kube/secret.go
+++ b/cmd/internal/kube/secret.go
@@ -22,7 +22,8 @@ var (
 
 var secretCmd = &cobra.Command{
 	Use:   "secret",
-	Short: "Generate a Kubernetes secret containing the Akita credentials",
+	Short: "Generate a Kubernetes Secret manifest",
+	Long: "Generate a Kubernetes Secret manfiest to store your Akita API credentials and output the result to standard output or a file",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		key, secret, err := cmderr.RequireAPICredentials("Akita API key is required for Kubernetes Secret generation")
 		if err != nil {

--- a/cmd/internal/kube/secret.go
+++ b/cmd/internal/kube/secret.go
@@ -22,8 +22,8 @@ var (
 
 var secretCmd = &cobra.Command{
 	Use:   "secret",
-	Short: "Generate a Kubernetes Secret manifest",
-	Long: "Generate a Kubernetes Secret manfiest to store your Akita API credentials and output the result to standard output or a file",
+	Short: "Generate a Kubernetes Secret manifest containing your Akita API credentials",
+	Long: "Generate a Kubernetes Secret manfiest containing your Akita API credentials and output the result to standard output or a file",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		key, secret, err := cmderr.RequireAPICredentials("Akita API key is required for Kubernetes Secret generation")
 		if err != nil {


### PR DESCRIPTION
This fixes an issue where the `kube` command did not show a help message as intended. For better clarity, I've also made some minor updates to the `kube secret` command description.
