### PR TITLE
[POA-484] Use postman's userID for telemetry userID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
-	github.com/akitasoftware/akita-libs v0.0.0-20231215074746-59e2f35abf36
+	github.com/akitasoftware/akita-libs v0.0.0-20240102045917-daed94f6a192
 	github.com/akitasoftware/go-utils v0.0.0-20221207014235-6f4c9079488d
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe/go.mod h1:W
 github.com/akitasoftware/akita-libs v0.0.0-20211020162041-fe02207174fb/go.mod h1:YLFCjhwQ0ZFfYWSUD2c9KYKEeBn+R+Cz+A5SitXvJz8=
 github.com/akitasoftware/akita-libs v0.0.0-20231215074746-59e2f35abf36 h1:7z3N2D1WNZBSwiVMBdvgq0jam2Vc/Hc6mr94Vdh8egg=
 github.com/akitasoftware/akita-libs v0.0.0-20231215074746-59e2f35abf36/go.mod h1:Wo3rkItMZBjXszdCutVK5I6QNMMEslN+ltRSS7C03jk=
+github.com/akitasoftware/akita-libs v0.0.0-20240102045917-daed94f6a192 h1:GIkafn5zQeWOUudECRkJnrxa7+8hPZRerwwmIxa0hFs=
+github.com/akitasoftware/akita-libs v0.0.0-20240102045917-daed94f6a192/go.mod h1:Wo3rkItMZBjXszdCutVK5I6QNMMEslN+ltRSS7C03jk=
 github.com/akitasoftware/go-utils v0.0.0-20221207014235-6f4c9079488d h1:pN1dbNacZ/mvlU1NcJVDxqmKnrDQDTVaN6iKOarfdYM=
 github.com/akitasoftware/go-utils v0.0.0-20221207014235-6f4c9079488d/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -132,6 +132,11 @@ func getDistinctID() string {
 		frontClient := rest.NewFrontClient(rest.Domain, GetClientID())
 		userResponse, err := frontClient.GetUser(ctx)
 		if err == nil {
+			// If we have Postman's user's data use that, otherwise fallback to akita's user email.
+			if userResponse.PostmanUser != nil && userResponse.PostmanUser.UserID != "" {
+				return userResponse.PostmanUser.UserID
+			}
+
 			if userResponse.Email != "" {
 				return userResponse.Email
 			}


### PR DESCRIPTION
If Postman's user data is present in UserResponse from the front service, use it as userId for Amplitude's telemetry otherwise fallback to Akita's logic.

**PS:**
Update `akita-libs` package once it's PR is merged to master