### PR TITLE
[OBS-137] Handle 409 response of create service to again check for service

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -177,7 +177,7 @@ func (a *apidump) LookupService() error {
 	frontClient := rest.NewFrontClient(a.Domain, a.ClientID)
 
 	if a.PostmanCollectionID != "" {
-		backendSvc, err := util.GetServiceIDByPostmanCollectionID(frontClient, a.PostmanCollectionID)
+		backendSvc, err := util.GetOrCreateServiceIDByPostmanCollectionID(frontClient, a.PostmanCollectionID)
 		if err != nil {
 			return err
 		}

--- a/cmd/internal/kube/inject.go
+++ b/cmd/internal/kube/inject.go
@@ -325,7 +325,7 @@ func lookupService(postmanCollectionID, serviceName string) error {
 	frontClient := rest.NewFrontClient(rest.Domain, telemetry.GetClientID())
 
 	if postmanCollectionID != "" {
-		_, err := util.GetServiceIDByPostmanCollectionID(frontClient, postmanCollectionID)
+		_, err := util.GetOrCreateServiceIDByPostmanCollectionID(frontClient, postmanCollectionID)
 		if err != nil {
 			return err
 		}

--- a/rest/models.go
+++ b/rest/models.go
@@ -20,6 +20,12 @@ type Service struct {
 type User = api_schema.UserResponse
 
 type CreateServiceResponse struct {
-	RequestID  string         `json:"request_id"`
+	RequestID  akid.RequestID `json:"request_id"`
 	ResourceID akid.ServiceID `json:"resource_id"`
+}
+
+type CreateServiceErrorResponse struct {
+	RequestID  akid.RequestID `json:"request_id"`
+	Message    string         `json:"message"`
+	ResourceID string         `json:"resource_id"`
 }


### PR DESCRIPTION
* Create a new model to parse error response
* Handle the 409 conflict case. Check for error message and call get services again 
* Try only one time after that bail out with error
* Other small fixes: Add to cache after create service flow, small model change