### PR TITLE
Select the default domain based on a Postman environment

### DIFF
--- a/cmd/internal/kube/inject.go
+++ b/cmd/internal/kube/inject.go
@@ -182,6 +182,14 @@ type secretGenerationOptions struct {
 }
 
 func createAkitaSidecar(projectName string) v1.Container {
+	args := []string{"apidump", "--project", projectName}
+
+	// If a nondefault --domain flag was used in the inject command, use it
+	// for the container as well.
+	if rest.Domain != rest.DefaultDomain() {
+		args = append(args, "--domain", rest.Domain)
+	}
+
 	sidecar := v1.Container{
 		Name:  "akita",
 		Image: "akitasoftware/cli:latest",
@@ -220,7 +228,7 @@ func createAkitaSidecar(projectName string) v1.Container {
 				},
 			},
 		},
-		Args: []string{"apidump", "--project", projectName},
+		Args: args,
 		SecurityContext: &v1.SecurityContext{
 			Capabilities: &v1.Capabilities{Add: []v1.Capability{"NET_RAW"}},
 		},
@@ -230,6 +238,13 @@ func createAkitaSidecar(projectName string) v1.Container {
 }
 
 func createPostmanSidecar(postmanCollectionID string, postmanEnvironment string) v1.Container {
+	args := []string{"apidump", "--collection", postmanCollectionID}
+
+	// If a nondefault --domain flag was used, specify it for the container as well.
+	if rest.Domain != rest.DefaultDomain() {
+		args = append(args, "--domain", rest.Domain)
+	}
+
 	envs := []v1.EnvVar{
 		{
 			Name: "POSTMAN_API_KEY",
@@ -266,7 +281,7 @@ func createPostmanSidecar(postmanCollectionID string, postmanEnvironment string)
 				},
 			},
 		},
