### PR TITLE
[OBS-138] fix: handle createService response properly

### DIFF
--- a/cfg/credentials.go
+++ b/cfg/credentials.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
@@ -104,7 +105,8 @@ func WriteAPIKeyAndSecret(profile, keyID, keySecret string) error {
 // Get Postman API key and environment from config file
 func GetPostmanAPIKeyAndEnvironment() (string, string) {
 	// Only support default profile for now.
-	return creds.GetString("default.postman_api_key"), creds.GetString("default.postman_env")
+	env := strings.ToUpper(creds.GetString("default.postman_env"))
+	return creds.GetString("default.postman_api_key"), env
 }
 
 // Writes Postman API key and environment to the config file.

--- a/rest/front_client.go
+++ b/rest/front_client.go
@@ -69,8 +69,8 @@ func (c *frontClientImpl) GetGitHubPREnabledState(ctx context.Context, gitHubPR 
 	return response.AkitaEnabled, nil
 }
 
-func (c *frontClientImpl) CreateService(ctx context.Context, serviceName, collectionId, env string) (Service, error) {
-	resp := Service{}
+func (c *frontClientImpl) CreateService(ctx context.Context, serviceName, collectionId, env string) (CreateServiceResponse, error) {
+	resp := CreateServiceResponse{}
 	body := struct {
 		Name            string          `json:"name"`
 		PostmanMetaData PostmanMetaData `json:"postman_meta_data"`

--- a/rest/front_client.go
+++ b/rest/front_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path"
 	"strconv"
+	"strings"
 
 	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/akita-libs/daemon"
@@ -78,7 +79,7 @@ func (c *frontClientImpl) CreateService(ctx context.Context, serviceName, collec
 		Name: serviceName,
 		PostmanMetaData: PostmanMetaData{
 			CollectionID: collectionId,
-			Environment:  env,
+			Environment:  strings.ToUpper(env),
 		},
 	}
 

--- a/rest/interface.go
+++ b/rest/interface.go
@@ -63,7 +63,7 @@ type LearnClient interface {
 
 type FrontClient interface {
 	GetServices(context.Context) ([]Service, error)
-	CreateService(context.Context, string, string, string) (Service, error)
+	CreateService(context.Context, string, string, string) (CreateServiceResponse, error)
 	DaemonHeartbeat(ctx context.Context, daemonName string) error
 
 	// Long-polls for changes to the set of active traces for a service.

--- a/rest/models.go
+++ b/rest/models.go
@@ -18,3 +18,8 @@ type Service struct {
 }
 
 type User = api_schema.UserResponse
+
+type CreateServiceResponse struct {
+	RequestID  string         `json:"request_id"`
+	ResourceID akid.ServiceID `json:"resource_id"`
+}

--- a/util/util.go
+++ b/util/util.go
@@ -137,14 +137,14 @@ func GetServiceIDByPostmanCollectionID(c rest.FrontClient, collectionID string) 
 		return result, nil
 	}
 
-	printer.Debugf("Found no service for given collectionID: %s, creating a new service", collectionID)
+	printer.Debugf("Found no service for given collectionID: %s, creating a new service\n", collectionID)
 	// Create service for given postman collectionID
-	service, err := c.CreateService(ctx, "Postman-"+randomName(), collectionID, env)
+	resp, err := c.CreateService(ctx, "Postman-"+randomName(), collectionID, env)
 	if err != nil {
 		return akid.ServiceID{}, errors.Wrap(err, fmt.Sprintf("failed to create or get service for given collectionID: %s", collectionID))
 	}
 
-	return service.ID, nil
+	return resp.ResourceID, nil
 }
 
 func DaemonHeartbeat(c rest.FrontClient, daemonName string) error {

--- a/util/util.go
+++ b/util/util.go
@@ -137,12 +137,15 @@ func GetServiceIDByPostmanCollectionID(c rest.FrontClient, collectionID string) 
 		return result, nil
 	}
 
-	printer.Debugf("Found no service for given collectionID: %s, creating a new service\n", collectionID)
+	name := postmanRandomName()
+	printer.Debugf("Found no service for given collectionID: %s, creating a new service %q\n", collectionID, name)
 	// Create service for given postman collectionID
-	resp, err := c.CreateService(ctx, "Postman-"+randomName(), collectionID, env)
+	resp, err := c.CreateService(ctx, name, collectionID, env)
 	if err != nil {
 		return akid.ServiceID{}, errors.Wrap(err, fmt.Sprintf("failed to create or get service for given collectionID: %s", collectionID))
 	}
+
+	printer.Debugf("Got service ID %s\n", resp.ResourceID)
 
 	return resp.ResourceID, nil
 }
@@ -255,10 +258,31 @@ func ResolveSpecURI(lc rest.LearnClient, uri akiuri.URI) (akid.APISpecID, error)
 	return lc.GetAPISpecIDByName(ctx, uri.ObjectName)
 }
 
+// Adjective and Noun are up to 11 characters each
+// Random hex = 8 characters
+// Separators = 2 characters
+// Up to 32 characters, which is the maximum supported.
 func randomName() string {
 	return strings.Join([]string{
 		randomdata.Adjective(),
 		randomdata.Noun(),
+		uuid.New().String()[0:8],
+	}, "-")
+}
+
+// Adjective: 11 characters
+// Random hex = 8 characters
+// "pm" and separators = 5 characters
+// Leaves up to 8 characters for the name
+func postmanRandomName() string {
+	noun := randomdata.Noun()
+	if len(noun) > 8 {
+		noun = noun[0:8]
+	}
+	return strings.Join([]string{
+		randomdata.Adjective(),
+		noun,
+		"pm",
 		uuid.New().String()[0:8],
 	}, "-")
 }


### PR DESCRIPTION
Response of `createService` endpoint is not handled properly which is causing serviceId being set to be `srv_000...`
Which is causing error while sending witness data to backend.