### PR TITLE
chore: always use userID for telemetry distinctID

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -133,12 +133,7 @@ func getDistinctID() string {
 		frontClient := rest.NewFrontClient(rest.Domain, GetClientID())
 		userResponse, err := frontClient.GetUser(ctx)
 		if err == nil {
-			if userResponse.Email != "" {
-				return userResponse.Email
-			}
-
-			// Use the user ID if no email is present;
-			// this should be fixed in the current backend.
+			// User postman user's userID as distinctID for telemetry
 			return fmt.Sprint(userResponse.ID)
 		}
 


### PR DESCRIPTION
Remove the check for emailID in the `getDistinctID()` function in `telemetry.go`. We will now always user userID, i.e. user's Postman UserID

**PS:** Will update akita-libs version once it's PR is approved