-		Args: []string{"apidump", "--collection", postmanCollectionID},
+		Args: args,
 		SecurityContext: &v1.SecurityContext{
 			Capabilities: &v1.Capabilities{Add: []v1.Capability{"NET_RAW"}},
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,10 +51,6 @@ var (
 	logFormatFlag                       string
 )
 
-const (
-	defaultDomain = "akita.software"
-)
-
 var (
 	rootCmd = &cobra.Command{
 		Use:           "akita",
@@ -74,6 +70,13 @@ var (
 )
 
 func preRun(cmd *cobra.Command, args []string) {
+	// Decide on the domain name to use, _before_ initializing telemetry,
+	// which may make an API call.
+	if rest.Domain == "" {
+		rest.Domain = rest.DefaultDomain()
+	}
+
+	// Initialize Segment-based telemetry of usage information and CLI errors.
 	telemetry.Init(true)
 
 	switch logFormatFlag {
@@ -178,7 +181,7 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&rest.Domain, "domain", defaultDomain, "Your assigned Akita domain (e.g. company.akita.software)")
+	rootCmd.PersistentFlags().StringVar(&rest.Domain, "domain", "", "The domain name of Akita cloud instance to use.")
 	rootCmd.PersistentFlags().MarkHidden("domain")
 
 	// Use a proxy or permit a mismatched certificate.

--- a/rest/base_client.go
+++ b/rest/base_client.go
@@ -5,11 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -17,11 +15,6 @@ import (
 
 	"github.com/akitasoftware/akita-libs/akid"
 )
-
-// Global flag exposed by the root command.
-// This doesn't *really* belong here, but previously it
-// was buried in the "internal" package where we couldn't use it.
-var Domain string
 
 // Use a proxy, "" is none. (This is because the flags package doesn't support Optional)
 // May be a URL, a domain name, or an IP address.  HTTP is assumed as the protocol if
@@ -64,20 +57,9 @@ type BaseClient struct {
 }
 
 func NewBaseClient(rawHost string, cli akid.ClientID) BaseClient {
-	host := "api." + rawHost
-	// If rawHost is either of these: IP, IP:port, localhost, localhost:port or postman host
-	// use that directly. This is to support postman agent and tests.
-	if h, _, err := net.SplitHostPort(rawHost); err == nil {
-		if h == "localhost" || net.ParseIP(h) != nil {
-			host = rawHost
-		}
-	} else if rawHost == "localhost" || net.ParseIP(rawHost) != nil || strings.Contains(rawHost, "postman") {
-		host = rawHost
-	}
-
 	c := BaseClient{
 		scheme:   "https",
-		host:     host,
+		host:     DomainToHost(rawHost),
 		clientID: cli,
 	}
 	if viper.GetBool("test_only_disable_https") {

--- a/rest/domain.go
+++ b/rest/domain.go
@@ -37,6 +37,11 @@ func DefaultDomain() string {
 	// Dispatch based on Postman environment.
 	// TODO: fill in with real domains once available.
 	switch strings.ToUpper(env) {
+	case "":
+		// Not specified by user, PREVIEW for now, but
+		// FIXME: change to PRODUCTION in next release.
+		printer.Warningf("Using Akita staging backend, default environment is PREVIEW\n")
+		return "api.staging.akita.software"
 	case "BETA", "PREVIEW":
 		printer.Debugf("Selecting Akita staging backend for Postman pre-production testing.\n")
 		return "api.staging.akita.software"

--- a/rest/domain.go
+++ b/rest/domain.go
@@ -1,0 +1,65 @@
+package rest
+
+import (
+	"strings"
+
+	"github.com/akitasoftware/akita-cli/cfg"
+	"github.com/akitasoftware/akita-cli/printer"
+)
+
+// This global setting identifies which backend to use, and defaults to akita.software.
+//
+// If Postman credentials are used, then the domain is chosen based on the
+// selected Postman environment (which may be the default or set in an
+// environment variable.)
+//
+// If the --domain flag is used, it unconditionally overrides this choice.
+//
+// The special values "akitasoftware.com" and "staging.akitasoftware.com"
+// need to be prefixed with an "api" to turn them into a host name.  We'll
+// assume everything else is supposed to be used as-is.
+//
+// (The initial goal of the --domain flag was to allow per-customer instances
+// of the Akita backend, i.e., myuser.akitasoftware.com and
+// api.myuser.akitasoftware.com, but this usage is not supported.)
+
+var Domain string
+
+// Return the default domain, given the settings in use
+func DefaultDomain() string {
+	// Check if Postman API key in use
+	key, env := cfg.GetPostmanAPIKeyAndEnvironment()
+	if key == "" {
+		printer.Debugf("No Postman API key, using Akita backend.\n")
+		return "akita.software"
+	}
+
+	// Dispatch based on Postman environment.
+	// TODO: fill in with real domains once available.
+	switch strings.ToUpper(env) {
+	case "BETA", "PREVIEW":
+		printer.Debugf("Selecting Akita staging backend for Postman pre-production testing.\n")
+		return "api.staging.akita.software"
+	case "PRODUCTION", "STAGE":
+		printer.Warningf("Using Akita staging backend, production not supported yet!\n")
+		return "api.staging.akita.software"
+	case "DEV":
+		printer.Debugf("Selecting localhost backend for DEV environment.\n")
+		return "localhost:50443"
+	default:
+		printer.Warningf("Unknown Postman environment %q, using production.\n")
+		return "api.akita.software"
+	}
+}
+
+// Convert domain to the specific host to contact.
+func DomainToHost(domain string) string {
+	switch domain {
+	case "akitasoftware.com":
+		return "api.akitasoftware.com"
+	case "staging.akitasoftware.com":
+		return "api.staging.akitasoftware.com"
+	default:
+		return domain
+	}
+}


### PR DESCRIPTION
If a non-default domain is used, include it in the injected container's
 command line.
Simplify the logic for deciding when to prefix "api" onto the domain.
