### PR TITLE
POA-114 Add ecs cf-fragment and ecs task-def subcommands

### DIFF
--- a/aws_utils/cloudformation/ecs/types.go
+++ b/aws_utils/cloudformation/ecs/types.go
@@ -1,0 +1,63 @@
+package ecs_cloudformation_utils
+
+import (
+	"encoding/json"
+
+	"github.com/akitasoftware/go-utils/slices"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+)
+
+// The JSON and YAML representations of this type are suitable for use in AWS
+// CloudFormation templates.
+//
+// XXX This is incomplete. Currently, only those fields we use are listed here.
+//
+// The fields here are taken from
+// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinition.html.
+// Their types correspond to those defined in the AWS SDK v2.
+type containerDefinition struct {
+	Environment []keyValuePair `json:"Environment,omitempty"`
+	EntryPoint  []string       `json:"EntryPoint,omitempty"`
+	Essential   *bool          `json:"Essential,omitempty"`
+	Image       *string        `json:"Image,omitempty"`
+	Name        *string        `json:"Name,omitempty"`
+}
+
+func convertContainerDefinition(cd types.ContainerDefinition) containerDefinition {
+	return containerDefinition{
+		Name:        cd.Name,
+		Image:       cd.Image,
+		Essential:   cd.Essential,
+		EntryPoint:  cd.EntryPoint,
+		Environment: slices.Map(cd.Environment, convertKeyValuePair),
+	}
+}
+
+// The JSON and YAML representations of this type are suitable for use in AWS
+// CloudFormation templates.
+//
+// The fields here are taken from
+// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-definition-template.html.
+// Their types correspond to those defined in the AWS SDK v2.
+type keyValuePair struct {
+	Name  *string `json:"Name,omitempty"`
+	Value *string `json:"Value,omitempty"`
+}
+
+func convertKeyValuePair(kv types.KeyValuePair) keyValuePair {
+	return keyValuePair{
+		Name:  kv.Name,
+		Value: kv.Value,
+	}
+}
+
+func ContainerDefinitionToJSONForCloudformation(
+	cd types.ContainerDefinition,
+) ([]byte, error) {
+	// Indent five levels to line up with expected indent level of other container
+	// definitions in a task definition.
+	prefix := "                    "
+	result, err := json.MarshalIndent(convertContainerDefinition(cd), prefix, "    ")
+	result = append([]byte(prefix), result...)
+	return result, err
+}

--- a/aws_utils/cloudformation/ecs/types.go
+++ b/aws_utils/cloudformation/ecs/types.go
@@ -1,10 +1,13 @@
 package ecs_cloudformation_utils
 
 import (
+	"bytes"
 	"encoding/json"
+	"strings"
 
 	"github.com/akitasoftware/go-utils/slices"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"gopkg.in/yaml.v2"
 )
 
 // The JSON and YAML representations of this type are suitable for use in AWS
