### PR TITLE
chore: remove env check while looping collnId and serviceId mapping

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -122,11 +122,10 @@ func GetServiceIDByPostmanCollectionID(c rest.FrontClient, collectionID string) 
 
 		// Normalize collectionID.
 		svcCollectionID := strings.ToLower(svc.PostmanMetaData.CollectionID)
-		svcEnv := strings.ToUpper(svc.PostmanMetaData.Environment)
 
 		if strings.EqualFold(collectionID, svcCollectionID) {
 			result = svc.ID
-			postmanCollectionIDCache.Set(svcEnv+"|"+svcCollectionID, svc.ID, cache.DefaultExpiration)
+			postmanCollectionIDCache.Set(svcCollectionID, svc.ID, cache.DefaultExpiration)
 		}
 	}
 

--- a/util/util.go
+++ b/util/util.go
@@ -12,7 +12,6 @@ import (
 	cache "github.com/patrickmn/go-cache"
 	"github.com/pkg/errors"
 
-	"github.com/akitasoftware/akita-cli/cfg"
 	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-cli/rest"
 	"github.com/akitasoftware/akita-cli/telemetry"
@@ -97,7 +96,6 @@ func GetServiceIDByName(c rest.FrontClient, name string) (akid.ServiceID, error)
 func GetServiceIDByPostmanCollectionID(c rest.FrontClient, collectionID string) (akid.ServiceID, error) {
 	// Normalize the collectionID.
 	collectionID = strings.ToLower(collectionID)
-	_, env := cfg.GetPostmanAPIKeyAndEnvironment()
 
 	if id, found := postmanCollectionIDCache.Get(collectionID); found {
 		printer.Stderr.Debugf("Cached collectionID %q is %q\n", collectionID, akid.String(id.(akid.ServiceID)))
@@ -126,7 +124,7 @@ func GetServiceIDByPostmanCollectionID(c rest.FrontClient, collectionID string) 
 		svcCollectionID := strings.ToLower(svc.PostmanMetaData.CollectionID)
 		svcEnv := strings.ToUpper(svc.PostmanMetaData.Environment)
 
-		if strings.EqualFold(collectionID, svcCollectionID) && strings.EqualFold(svcEnv, env) {
+		if strings.EqualFold(collectionID, svcCollectionID) {
 			result = svc.ID
 			postmanCollectionIDCache.Set(svcEnv+"|"+svcCollectionID, svc.ID, cache.DefaultExpiration)
 		}


### PR DESCRIPTION
* Since we are moving away from the environment flag, whenever we try to get `postman_env's` value we get the empty string `""`
* This is causing an issue while checking for the mapping between service and collectionId, cause we will be getting environment value also from BE and hence `strings.EqualFold(svcEnv, env)` will never be true and we will create a new service every time cli starts
* So in this PR we have removed this check of env vars from here. We don't really need this check because after 9/15 release  `postman_env` field will be irrelevant (every environment has its own infra) and AFAIK, for the existing stage services there are no collections with the same Id within an org

**PS:** One other option we have is, setting a default value for `postman_env` in `initCreds()` [function](https://github.com/akitasoftware/akita-cli/blob/bugfix/remove-env-check-in-service-list/cfg/credentials.go#L60) if it's value is empty 