### PR TITLE
OBS-419: Fix distinct ID for Postman API key users.

### DIFF
--- a/cfg/credentials.go
+++ b/cfg/credentials.go
@@ -118,3 +118,24 @@ func WritePostmanAPIKeyAndEnvironment(profile, postmanApiKey, postmanEnvironment
 
 	return writeConfigToFile(profile, keyValueMap)
 }
+
+// Check whether credentials are present, of any variety.
+func CredentialsPresent() bool {
+	key, _ := GetPostmanAPIKeyAndEnvironment()
+	if key != "" {
+		return true
+	}
+
+	key, secret := GetAPIKeyAndSecret()
+	return key != "" && secret != ""
+}
+
+// If we can't call /v1/user to get a distinct ID, we can try using
+// the credentials provided -- for now this is just an Akita API Key ID.
+// To use a Postman API key we'd have to both obfuscate it (logging
+// the user's API key would be bad) and have a way to map it to a
+// particular user -- seems better to fall back to local IDs.
+func DistinctIDFromCredentials() string {
+	key, _ := GetPostmanAPIKeyAndEnvironment()
+	return key
+}

--- a/cfg/credentials.go
+++ b/cfg/credentials.go
@@ -136,6 +136,6 @@ func CredentialsPresent() bool {
 // the user's API key would be bad) and have a way to map it to a
 // particular user -- seems better to fall back to local IDs.
 func DistinctIDFromCredentials() string {
-	key, _ := GetPostmanAPIKeyAndEnvironment()
+	key, _ := GetAPIKeyAndSecret()
 	return key
 }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -122,8 +122,7 @@ func getDistinctID() string {
 	// If there's no credentials configured, skip the API call and
 	// do not emit a log message.
 	// Similarly if telemetry is disabled.
-	key, secret := cfg.GetAPIKeyAndSecret()
-	if key != "" && secret != "" && analyticsEnabled {
+	if cfg.CredentialsPresent() && analyticsEnabled {
 		// Call the REST API to get the user email associated with the configured
 		// API key.
 		ctx, cancel := context.WithTimeout(context.Background(), userAPITimeout)
@@ -145,8 +144,11 @@ func getDistinctID() string {
 		printer.Infof("but the agent will still attempt to send telemetry to Postman support.\n")
 	}
 
-	if key != "" {
-		return key
+	// Try to derive a distinct ID from the credentials, if present, even
+	// if the /v1/user call failed.
+	keyID := cfg.DistinctIDFromCredentials()
+	if keyID != "" {
+		return keyID
 	}
 
 	localUser, err := user.Current()


### PR DESCRIPTION
Previously we were calling /v1/users to get an email to use as a distinct ID only when an Akita API Key was present.