### PR TITLE
Partial Postman rebrand

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -11,6 +11,6 @@ jobs:
    name: Security Scan Job
    uses: postmanlabs/gh-security-scan-workflow/.github/workflows/security.yml@v1.0
    with: 
-     imagename: akita-cli
+     imagename: postman-lc-agent
      language: "['go']"
   

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-akita-cli
+postman-lc-agent
 bin/
 
 # Test binary, built with `go test -c`

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 export GO111MODULE = on
 
 build: clean
-	go build -o bin/akita .
+	go build -o bin/postman-lc-agent .
 
 clean:
 	go clean

--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -63,7 +63,7 @@ const (
 )
 
 const (
-	subcommandOutputDelimiter = "======= _AKITA_SUBCOMMAND_ ======="
+	subcommandOutputDelimiter = "======= _POSTMAN_SUBCOMMAND_ ======="
 )
 
 type filterState string
@@ -394,7 +394,7 @@ func (a *apidump) RotateLearnSession(done <-chan struct{}, collectors []trace.Le
 				printer.Errorf("Failed to create trace %s: %v\n", traceName, err)
 				break
 			}
-			printer.Infof("Rotating to new trace on Akita Cloud: %v\n", traceName)
+			printer.Infof("Rotating to new trace on Postman Cloud: %v\n", traceName)
 			for _, c := range collectors {
 				c.SwitchLearnSession(backendLrn)
 			}
