### PR TITLE
Remove 'env' parameter from CreateService.

### DIFF
--- a/rest/front_client.go
+++ b/rest/front_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"path"
 	"strconv"
-	"strings"
 
 	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/akita-libs/daemon"
@@ -72,7 +71,7 @@ func (c *frontClientImpl) GetGitHubPREnabledState(ctx context.Context, gitHubPR 
 
 // Create a mirror service in the user's organization. The environment is implicit based
 // on credentials.
-func (c *frontClientImpl) CreateService(ctx context.Context, serviceName, collectionId) (CreateServiceResponse, error) {
+func (c *frontClientImpl) CreateService(ctx context.Context, serviceName string, collectionId string) (CreateServiceResponse, error) {
 	resp := CreateServiceResponse{}
 	body := struct {
 		Name            string          `json:"name"`

--- a/rest/front_client.go
+++ b/rest/front_client.go
@@ -70,7 +70,9 @@ func (c *frontClientImpl) GetGitHubPREnabledState(ctx context.Context, gitHubPR 
 	return response.AkitaEnabled, nil
 }
 
-func (c *frontClientImpl) CreateService(ctx context.Context, serviceName, collectionId, env string) (CreateServiceResponse, error) {
+// Create a mirror service in the user's organization. The environment is implicit based
+// on credentials.
+func (c *frontClientImpl) CreateService(ctx context.Context, serviceName, collectionId) (CreateServiceResponse, error) {
 	resp := CreateServiceResponse{}
 	body := struct {
 		Name            string          `json:"name"`
@@ -79,7 +81,6 @@ func (c *frontClientImpl) CreateService(ctx context.Context, serviceName, collec
 		Name: serviceName,
 		PostmanMetaData: PostmanMetaData{
 			CollectionID: collectionId,
-			Environment:  strings.ToUpper(env),
 		},
 	}
 

--- a/rest/interface.go
+++ b/rest/interface.go
@@ -63,7 +63,7 @@ type LearnClient interface {
 
 type FrontClient interface {
 	GetServices(context.Context) ([]Service, error)
-	CreateService(context.Context, string, string, string) (CreateServiceResponse, error)
+	CreateService(context.Context, string, string) (CreateServiceResponse, error)
 	DaemonHeartbeat(ctx context.Context, daemonName string) error
 
 	// Long-polls for changes to the set of active traces for a service.

--- a/util/util.go
+++ b/util/util.go
@@ -140,7 +140,7 @@ func GetServiceIDByPostmanCollectionID(c rest.FrontClient, collectionID string) 
 	name := postmanRandomName()
 	printer.Debugf("Found no service for given collectionID: %s, creating a new service %q\n", collectionID, name)
 	// Create service for given postman collectionID
-	resp, err := c.CreateService(ctx, name, collectionID, env)
+	resp, err := c.CreateService(ctx, name, collectionID)
 	if err != nil {
 		return akid.ServiceID{}, errors.Wrap(err, fmt.Sprintf("failed to create or get service for given collectionID: %s", collectionID))
 	}


### PR DESCRIPTION
Front determines the environment to use based on the X-Postman-Env header; only admins can create a service in a different environment.