### PR TITLE
[OBS-37|38] Add support for Postman flags in `kube inject` command

### DIFF
--- a/cfg/credentials.go
+++ b/cfg/credentials.go
@@ -67,6 +67,7 @@ func initCreds() {
 	creds.AutomaticEnv()
 	creds.BindEnv("default.api_key_id", "AKITA_API_KEY_ID")
 	creds.BindEnv("default.api_key_secret", "AKITA_API_KEY_SECRET")
+	creds.BindEnv("default.postman_api_key", "AKITA_POSTMAN_API_KEY")
 
 	if err := creds.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {

--- a/cfg/credentials.go
+++ b/cfg/credentials.go
@@ -67,7 +67,7 @@ func initCreds() {
 	creds.AutomaticEnv()
 	creds.BindEnv("default.api_key_id", "AKITA_API_KEY_ID")
 	creds.BindEnv("default.api_key_secret", "AKITA_API_KEY_SECRET")
-	creds.BindEnv("default.postman_api_key", "AKITA_POSTMAN_API_KEY")
+	creds.BindEnv("default.postman_api_key", "POSTMAN_API_KEY")
 
 	if err := creds.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {

--- a/cmd/internal/cmderr/checks.go
+++ b/cmd/internal/cmderr/checks.go
@@ -10,7 +10,7 @@ import (
 
 // Checks that a user has configured their API key and secret and returned them.
 // If the user has not configured their API key, a user-friendly error message is printed and an error is returned.
-func RequireAPICredentials(explanation string) (string, string, error) {
+func RequireAkitaAPICredentials(explanation string) (string, string, error) {
 	key, secret := cfg.GetAPIKeyAndSecret()
 	if key == "" || secret == "" {
 		printer.Errorf("No Akita API key configured. %s\n", explanation)
@@ -24,4 +24,22 @@ func RequireAPICredentials(explanation string) (string, string, error) {
 	}
 
 	return key, secret, nil
+}
+
+// Checks that a user has configured their Postman API key and returned them.
+// If the user has not configured their API key, a user-friendly error message is printed and an error is returned.
+func RequirePostmanAPICredentials(explanation string) (string, error) {
+	key, _ := cfg.GetPostmanAPIKeyAndEnvironment()
+	if key == "" {
+		printer.Errorf("No Postman API key configured. %s\n", explanation)
+		if env.InDocker() {
+			printer.Infof("Please set the POSTMAN_API_KEY environment variables on the Docker command line.\n")
+		} else {
+			printer.Infof("Use the POSTMAN_API_KEY environment variables, or run 'akita login'.\n")
+		}
+
+		return "", AkitaErr{Err: errors.New("could not find an Postman API key to use")}
+	}
+
+	return key, nil
 }

--- a/cmd/internal/cmderr/checks.go
+++ b/cmd/internal/cmderr/checks.go
@@ -2,6 +2,7 @@ package cmderr
 
 import (
 	"errors"
+
 	"github.com/akitasoftware/akita-cli/cfg"
 	"github.com/akitasoftware/akita-cli/env"
 	"github.com/akitasoftware/akita-cli/printer"

--- a/cmd/internal/ecs/ecs.go
+++ b/cmd/internal/ecs/ecs.go
@@ -91,7 +91,7 @@ func init() {
 
 func addAgentToECS(cmd *cobra.Command, args []string) error {
 	// Check for API key
-	_, _, err := cmderr.RequireAPICredentials("The Akita agent must have an API key in order to capture traces.")
+	_, _, err := cmderr.RequireAkitaAPICredentials("The Akita agent must have an API key in order to capture traces.")
 	if err != nil {
 		return err
 	}

--- a/cmd/internal/kube/inject.go
+++ b/cmd/internal/kube/inject.go
@@ -2,9 +2,7 @@ package kube
 
 import (
 	"bytes"
-	"strings"
 
-	"github.com/akitasoftware/akita-cli/cfg"
 	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
 	"github.com/akitasoftware/akita-cli/cmd/internal/kube/injector"
 	"github.com/akitasoftware/akita-cli/printer"
@@ -47,17 +45,6 @@ var injectCmd = &cobra.Command{
 			return cmderr.AkitaErr{
 				Err: errors.New("exactly one of --project or --collection must be specified"),
 			}
-		}
-
-		// If --collection was given, set rest.domain and environment config (if given)
-		if postmanCollectionID != "" {
-			if postmanEnvironment != "" {
-				env := strings.ToUpper(postmanEnvironment)
-
-				cfg.WritePostmanEnvironment("default", env)
-			}
-
-			rest.Domain = "staging.akita.software"
 		}
 
 		// Lookup service *first* (if we are remote) ensuring that collectionId
@@ -365,13 +352,6 @@ func init() {
 		"collection",
 		"",
 		"Your Postman collectionID.")
-
-	injectCmd.Flags().StringVar(
-		&postmanEnvironment,
-		"environment",
-		"",
-		"Your Postman Environment.")
-	injectCmd.Flags().MarkHidden("environment")
 
 	injectCmd.MarkFlagsMutuallyExclusive("project", "collection")
 

--- a/cmd/internal/kube/secret.go
+++ b/cmd/internal/kube/secret.go
@@ -25,7 +25,7 @@ var secretCmd = &cobra.Command{
 	Short: "Generate a Kubernetes Secret manifest containing your Akita API credentials",
 	Long:  "Generate a Kubernetes Secret manifest containing your Akita API credentials and output the result to standard output or a file",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		key, secret, err := cmderr.RequireAPICredentials("Akita API key is required for Kubernetes Secret generation")
+		key, secret, err := cmderr.RequireAkitaAPICredentials("Akita API key is required for Kubernetes Secret generation")
 		if err != nil {
 			return err
 		}

--- a/cmd/internal/kube/secret_test.go
+++ b/cmd/internal/kube/secret_test.go
@@ -2,14 +2,18 @@ package kube
 
 import (
 	_ "embed"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 //go:embed test_resource/akita-secret.yml
 var testAkitaSecretYAML []byte
 
-func Test_secretGeneration(t *testing.T) {
+//go:embed test_resource/postman-secret.yml
+var testPostmanSecretYAML []byte
+
+func TestSecretGeneration(t *testing.T) {
 	// GIVEN
 	const (
 		namespace = "default"
@@ -18,11 +22,28 @@ func Test_secretGeneration(t *testing.T) {
 	)
 
 	// WHEN
-	output, err := handleSecretGeneration(namespace, key, secret)
+	output, err := handleAkitaSecretGeneration(namespace, key, secret)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
 
 	// THEN
 	assert.Equal(t, testAkitaSecretYAML, output)
+}
+
+func TestPostmanSecretGeneration(t *testing.T) {
+	// GIVEN
+	const (
+		namespace = "default"
+		key       = "postman-api-key"
+	)
+
+	// WHEN
+	output, err := handlePostmanSecretGeneration(namespace, key)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+
+	// THEN
+	assert.Equal(t, testPostmanSecretYAML, output)
 }

--- a/cmd/internal/kube/template/postman-secret.tmpl
+++ b/cmd/internal/kube/template/postman-secret.tmpl
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: akita-postman-secrets
+  namespace: {{.Namespace}}
+type: Opaque
+data:
+  akita-postman-api-key: {{.APIKey}}

--- a/cmd/internal/kube/template/postman-secret.tmpl
+++ b/cmd/internal/kube/template/postman-secret.tmpl
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: akita-postman-secrets
+  name: postman-agent-secrets
   namespace: {{.Namespace}}
 type: Opaque
 data:
-  akita-postman-api-key: {{.APIKey}}
+  postman-api-key: {{.APIKey}}

--- a/cmd/internal/kube/test_resource/postman-secret.yml
+++ b/cmd/internal/kube/test_resource/postman-secret.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: akita-postman-secrets
+  namespace: default
+type: Opaque
+data:
+  akita-postman-api-key: cG9zdG1hbi1hcGkta2V5

--- a/cmd/internal/kube/test_resource/postman-secret.yml
+++ b/cmd/internal/kube/test_resource/postman-secret.yml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: akita-postman-secrets
+  name: postman-agent-secrets
   namespace: default
 type: Opaque
 data:
-  akita-postman-api-key: cG9zdG1hbi1hcGkta2V5
+  postman-api-key: cG9zdG1hbi1hcGkta2V5


### PR DESCRIPTION
* Add support for 3 Postman flags in `kubectl inject` command, namely --collection, --key , and --environment
* Setting postman API key as an k8s secret
* Passing other two params normally in args
* Added env var support for postman API key
* Other refactoring and typos fix wherever necessary