@@ -16,11 +19,11 @@ import (
 // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinition.html.
 // Their types correspond to those defined in the AWS SDK v2.
 type containerDefinition struct {
-	Environment []keyValuePair `json:"Environment,omitempty"`
-	EntryPoint  []string       `json:"EntryPoint,omitempty"`
-	Essential   *bool          `json:"Essential,omitempty"`
-	Image       *string        `json:"Image,omitempty"`
-	Name        *string        `json:"Name,omitempty"`
+	Name        *string        `json:"Name,omitempty" yaml:"Name,omitempty"`
+	Image       *string        `json:"Image,omitempty" yaml:"Image,omitempty"`
+	Environment []keyValuePair `json:"Environment,omitempty" yaml:"Environment,omitempty"`
+	EntryPoint  []string       `json:"EntryPoint,omitempty" yaml:"EntryPoint,omitempty"`
+	Essential   *bool          `json:"Essential,omitempty" yaml:"Essential,omitempty"`
 }
 
 func convertContainerDefinition(cd types.ContainerDefinition) containerDefinition {
@@ -40,8 +43,8 @@ func convertContainerDefinition(cd types.ContainerDefinition) containerDefinitio
 // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-definition-template.html.
 // Their types correspond to those defined in the AWS SDK v2.
 type keyValuePair struct {
-	Name  *string `json:"Name,omitempty"`
-	Value *string `json:"Value,omitempty"`
+	Name  *string `json:"Name,omitempty" yaml:"Name,omitempty"`
+	Value *string `json:"Value,omitempty" yaml:"Value,omitempty"`
 }
 
 func convertKeyValuePair(kv types.KeyValuePair) keyValuePair {
@@ -51,13 +54,39 @@ func convertKeyValuePair(kv types.KeyValuePair) keyValuePair {
 	}
 }
 
-func ContainerDefinitionToJSONForCloudformation(
+func ContainerDefinitionToJSONForCloudFormation(
 	cd types.ContainerDefinition,
-) ([]byte, error) {
+) (string, error) {
 	// Indent five levels to line up with expected indent level of other container
 	// definitions in a task definition.
 	prefix := "                    "
 	result, err := json.MarshalIndent(convertContainerDefinition(cd), prefix, "    ")
 	result = append([]byte(prefix), result...)
-	return result, err
+	return string(result), err
+}
+
+func ContainerDefinitionToYAMLForCloudFormation(
+	cd types.ContainerDefinition,
+) (string, error) {
+	// Put the container definition in a list, so it can be easily appended to an
+	// existing list of container definitions.
+	containerDefs := []containerDefinition{
+		convertContainerDefinition(cd),
+	}
+
+	yamlBytes, err := yaml.Marshal(
+		containerDefs,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	// Trim off any extraneous newlines.
+	yamlBytes = bytes.Trim(yamlBytes, "\n")
+
+	// Indent four levels to line up with the expected indent level of the other
+	// container definitions in a task definition.
+	prefix := "        "
+	result := prefix + strings.ReplaceAll(string(yamlBytes), "\n", "\n"+prefix)
+	return result, nil
 }

--- a/aws_utils/console/ecs/types.go
+++ b/aws_utils/console/ecs/types.go
@@ -1,0 +1,104 @@
+package ecs_console_utils
+
+import (
+	"encoding/json"
+
+	"github.com/akitasoftware/go-utils/slices"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+)
+
+// A type whose JSON representation is suitable for use with the AWS console for
+// creating a ECS task definition.
+//
+// XXX This is incomplete. Currently, only those fields we use are listed here.
+//
+// The fields here are taken from
+// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-definition-template.html.
+// Their types correspond to those defined in the AWS SDK v2.
+type taskDefinition struct {
+	Family                  *string               `json:"family,omitempty"`
+	NetworkMode             types.NetworkMode     `json:"networkMode,omitempty"`
+	ContainerDefinitions    []containerDefinition `json:"containerDefinitions,omitempty"`
+	RequiresCompatibilities []types.Compatibility `json:"requiresCompatibilities,omitempty"`
+	CPU                     *string               `json:"cpu,omitempty"`
+	Memory                  *string               `json:"memory,omitempty"`
+	RuntimePlatform         *runtimePlatform      `json:"runtimePlatform,omitempty"`
+}
+
+func convertTaskDefinition(td types.TaskDefinition) taskDefinition {
+	return taskDefinition{
+		Family:                  td.Family,
+		NetworkMode:             td.NetworkMode,
+		ContainerDefinitions:    slices.Map(td.ContainerDefinitions, convertContainerDefinition),
+		RequiresCompatibilities: td.RequiresCompatibilities,
+		CPU:                     td.Cpu,
+		Memory:                  td.Memory,
+		RuntimePlatform:         convertRuntimePlatform(td.RuntimePlatform),
+	}
+}
+
+// A container definition within a task definition. The JSON representation of
+// this type is suitable for use with the AWS console.
+//
+// XXX This is incomplete. Currently, only those fields we use are listed here.
+//
+// The fields here are taken from
+// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-definition-template.html.
+// Their types correspond to those defined in the AWS SDK v2.
+type containerDefinition struct {
+	Name        *string        `json:"name,omitempty"`
+	Image       *string        `json:"image,omitempty"`
+	Essential   *bool          `json:"essential,omitempty"`
+	EntryPoint  []string       `json:"entryPoint,omitempty"`
+	Environment []keyValuePair `json:"environment,omitempty"`
+}
+
+func convertContainerDefinition(cd types.ContainerDefinition) containerDefinition {
+	return containerDefinition{
+		Name:        cd.Name,
+		Image:       cd.Image,
+		Essential:   cd.Essential,
+		EntryPoint:  cd.EntryPoint,
+		Environment: slices.Map(cd.Environment, convertKeyValuePair),
+	}
+}
+
+// The JSON representation of this type is suitable for use with the AWS
+// console.
+//
+// The fields here are taken from
+// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-definition-template.html.
+// Their types correspond to those defined in the AWS SDK v2.
+type keyValuePair struct {
+	Name  *string `json:"name,omitempty"`
+	Value *string `json:"value,omitempty"`
+}
+
+func convertKeyValuePair(kv types.KeyValuePair) keyValuePair {
+	return keyValuePair{
+		Name:  kv.Name,
+		Value: kv.Value,
+	}
+}
+
+// The JSON representation of this type is suitable for use with the AWS
+// console.
+//
+// The fields here are taken from
+// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-definition-template.html.
+// Their types correspond to those defined in the AWS SDK v2.
+type runtimePlatform struct {
+	CpuArchitecture       types.CPUArchitecture `json:"cpuArchitecture,omitempty"`
+	OperatingSystemFamily types.OSFamily        `json:"operatingSystemFamily,omitempty"`
+}
+
+func convertRuntimePlatform(rp *types.RuntimePlatform) *runtimePlatform {
+	return &runtimePlatform{
+		CpuArchitecture:       rp.CpuArchitecture,
+		OperatingSystemFamily: rp.OperatingSystemFamily,
+	}
+}
+
+func TaskDefinitionToJSONForConsole(td types.TaskDefinition) ([]byte, error) {
+	return json.MarshalIndent(convertTaskDefinition(td), "", "  ")
+}

--- a/cmd/internal/ecs/add.go
+++ b/cmd/internal/ecs/add.go
@@ -961,6 +961,9 @@ func makeAgentContainerDefinition(
 		}
 	}
 
+	// XXX If we instantiate any new fields in the container definition here, we
+	// need to remember to update the serialization code in
+	// printECSTaskDefinition.
 	return types.ContainerDefinition{
 		Name:        aws.String("postman-insights-agent"),
 		EntryPoint:  entryPoint,

--- a/cmd/internal/ecs/add.go
+++ b/cmd/internal/ecs/add.go
@@ -943,22 +943,11 @@ func makeAgentContainerDefinition(
 	addOptToEnv("POSTMAN_ECS_SERVICE", ecsService)
 	addOptToEnv("POSTMAN_ECS_TASK", ecsTaskDefinitionFamily)
 
-	var entryPoint []string
-
-	if collectionId != "" {
-		entryPoint = []string{
-			"/postman-insights-agent",
-			"apidump",
-			"--collection",
-			collectionId,
-		}
-	} else {
-		entryPoint = []string{
-			"/postman-insights-agent",
-			"apidump",
-			"--project",
-			projectId,
-		}
+	entryPoint := []string{
+		"/postman-insights-agent",
+		"apidump",
+		"--project",
+		projectId,
 	}
 
 	// XXX If we instantiate any new fields in the container definition here, we

--- a/cmd/internal/ecs/add.go
+++ b/cmd/internal/ecs/add.go
@@ -962,8 +962,8 @@ func makeAgentContainerDefinition(
 	}
 
 	// XXX If we instantiate any new fields in the container definition here, we
-	// need to remember to update the serialization code in
-	// printECSTaskDefinition.
+	// need to remember to update the code in the ecs_console_utils and the
+	// ecs_cloudformation_utils packages.
 	return types.ContainerDefinition{
 		Name:        aws.String("postman-insights-agent"),
 		EntryPoint:  entryPoint,

--- a/cmd/internal/ecs/ecs.go
+++ b/cmd/internal/ecs/ecs.go
@@ -36,6 +36,9 @@ var (
 	// Location of credentials file.
 	awsCredentialsFlag string
 
+	// Output in YAML instead of JSON.
+	yamlFlag bool
+
 	// Print out the steps that would be taken, but do not do them
 	dryRunFlag bool
 )
@@ -106,6 +109,13 @@ func init() {
 		"dry-run",
 		false,
 		"Perform a dry run: show what will be done, but do not modify ECS.",
+	)
+
+	PrintCloudFormationFragmentCmd.Flags().BoolVar(
+		&yamlFlag,
+		"yaml",
+		false,
+		"Output as YAML instead of JSON",
 	)
 
 	// Support for credentials in a nonstandard location
@@ -181,12 +191,16 @@ func printCloudFormationFragment(cmd *cobra.Command, args []string) error {
 		isEssential,
 	)
 
-	result, err := ecs_cloudformation_utils.ContainerDefinitionToJSONForCloudformation(agentContainer)
+	formatter := ecs_cloudformation_utils.ContainerDefinitionToJSONForCloudFormation
+	if yamlFlag {
+		formatter = ecs_cloudformation_utils.ContainerDefinitionToYAMLForCloudFormation
+	}
+	result, err := formatter(agentContainer)
 	if err != nil {
-		return errors.Wrapf(err, "unable to format container definition as JSON")
+		return errors.Wrapf(err, "unable to format CloudFormation fragment")
 	}
 
-	fmt.Println(string(result))
+	fmt.Println(result)
 	return nil
 }
 

--- a/cmd/internal/ecs/ecs.go
+++ b/cmd/internal/ecs/ecs.go
@@ -238,7 +238,7 @@ func printECSTaskDefinition(cmd *cobra.Command, args []string) error {
 		"requiresCompatibilities": []types.Compatibility{
 			types.CompatibilityEc2,
 		},
-		"cpu":    "256",
+		"cpu":    "512",
 		"memory": "512",
 		"runtimePlatform": map[string]any{
 			"cpuArchitecture":       types.CPUArchitectureX8664,

--- a/cmd/internal/ecs/ecs.go
+++ b/cmd/internal/ecs/ecs.go
@@ -1,16 +1,17 @@
 package ecs
 
 import (
-	"encoding/json"
 	"fmt"
 
+	ecs_cloudformation_utils "github.com/akitasoftware/akita-cli/aws_utils/cloudformation/ecs"
+	ecs_console_utils "github.com/akitasoftware/akita-cli/aws_utils/console/ecs"
 	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
 	"github.com/akitasoftware/akita-cli/rest"
 	"github.com/akitasoftware/akita-cli/telemetry"
 	"github.com/akitasoftware/akita-cli/util"
 	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/go-utils/optionals"
-	"github.com/akitasoftware/go-utils/slices"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -180,7 +181,7 @@ func printCloudFormationFragment(cmd *cobra.Command, args []string) error {
 		isEssential,
 	)
 
-	result, err := json.MarshalIndent(agentContainer, "", "  ")
+	result, err := ecs_cloudformation_utils.ContainerDefinitionToJSONForCloudformation(agentContainer)
 	if err != nil {
 		return errors.Wrapf(err, "unable to format container definition as JSON")
 	}
@@ -203,50 +204,24 @@ func printECSTaskDefinition(cmd *cobra.Command, args []string) error {
 		isEssential,
 	)
 
-	// XXX Whereas the AWS SDK defines a `types.TaskDefinition`, that type is
-	// intended for use in calling the AWS APIs, not for printing JSON fragments
-	// for pasting into the AWS console. We therefore take the brittle approach of
-	// manually cobbling together an object that will serialize to the appropriate
-	// JSON value.
-	taskDefinition := map[string]any{
-		"containerDefinitions": []map[string]any{
-			{
-				// XXX Omitting a bunch of fields here. If any omitted field gets
-				// instantiated in makeAgentContainerDefinition, that value will not be
-				// included here unless we remember to update this code.
-				"entryPoint": agentContainer.EntryPoint,
-				"environment": slices.Map(
-					agentContainer.Environment,
-					func(kv types.KeyValuePair) map[string]string {
-						result := map[string]string{}
-						if kv.Name != nil {
-							result["name"] = *kv.Name
-						}
-						if kv.Value != nil {
-							result["value"] = *kv.Value
-						}
-						return result
-					},
-				),
-				"essential": optionals.ToOptional(agentContainer.Essential).GetOrDefault(false),
-				"image":     agentContainer.Image,
-				"name":      agentContainer.Name,
-			},
-		},
-		"family":      "postman-insights-agent",
-		"networkMode": types.NetworkModeHost,
-		"requiresCompatibilities": []types.Compatibility{
+	// XXX If we instantiate any new fields in the task definition here, we need
+	// to remember to update the code in the ecs_console_utils package.
+	taskDefinition := types.TaskDefinition{
+		ContainerDefinitions: []types.ContainerDefinition{agentContainer},
+		Family:               aws.String("postman-insights-agent"),
+		NetworkMode:          types.NetworkModeHost,
+		RequiresCompatibilities: []types.Compatibility{
 			types.CompatibilityEc2,
 		},
-		"cpu":    "512",
-		"memory": "512",
-		"runtimePlatform": map[string]any{
-			"cpuArchitecture":       types.CPUArchitectureX8664,
-			"operatingSystemFamily": types.OSFamilyLinux,
+		Cpu:    aws.String("512"),
+		Memory: aws.String("512"),
+		RuntimePlatform: &types.RuntimePlatform{
+			CpuArchitecture:       types.CPUArchitectureX8664,
+			OperatingSystemFamily: types.OSFamilyLinux,
 		},
 	}
 
-	result, err := json.MarshalIndent(taskDefinition, "", "  ")
+	result, err := ecs_console_utils.TaskDefinitionToJSONForConsole(taskDefinition)
 	if err != nil {
 		return errors.Wrapf(err, "unable to format task definition as JSON")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,7 +89,7 @@ func preRun(cmd *cobra.Command, args []string) {
 	// Somehow, this doesn't appear before "postman-insights-agent --version"
 	// (good) or "postman-insights-agent --help" (less good), only before
 	// commands or the usage information if no command is given.
-	printer.Stdout.Infof("Postman Insights Agent %s\n", version.ReleaseVersion())
+	printer.Stderr.Infof("Postman Insights Agent %s\n", version.ReleaseVersion())
 
 	// This is after argument parsing so that rest.Domain is correct,
 	// but won't be called if there is an error parsing the flags.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe
 	github.com/akitasoftware/akita-libs v0.0.0-20240415065826-ff8036138dc1
-	github.com/akitasoftware/go-utils v0.0.0-20221207014235-6f4c9079488d
+	github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803
 	github.com/akitasoftware/plugin-flickr v0.2.0
 	github.com/andybalholm/brotli v1.0.1
 	github.com/aws/aws-sdk-go-v2 v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/akitasoftware/akita-ir v0.0.0-20220630210013-8926783978fe/go.mod h1:W
 github.com/akitasoftware/akita-libs v0.0.0-20211020162041-fe02207174fb/go.mod h1:YLFCjhwQ0ZFfYWSUD2c9KYKEeBn+R+Cz+A5SitXvJz8=
 github.com/akitasoftware/akita-libs v0.0.0-20240415065826-ff8036138dc1 h1:z2VL5kA1ogtMU92PTzArL+ipGpZLPAWJYY9ent/0BrE=
 github.com/akitasoftware/akita-libs v0.0.0-20240415065826-ff8036138dc1/go.mod h1:kDm2NMNWts5dJHpVMhFznr+G1Hk/zz80l6aOZ+2fPdc=
-github.com/akitasoftware/go-utils v0.0.0-20221207014235-6f4c9079488d h1:pN1dbNacZ/mvlU1NcJVDxqmKnrDQDTVaN6iKOarfdYM=
-github.com/akitasoftware/go-utils v0.0.0-20221207014235-6f4c9079488d/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
+github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803 h1:ebIh/EFuaP8GczzMe8EwVID/blSv5Tej6S8NE4xyarQ=
+github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b h1:toBhS5rhCjo/N4YZ1cYtlsdSTGjMFH+gbJGCc+OmZiY=
 github.com/akitasoftware/gopacket v1.1.18-0.20210730205736-879e93dac35b/go.mod h1:wteInquxIdgWpGJEJmJEMJVtqM2i2vFZJ4W7B8G9ex8=
 github.com/akitasoftware/martian/v3 v3.0.1-0.20210608174341-829c1134e9de h1:rWkji88f/EWUY+qGc6pEyhpjgFbpsXwrnlTDTu5mLjY=


### PR DESCRIPTION
Added `ecs cf-fragment` subcommand for printing an AWS CloudFormation fragment for adding the agent to ECS as a sidecar.

Added `ecs task-def` subcommand for printing a task definition that can be added to an ECS cluster to run the agent as a daemon in host-networking mode on every EC2 instance in the cluster.

Removed `--collection` from `ecs` subcommands.