### PR TITLE
POA-894 Fix default log format

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,8 +76,10 @@ func preRun(cmd *cobra.Command, args []string) {
 		printer.SwitchToJSON()
 	case "plain":
 		printer.SwitchToPlain()
-	case "color":
+	case "color", "colour":
 		// No change needed
+	case "":
+		// Default to 'colour'.
 	default:
 		// Use color
 		printer.Warningln("Unknown log format, using `color`.")


### PR DESCRIPTION
Fixes an annoyance introduced in #258.
Also accept 'colour' for log format.