### PR TITLE
Call DefaultDomain() in kube subcommands.

### DIFF
--- a/cmd/internal/kube/inject.go
+++ b/cmd/internal/kube/inject.go
@@ -168,6 +168,11 @@ var injectCmd = &cobra.Command{
 		return nil
 	},
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// This function overrides the root command preRun so we need to duplicate the domain setup.
+		if rest.Domain == "" {
+			rest.Domain = rest.DefaultDomain()
+		}
+
 		// Initialize the telemetry client, but do not allow any logs to be printed
 		telemetry.Init(false)
 	},

--- a/cmd/internal/kube/secret.go
+++ b/cmd/internal/kube/secret.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"text/template"
 
+	"github.com/akitasoftware/akita-cli/rest"
 	"github.com/akitasoftware/akita-cli/telemetry"
 
 	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
@@ -54,6 +55,11 @@ var secretCmd = &cobra.Command{
 	// Override the parent command's PersistentPreRun to prevent any logs from being printed.
 	// This is necessary because the secret command is intended to be used in a pipeline
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// This function overrides the root command preRun so we need to duplicate the domain setup.
+		if rest.Domain == "" {
+			rest.Domain = rest.DefaultDomain()
+		}
+
 		// Initialize the telemetry client, but do not allow any logs to be printed
 		telemetry.Init(false)
 	},

--- a/util/util.go
+++ b/util/util.go
@@ -137,7 +137,7 @@ func GetServiceIDByPostmanCollectionID(c rest.FrontClient, collectionID string) 
 		return result, nil
 	}
 
-	printer.Debugf("Found no service for given collectionID: %s, creating a new service", collectionID)
+	printer.Debugf("Found no service for given collectionID: %s, creating a new service\n", collectionID)
 	// Create service for given postman collectionID
 	service, err := c.CreateService(ctx, "Postman-"+randomName(), collectionID, env)
 	if err != nil {


### PR DESCRIPTION
These override PersistentPreRun (to avoid logging output) which means that the rest.Domain value was not getting set.