### PR TITLE
[OBS-407]Linux agent: Handle reconfiguration

### DIFF
--- a/cmd/internal/ec2/add.go
+++ b/cmd/internal/ec2/add.go
@@ -84,6 +84,10 @@ func askToReconfigure() error {
 		},
 		&isReconfigure,
 	)
+	if !isReconfigure {
+		printer.Infof("Exiting setup")
+		return nil
+	}
 	if err != nil {
 		return errors.Wrap(err, "failed to run reconfiguration prompt")
 	}

--- a/cmd/internal/ec2/add.go
+++ b/cmd/internal/ec2/add.go
@@ -118,7 +118,7 @@ func checkReconfiguration() error {
 	if strings.Contains(string(out), enabled) {
 		return askToReconfigure()
 	}
-	return errors.Errorf("The systemctl is-enabled command produced output this tool doesnt' recognize: %q. \n Please send this log message to observability-support@postman.com for assistance\n", string(out))
+	return errors.Errorf("The systemctl is-enabled command produced output this tool doesn't recognize: %q. \n Please send this log message to observability-support@postman.com for assistance\n", string(out))
 
 }
 

--- a/cmd/internal/ec2/add.go
+++ b/cmd/internal/ec2/add.go
@@ -105,7 +105,7 @@ func checkReconfiguration() error {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			exitCode := exitError.ExitCode()
 			if exitCode != 1 {
-				return errors.Wrapf(err, "Received non 1 exitcode for systemctl is-enabled.\n Please send this log message to observability-support@postman.com for assistance\n")
+				return errors.Wrapf(err, "Received non 1 exitcode for systemctl is-enabled. \n Command output:%s \n Please send this log message to observability-support@postman.com for assistance\n", out)
 			}
 			if strings.Contains(string(out), disabled) {
 				return askToReconfigure()

--- a/cmd/internal/ec2/add.go
+++ b/cmd/internal/ec2/add.go
@@ -85,7 +85,7 @@ func askToReconfigure() error {
 		&isReconfigure,
 	)
 	if !isReconfigure {
-		printer.Infof("Exiting setup")
+		printer.Infof("Exiting setup \n")
 		os.Exit(0)
 		return nil
 	}

--- a/cmd/internal/ec2/add.go
+++ b/cmd/internal/ec2/add.go
@@ -86,6 +86,7 @@ func askToReconfigure() error {
 	)
 	if !isReconfigure {
 		printer.Infof("Exiting setup")
+		os.Exit(0)
 		return nil
 	}
 	if err != nil {


### PR DESCRIPTION
### What
- Handle the case when linux setup command is run again on a system on which it was previously used.
- There can be three possibilities
    - systemd service exists and is enabled: Ask user if old values should be over-written with current input
    - systemd service exists and is disabled: Ask user if old values should be over-written with current input and enable the service
    - systemd service doesn't exist: Proceed with normal flow


Ticket: https://postmanlabs.atlassian.net/browse/OBS-407