@@ -542,7 +542,7 @@ func (a *apidump) Run() error {
 		if uri.ObjectType == nil {
 			uri.ObjectType = akiuri.TRACE.Ptr()
 		} else if !uri.ObjectType.IsTrace() {
-			return errors.Errorf("%q is not an Akita trace URI", uri)
+			return errors.Errorf("%q is not a Postman trace URI", uri)
 		}
 
 		// Use a random object name by default.
@@ -580,7 +580,7 @@ func (a *apidump) Run() error {
 		uri := a.Out.AkitaURI
 		backendLrn, err = util.NewLearnSession(args.Domain, args.ClientID, a.backendSvc, uri.ObjectName, traceTags, nil)
 		if err == nil {
-			printer.Infof("Created new trace on Akita Cloud: %s\n", uri)
+			printer.Infof("Created new trace on Postman Cloud: %s\n", uri)
 		} else {
 			var httpErr rest.HTTPError
 			if ok := errors.As(err, &httpErr); ok && httpErr.StatusCode == 409 {
@@ -955,7 +955,7 @@ func createLocalCollector(interfaceName, outDir string, tags map[tags.Key]string
 		}
 
 		// Check if we have permission to write to the directory.
-		testFile := filepath.Join(outDir, "akita_test")
+		testFile := filepath.Join(outDir, "postman_test")
 		if err := ioutil.WriteFile(testFile, []byte{1}, 0644); err == nil {
 			os.Remove(testFile)
 		} else {

--- a/apidump/net.go
+++ b/apidump/net.go
@@ -47,7 +47,7 @@ func showPermissionErrors(sampleError error) error {
 				printer.Warningf("It might be that you are in a PaaS that disallows packet capture, or the local configuration has disabled that privilege by default.\n")
 				return NewApidumpError(api_schema.ApidumpError_PCAPPermission, "Insufficient permissions in container.")
 			} else {
-				printer.Warningf("Although you are running as root, the Akita agent lacks the CAP_NET_RAW capability.\n")
+				printer.Warningf("Although you are running as root, the Postman Live Collections Agent lacks the CAP_NET_RAW capability.\n")
 				printer.Warningf("It might be that you are in a restricted environment which disallows packet capture, even as the root user.\n")
 				return NewApidumpError(api_schema.ApidumpError_PCAPPermission, "Insufficient permissions.")
 			}
@@ -63,8 +63,8 @@ func showPermissionErrors(sampleError error) error {
 
 		printer.Warningf(
 			"The agent received \"Function not implemented\" when trying to read from your network interfaces. "+
-				"This often indicates that the Akita agent was built for a different architecture than your host architecture. "+
-				"This Akita agent binary was built for %s.\n",
+				"This often indicates that the Postman Live Collections Agent was built for a different architecture than your host architecture. "+
+				"This Postman Live Collections Agent binary was built for %s.\n",
 			arch,
 		)
 
@@ -72,7 +72,7 @@ func showPermissionErrors(sampleError error) error {
 			return NewApidumpErrorf(
 				api_schema.ApidumpError_PCAPInterfaceNotImplemented,
 				"Unable to read network interfaces. If your host architecture is not %s, try using "+
-					"`docker pull --platform $YOUR_ARCHITECTURE docker.postman.com/postman-lc-agent:latest` to pull an Akita agent "+
+					"`docker pull --platform $YOUR_ARCHITECTURE docker.postman.com/postman-lc-agent:latest` to pull a Postman Live Collections Agent "+
 					"built for your architecture.",
 				arch,
 			)

--- a/apidump/net.go
+++ b/apidump/net.go
@@ -79,7 +79,7 @@ func showPermissionErrors(sampleError error) error {
 		} else {
 			return NewApidumpErrorf(
 				api_schema.ApidumpError_PCAPInterfaceNotImplemented,
-				"Unable to read network interfaces. If your host architecture is not %s, try using the Akita install script: `bash -c \"$(curl -L https://releases.akita.software/scripts/install_akita.sh)\"`",
+				"Unable to read network interfaces. If your host architecture is not %s, try using the Postman Live Collections Agent install script: `bash -c \"$(curl -L https://releases.observability.postman.com/scripts/install-postman-lc-agent.sh)\"`",
 				arch,
 			)
 		}

--- a/apidump/summary.go
+++ b/apidump/summary.go
@@ -133,10 +133,10 @@ func (s *Summary) printPortHighlights(top *client_telemetry.PacketCountSummary) 
 			if thisPort.TLSHello > 0 {
 				printer.Stderr.Infof("TCP Port %5d: appears to contain a mix of encrypted and unencrypted traffic.\n", p)
 			} else if thisPort.Unparsed > thisPort.TCPPackets*3/10 {
-				printer.Stderr.Infof("TCP Port %5d: has an unusually high amount of traffic that Akita cannot parse.\n", p)
+				printer.Stderr.Infof("TCP Port %5d: has an unusually high amount of traffic that Postman cannot parse.\n", p)
 			}
 			if thisPort.HTTP2Prefaces > 0 {
-				printer.Stderr.Infof("TCP Port %5d: Contains HTTP/2 traffic (%d connections detected), which Akita cannot parse.\n", p, thisPort.HTTP2Prefaces)
+				printer.Stderr.Infof("TCP Port %5d: Contains HTTP/2 traffic (%d connections detected), which Postman cannot parse.\n", p, thisPort.HTTP2Prefaces)
 			}
 			continue
 		}
@@ -158,7 +158,7 @@ func (s *Summary) printPortHighlights(top *client_telemetry.PacketCountSummary) 
 
 		// If we saw HTTP/2, report it.
 		if thisPort.HTTP2Prefaces > 0 {
-			printer.Stderr.Infof("TCP port %5d: %5d packets (%d%% of total), no HTTP/1.1 requests or responses, %d HTTP/2 connection attempts. Akita cannot currently parse HTTP/2.\n",
+			printer.Stderr.Infof("TCP port %5d: %5d packets (%d%% of total), no HTTP/1.1 requests or responses, %d HTTP/2 connection attempts. Postman cannot currently parse HTTP/2.\n",
 				p, thisPort.TCPPackets, pct, thisPort.HTTP2Prefaces)
 			continue
 		}
@@ -170,7 +170,8 @@ func (s *Summary) printPortHighlights(top *client_telemetry.PacketCountSummary) 
 }
 
 // XXX(cns): Not all metrics can be associated with a host.  We currently have
-//    HTTP requests and TLS handshakes.
+//
+//	HTTP requests and TLS handshakes.
 func (s *Summary) printHostHighlights(top *client_telemetry.PacketCountSummary) {
 	// Sort by HTTP traffic volume, then TLS handshake counts, both descending.
 	// We do not have TCP packet counts for hosts.
@@ -300,7 +301,7 @@ func (s *Summary) PrintWarnings() {
 				s.PrefilterSummary.Total().HTTPRequests)
 		}
 		if env.InDocker() && env.HasDockerInternalHostAddress() {
-			printer.Stderr.Infof("If you're using macOS and your service is not running in a Docker container, try using the native Postman Live Collections Agent with `brew install akita-cli`.  See docs.akita.software/docs/macos-local for details.\n")
+			printer.Stderr.Infof("If you're using macOS and your service is not running in a Docker container, try using the native Postman Live Collections Agent with `brew install postman-lc-agent`.\n")
 		}
 		printer.Stderr.Errorf("%s 🛑\n\n", printer.Color.Red("No HTTP calls captured!"))
 		return

--- a/apidump/summary.go
+++ b/apidump/summary.go
@@ -300,7 +300,7 @@ func (s *Summary) PrintWarnings() {
 				s.PrefilterSummary.Total().HTTPRequests)
 		}
 		if env.InDocker() && env.HasDockerInternalHostAddress() {
-			printer.Stderr.Infof("If you're using macOS and your service is not running in a Docker container, try using the native Akita agent with `brew install akita-cli`.  See docs.akita.software/docs/macos-local for details.\n")
+			printer.Stderr.Infof("If you're using macOS and your service is not running in a Docker container, try using the native Postman Live Collections Agent with `brew install akita-cli`.  See docs.akita.software/docs/macos-local for details.\n")
 		}
 		printer.Stderr.Errorf("%s 🛑\n\n", printer.Color.Red("No HTTP calls captured!"))
 		return

--- a/apispec/har.go
+++ b/apispec/har.go
@@ -31,7 +31,7 @@ func ProcessHAR(col trace.Collector, p string) (int, error) {
 	if errs.TotalCount > 0 {
 		entriesCount := len(harContent.Log.Entries)
 		printer.Stderr.Warningf("Encountered errors with %d HAR file entries.\n", entriesCount-successCount)
-		printer.Stderr.Warningf("Akita will ignore entries with errors and generate a spec from the %d entries successfully processed.\n", successCount)
+		printer.Stderr.Warningf("Postman Live Insights will ignore entries with errors and generate a spec from the %d entries successfully processed.\n", successCount)
 
 		printer.Stderr.Warningf("Sample errors:\n")
 		for _, e := range errs.Samples {

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -196,12 +196,14 @@ func init() {
 		&outFlag,
 		"out",
 		"The location to store the trace. Can be an AkitaURI or a local directory. Defaults to a trace on the Akita Cloud. Exactly one of --out or --project must be specified.")
+	Cmd.Flags().MarkDeprecated("out", "For use by Akita users")
 
 	Cmd.Flags().StringVar(
 		&serviceFlag,
 		"project",
 		"",
 		"Your Akita project. Exactly one of --out or --project must be specified.")
+	Cmd.Flags().MarkDeprecated("project", "For use by Akita users")
 
 	Cmd.Flags().StringVar(
 		&postmanCollectionID,
@@ -263,7 +265,7 @@ func init() {
 		&appendByTagFlag,
 		"append-by-tag",
 		false,
-		"Add to the most recent Akita trace with matching tag.")
+		"Add to the most recent trace with matching tag.")
 	Cmd.Flags().MarkDeprecated("append-by-tag", "and is no longer necessary. All traces in a project are now combined into a single model. Please remove this flag.")
 
 	Cmd.Flags().StringSliceVar(
@@ -314,7 +316,7 @@ func init() {
 		&pluginsFlag,
 		"plugins",
 		nil,
-		"Paths of third-party Akita plugins. They are executed in the order given.",
+		"Paths of third-party plugins. They are executed in the order given.",
 	)
 	Cmd.Flags().MarkHidden("plugins")
 

--- a/cmd/internal/cmderr/checks.go
+++ b/cmd/internal/cmderr/checks.go
@@ -35,7 +35,7 @@ func RequirePostmanAPICredentials(explanation string) (string, error) {
 		if env.InDocker() {
 			printer.Infof("Please set the POSTMAN_API_KEY environment variables on the Docker command line.\n")
 		} else {
-			printer.Infof("Use the POSTMAN_API_KEY environment variables, or run 'akita login'.\n")
+			printer.Infof("Use the POSTMAN_API_KEY environment variables, or run 'postman-lc-agent login'.\n")
 		}
 
 		return "", AkitaErr{Err: errors.New("could not find an Postman API key to use")}

--- a/cmd/internal/ecs/add.go
+++ b/cmd/internal/ecs/add.go
@@ -96,7 +96,7 @@ const (
 	defaultKeyIDName     = akitaSecretPrefix + "api_key_id"
 	defaultKeySecretName = akitaSecretPrefix + "api_key_secret"
 
-	// Akita agent image locations
+	// Postman Live Collections Agent image locations
 	akitaECRImage    = "public.ecr.aws/akitasoftware/akita-cli"
 	akitaDockerImage = "akitasoftware/cli"
 	postmanECRImage  = "docker.postman.com/postman-lc-agent"
@@ -486,7 +486,7 @@ func getTaskState(wf *AddWorkflow) (nextState optionals.Optional[AddWorkflowStat
 	err = survey.AskOne(
 		&survey.Select{
 			Message: "Which task should Akita monitor?",
-			Help:    "Select the ECS task definition to modify. We will add the Akita agent as a sidecar to the task.",
+			Help:    "Select the ECS task definition to modify. We will add the Postman Live Collections Agent as a sidecar to the task.",
 			Options: tasks,
 		},
 		&taskAnswer,
@@ -668,7 +668,7 @@ func (wf *AddWorkflow) showPlannedChanges() {
 				defaultKeySecretName, wf.awsRegion)
 		}
 	}
-	printer.Infof("Create a new version %d of task definition %q which includes the Akita agent as a sidecar.\n",
+	printer.Infof("Create a new version %d of task definition %q which includes the Postman Live Collections Agent as a sidecar.\n",
 		wf.ecsTaskDefinition.Revision+1, wf.ecsTaskDefinitionFamily)
 	printer.Infof("Update service %q in cluster %q to the new task definition.\n",
 		wf.ecsService, wf.ecsCluster)

--- a/cmd/internal/ecs/ecs.go
+++ b/cmd/internal/ecs/ecs.go
@@ -33,7 +33,7 @@ var (
 
 var Cmd = &cobra.Command{
 	Use:   "ecs",
-	Short: "Add the Akita agent to AWS ECS.",
+	Short: "Add the Postman Live Collections Agent to AWS ECS.",
 	Long:  "The CLI will collect information from you and add the Akita container to an ECS Task.",
 	// N.B.: this is useless because the root command makes its own determination,
 	// need to return AkitaErr to not show the usage.
@@ -52,7 +52,7 @@ var AddToECSCmd = &cobra.Command{
 
 var RemoveFromECSCmd = &cobra.Command{
 	Use:          "remove",
-	Short:        "Remove the Akita agent from AWS ECS.",
+	Short:        "Remove the Postman Live Collections Agent from AWS ECS.",
 	Long:         "Remove a previously installed Akita container from an ECS Task.",
 	SilenceUsage: true,
 	RunE:         removeAgentFromECS,
@@ -91,7 +91,7 @@ func init() {
 
 func addAgentToECS(cmd *cobra.Command, args []string) error {
 	// Check for API key
-	_, _, err := cmderr.RequireAkitaAPICredentials("The Akita agent must have an API key in order to capture traces.")
+	_, _, err := cmderr.RequireAkitaAPICredentials("The Postman Live Collections Agent must have an API key in order to capture traces.")
 	if err != nil {
 		return err
 	}

--- a/cmd/internal/get/cmd.go
+++ b/cmd/internal/get/cmd.go
@@ -10,6 +10,7 @@ import (
 
 // Parent command for listing objects from Akita.
 var Cmd = &cobra.Command{
+	Deprecated:   "This is no longer supported and will be removed in a future release.",
 	Use:          "get [AKITAURI]",
 	Short:        "List or download objects in the Akita cloud.",
 	Long:         "List or download objects in the Akita cloud.",

--- a/cmd/internal/kube/inject.go
+++ b/cmd/internal/kube/inject.go
@@ -38,12 +38,12 @@ var (
 
 var injectCmd = &cobra.Command{
 	Use:   "inject",
-	Short: "Inject Akita into a Kubernetes deployment",
-	Long:  "Inject Akita into a Kubernetes deployment or set of deployments, and output the result to stdout or a file",
+	Short: "Inject the Postman Live Collections Agent into a Kubernetes deployment",
+	Long:  "Inject the Postman Live Collections Agent into a Kubernetes deployment or set of deployments, and output the result to stdout or a file",
 	RunE: func(_ *cobra.Command, args []string) error {
 		if projectNameFlag == "" && postmanCollectionID == "" {
 			return cmderr.AkitaErr{
-				Err: errors.New("exactly one of --project or --collection must be specified"),
+				Err: errors.New("--collection must be specified. Or, if you are an Akita user, use --project instead."),
 			}
 		}
 
@@ -60,7 +60,7 @@ var injectCmd = &cobra.Command{
 		// their dependent Secrets, require that the user explicitly specify an output file.
 		if secretOpts.ShouldInject && secretOpts.Filepath.IsSome() && injectOutputFlag == "" {
 			printer.Errorln("Cannot specify a Secret file path without an output file (using --output or -o)")
-			printer.Infoln("To generate a Secret file on its own, use `akita kube secret`")
+			printer.Infoln("To generate a Secret file on its own, use `postman-lc-agent kube secret`")
 			return cmderr.AkitaErr{
 				Err: errors.New("invalid flag usage"),
 			}
@@ -186,7 +186,7 @@ type secretGenerationOptions struct {
 	Filepath optionals.Optional[string]
 }
 
-// The image to use for the Akita sidecar
+// The image to use for the Postman LCA sidecar
 const akitaImage = "docker.postman.com/postman-lc-agent:latest"
 
 func createAkitaSidecar(projectName string) v1.Container {
@@ -275,7 +275,7 @@ func createPostmanSidecar(postmanCollectionID string, postmanEnvironment string)
 	}
 
 	sidecar := v1.Container{
-		Name:  "akita",
+		Name:  "postman-lc-agent",
 		Image: akitaImage,
 		Env:   envs,
 		Lifecycle: &v1.Lifecycle{
@@ -361,7 +361,7 @@ func init() {
 		"project",
 		"p",
 		"",
-		"Name of the Akita project to which the traffic will be uploaded.",
+		"Name of the Akita project to which the traffic will be uploaded. If you are a Postman user, use --collection instead.",
 	)
 
 	injectCmd.Flags().StringVarP(
@@ -378,7 +378,7 @@ func init() {
 		&postmanCollectionID,
 		"collection",
 		"",
-		"Your Postman collectionID.")
+		"Your Postman collection ID. If you are an Akita user, use --project instead.")
 
 	injectCmd.MarkFlagsMutuallyExclusive("project", "collection")
 

--- a/cmd/internal/kube/kube.go
+++ b/cmd/internal/kube/kube.go
@@ -6,7 +6,7 @@ import (
 
 var Cmd = &cobra.Command{
 	Use:   "kube",
-	Short: "Install Akita in your Kubernetes cluster",
+	Short: "Install the Postman Live Collections Agent in your Kubernetes cluster",
 	Aliases: []string{
 		"k8s",
 		"kubernetes",

--- a/cmd/internal/kube/secret.go
+++ b/cmd/internal/kube/secret.go
@@ -17,7 +17,8 @@ import (
 var (
 	secretFilePathFlag string
 	namespaceFlag      string
-	// Store a parsed representation of /template/akita-secret.tmpl
+	// Store a parsed representation of /template/akita-secret.tmpl or
+	// /template/postman-secret.tmpl.
 	secretTemplate *template.Template
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,9 +53,9 @@ var (
 
 var (
 	rootCmd = &cobra.Command{
-		Use:           "akita",
-		Short:         "Gateway to all Akita services.",
-		Long:          "Complete documentation is available at https://docs.akita.software",
+		Use:           "postman-lc-agent",
+		Short:         "The Postman Live Collections Agent",
+		Long:          "Documentation is available at https://voyager.postman.com/pdf/live-insights-documentation-postman.pdf",
 		Version:       version.CLIDisplayString(),
 		SilenceErrors: true, // We print our own errors from subcommands in Execute function
 		// Don't print usage after error, we only print help if we cannot parse
@@ -101,7 +101,7 @@ func preRun(cmd *cobra.Command, args []string) {
 	// Somehow, this doesn't appear before "akita --version" (good) or
 	// "akita --help" (less good), only before commands or the usage
 	// information if no command is given.
-	printer.Stdout.Infof("Akita Agent %s\n", version.ReleaseVersion())
+	printer.Stdout.Infof("Postman Live Collections Agent %s\n", version.ReleaseVersion())
 
 	// This is after argument parsing so that rest.Domain is correct,
 	// but won't be called if there is an error parsing the flags.
@@ -186,9 +186,9 @@ func init() {
 
 	// Use a proxy or permit a mismatched certificate.
 	rootCmd.PersistentFlags().StringVar(&rest.ProxyAddress, "proxy", "", "The domain name, IP address, or URL of an HTTP proxy server to use")
-	rootCmd.PersistentFlags().BoolVar(&rest.PermitInvalidCertificate, "skip-tls-validate", false, "Skip TLS validation on the connection to api.akita.software")
+	rootCmd.PersistentFlags().BoolVar(&rest.PermitInvalidCertificate, "skip-tls-validate", false, "Skip TLS validation on the connection to the back end")
 	rootCmd.PersistentFlags().MarkHidden("skip-tls-validate")
-	rootCmd.PersistentFlags().StringVar(&rest.ExpectedServerName, "server-tls-name", "", "Provide an alternate TLS server name to accept instead of api.akita.software")
+	rootCmd.PersistentFlags().StringVar(&rest.ExpectedServerName, "server-tls-name", "", "Provide an alternate TLS server name to accept")
 	rootCmd.PersistentFlags().MarkHidden("server-tls-name")
 
 	// Semi-secret somewhat-safe flags
@@ -272,8 +272,10 @@ func init() {
 	rootCmd.AddCommand(ci_guard.GuardCommand(apidiff.Cmd))
 	rootCmd.AddCommand(ci_guard.GuardCommand(apidump.Cmd))
 	rootCmd.AddCommand(ci_guard.GuardCommand(apispec.Cmd))
+	daemon.Cmd.Hidden = true
 	rootCmd.AddCommand(daemon.Cmd)
 	rootCmd.AddCommand(ci_guard.GuardCommand(learn.Cmd))
+	login.Cmd.Hidden = true
 	rootCmd.AddCommand(login.Cmd)
 	rootCmd.AddCommand(ci_guard.GuardCommand(setversion.Cmd))
 

--- a/daemon/internal/cloud_client/cloud_client.go
+++ b/daemon/internal/cloud_client/cloud_client.go
@@ -197,7 +197,7 @@ func collectTraces(traceEventChannel <-chan *TraceEvent, learnClient rest.LearnC
 		for _, e := range sampledErrs.Samples {
 			sampledErrsStr = fmt.Sprintf("%s\t- %s\n", sampledErrsStr, e)
 		}
-		printer.Stderr.Warningf("Encountered errors with %d entries for trace %s.\nAkita will ignore entries with errors and proceed with the %d entries successfully processed.\nSample errors: %s\n", sampledErrs.TotalCount, loggingOptions.TraceID, successfulEntries, sampledErrsStr)
+		printer.Stderr.Warningf("Encountered errors with %d entries for trace %s.\nPostman Live Insights will ignore entries with errors and proceed with the %d entries successfully processed.\nSample errors: %s\n", sampledErrs.TotalCount, loggingOptions.TraceID, successfulEntries, sampledErrsStr)
 	}
 }
 

--- a/integrations/nginx/schema.go
+++ b/integrations/nginx/schema.go
@@ -7,7 +7,7 @@ import (
 )
 
 /* Rest API schema objects for the communcation between
-   the NGINX module and the Akita agent */
+   the NGINX module and the Postman Live Collections Agent */
 
 // An incoming request to Nginx.
 type MirroredRequest struct {

--- a/rest/http.go
+++ b/rest/http.go
@@ -38,8 +38,7 @@ type HTTPError struct {
 
 func (he HTTPError) Error() string {
 	if he.StatusCode == 401 {
-		return `Invalid credentials, run "login" or use AKITA_API_KEY_SECRET environment variable. ` +
-			`If using with Postman, use POSTMAN_API_KEY environment variable`
+		return `Invalid credentials. Ensure the POSTMAN_API_KEY environment variable has a valid API key for Postman. If using with Akita, run "login" or use the AKITA_API_KEY_ID and AKITA_API_KEY_SECRET environment variables.`
 	}
 	return fmt.Sprintf("received status code %d, body: %s", he.StatusCode, string(he.Body))
 }
@@ -91,7 +90,7 @@ func initHTTPClient() {
 	}
 	transport.TLSClientConfig = &tls.Config{}
 	if PermitInvalidCertificate {
-		printer.Warningf("Disabling TLS checking; sending traffic without verifying identity of Akita servers.\n")
+		printer.Warningf("Disabling TLS checking; sending traffic without verifying identity of Postman servers.\n")
 		transport.TLSClientConfig.InsecureSkipVerify = true
 	}
 	if ExpectedServerName != "" {
@@ -124,13 +123,11 @@ func sendRequest(ctx context.Context, req *http.Request) ([]byte, error) {
 		apiKeyID, apiKeySecret := cfg.GetAPIKeyAndSecret()
 
 		if apiKeyID == "" {
-			return nil, errors.New(`API key ID not found, run "login" or use AKITA_API_KEY_ID environment variable. ` +
-				`If using with Postman, use POSTMAN_API_KEY environment variable`)
+			return nil, errors.New(`Missing or incomplete credentials. Ensure the POSTMAN_API_KEY environment variable has a valid API key for Postman. If using with Akita, run "login" or use the AKITA_API_KEY_ID and AKITA_API_KEY_SECRET environment variables.`)
 		}
 
 		if apiKeySecret == "" {
-			return nil, errors.New(`API key secret not found, run "login" or use AKITA_API_KEY_SECRET environment variable. ` +
-				`If using with Postman, use POSTMAN_API_KEY environment variable`)
+			return nil, errors.New(`Akita API key secret not found, run "login" or use AKITA_API_KEY_SECRET environment variable. If using with Postman, ensure the POSTMAN_API_KEY environment variable has a valid API key for Postman.`)
 		}
 
 		req.SetBasicAuth(apiKeyID, apiKeySecret)

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -100,7 +100,7 @@ func Init(isLoggingEnabled bool) {
 	if err != nil {
 		if isLoggingEnabled {
 			printer.Infof("Telemetry unavailable; error setting up Segment client: %v\n", err)
-			printer.Infof("Akita support will not be able to see any errors you encounter.\n")
+			printer.Infof("Postman support will not be able to see any errors you encounter.\n")
 			printer.Infof("Please send this log message to observability-support@postman.com.\n")
 		}
 		analyticsClient = nullClient{}
@@ -141,8 +141,8 @@ func getDistinctID() string {
 		}
 
 		printer.Infof("Telemetry using temporary ID; /v1/user API call failed: %v\n", err)
-		printer.Infof("This error may indicate a problem communicating with the Akita servers,\n")
-		printer.Infof("but the agent will still attempt to send telemetry Akita support.\n")
+		printer.Infof("This error may indicate a problem communicating with the Postman servers,\n")
+		printer.Infof("but the agent will still attempt to send telemetry to Postman support.\n")
 	}
 
 	if key != "" {
@@ -312,7 +312,7 @@ func Shutdown() {
 	err := analyticsClient.Close()
 	if err != nil {
 		printer.Stderr.Errorf("Error flushing telemetry: %v\n", err)
-		printer.Infof("Akita support may not be able to see the last error message you received.\n")
+		printer.Infof("Postman support may not be able to see the last error message you received.\n")
 		printer.Infof("Please send the CLI output to observability-support@postman.com.\n")
 	}
 }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -54,7 +54,7 @@ func (_ nullClient) Close() error {
 // This should be called once at startup either from the root command or from a subcommand that overrides the default PersistentPreRun.
 func Init(isLoggingEnabled bool) {
 	// Opt-out mechanism
-	disableTelemetry := os.Getenv("AKITA_DISABLE_TELEMETRY")
+	disableTelemetry := os.Getenv("AKITA_DISABLE_TELEMETRY") + os.Getenv("POSTMAN_LC_AGENT_DISABLE_TELEMETRY")
 	if disableTelemetry != "" {
 		if val, err := strconv.ParseBool(disableTelemetry); err == nil && val {
 			printer.Infof("Telemetry disabled via opt-out.\n")

--- a/trace/report_buffer.go
+++ b/trace/report_buffer.go
@@ -96,11 +96,11 @@ func (buf *reportBuffer) Flush() error {
 			if e.StatusCode == http.StatusTooManyRequests {
 				// XXX Not all commands that call into this code have a --rate-limit
 				// option.
-				err = errors.Wrap(err, "your witness uploads are being throttled. Akita will generate partial results. Try reducing the --rate-limit value to avoid this.")
+				err = errors.Wrap(err, "your witness uploads are being throttled. Postman Live Insights will generate partial results. Try reducing the --rate-limit value to avoid this.")
 			}
 		}
 
-		printer.Warningf("Failed to upload to Akita Cloud: %v\n", err)
+		printer.Warningf("Failed to upload to Postman: %v\n", err)
 	}
 	printer.Debugf("Uploaded %d witnesses, %d TCP connection reports, and %d TLS handshake reports\n", len(buf.Witnesses), len(buf.TCPConnections), len(buf.TLSHandshakes))
 

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -57,7 +57,7 @@ var (
 	isPollingMutex sync.Mutex
 )
 
-// Returns a 1-hour sliding window reflecting this Akita agent's CPU and
+// Returns a 1-hour sliding window reflecting this Postman Live Collections Agent's CPU and
 // memory usage, updated every pollingInterval minutes, or nil if resource
 // usage is unavailable.
 //

--- a/useragent/useragent.go
+++ b/useragent/useragent.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	uaRegexp = regexp.MustCompile(`^akita-cli\/(.*) \((.*); (.*); (.*)\)$`)
+	uaRegexp = regexp.MustCompile(`^postman-lc-agent\/(.*) \((.*); (.*); (.*)\)$`)
 )
 
 // Type of environment where the CLI is running.
@@ -58,7 +58,7 @@ type UA struct {
 }
 
 func (ua UA) String() string {
-	return fmt.Sprintf("akita-cli/%s (%s; %s; %s)", ua.Version, ua.OS, ua.Arch, ua.EnvType)
+	return fmt.Sprintf("postman-lc-agent/%s (%s; %s; %s)", ua.Version, ua.OS, ua.Arch, ua.EnvType)
 }
 
 func FromString(s string) (UA, error) {

--- a/useragent/useragent_test.go
+++ b/useragent/useragent_test.go
@@ -14,7 +14,7 @@ func TestString(t *testing.T) {
 		Arch:    "amd64",
 		EnvType: ENV_DOCKER,
 	}
-	assert.Equal(t, "akita-cli/1.2.3 (linux; amd64; docker)", ua.String())
+	assert.Equal(t, "postman-lc-agent/1.2.3 (linux; amd64; docker)", ua.String())
 }
 
 func TestFromString(t *testing.T) {
@@ -26,7 +26,7 @@ func TestFromString(t *testing.T) {
 	}{
 		{
 			name:  "good case",
-			input: "akita-cli/1.2.3 (linux; amd64; docker)",
+			input: "postman-lc-agent/1.2.3 (linux; amd64; docker)",
 			expected: UA{
 				Version: ver.Must(ver.NewSemver("1.2.3")),
 				OS:      "linux",
@@ -36,7 +36,7 @@ func TestFromString(t *testing.T) {
 		},
 		{
 			name:  "empty os is ok",
-			input: "akita-cli/1.2.3 (; amd64; docker)",
+			input: "postman-lc-agent/1.2.3 (; amd64; docker)",
 			expected: UA{
 				Version: ver.Must(ver.NewSemver("1.2.3")),
 				OS:      "",
@@ -46,7 +46,7 @@ func TestFromString(t *testing.T) {
 		},
 		{
 			name:  "empty arch is ok",
-			input: "akita-cli/1.2.3 (linux; ; docker)",
+			input: "postman-lc-agent/1.2.3 (linux; ; docker)",
 			expected: UA{
 				Version: ver.Must(ver.NewSemver("1.2.3")),
 				OS:      "linux",
@@ -56,12 +56,12 @@ func TestFromString(t *testing.T) {
 		},
 		{
 			name:      "bad version",
-			input:     "akita-cli/1.2x.3 (linux; amd64; docker)",
+			input:     "postman-lc-agent/1.2x.3 (linux; amd64; docker)",
 			expectErr: true,
 		},
 		{
 			name:      "bad env",
-			input:     "akita-cli/1.2.3 (linux; amd64; i-dont-exist)",
+			input:     "postman-lc-agent/1.2.3 (linux; amd64; i-dont-exist)",
 			expectErr: true,
 		},
 	}


### PR DESCRIPTION
All environment variables are still Akita-branded, but we now recognize `POSTMAN_LC_AGENT_DISABLE_TELEMETRY` in addition to the existing `AKITA_DISABLE_TELEMETRY`.