### PR TITLE
fix: omit empty env value

### DIFF
--- a/rest/models.go
+++ b/rest/models.go
@@ -7,7 +7,7 @@ import (
 
 type PostmanMetaData struct {
 	CollectionID string `json:"collection_id"`
-	Environment  string `json:"environment"`
+	Environment  string `json:"environment,omitempty"`
 }
 
 // TODO: shouldn't this be in akita-cli/api_schema?


### PR DESCRIPTION
Currently if we don't send any value for env then it is sending an empty string which is throwing error in BE due to wrong enum type.
So need to add `omitempty` in model