### PR TITLE
Don't qualify domain for local back ends

### DIFF
--- a/rest/base_client.go
+++ b/rest/base_client.go
@@ -64,13 +64,13 @@ type baseClient struct {
 
 func newBaseClient(rawHost string, cli akid.ClientID) baseClient {
 	host := "api." + rawHost
-	// If rawHost is IP or IP:port, use that directly. This is mostly to support
-	// tests.
+	// If rawHost is IP, IP:port, localhost, or localhost:port, use that
+	// directly. This is mostly to support tests.
 	if h, _, err := net.SplitHostPort(rawHost); err == nil {
-		if net.ParseIP(h) != nil {
+		if h == "localhost" || net.ParseIP(h) != nil {
 			host = rawHost
 		}
-	} else if net.ParseIP(rawHost) != nil {
+	} else if rawHost == "localhost" || net.ParseIP(rawHost) != nil {
 		host = rawHost
 	}
 


### PR DESCRIPTION
When running against `localhost:port`, don't add the "api." prefix. While Linux will resolve `api.localhost` an unmodified `/etc/hosts`, this is not true for macOS.