### PR TITLE
[POA-168] Clean up authentication messages

### DIFF
--- a/cmd/internal/cmderr/checks.go
+++ b/cmd/internal/cmderr/checks.go
@@ -17,10 +17,10 @@ func RequirePostmanAPICredentials(explanation string) (string, error) {
 		if env.InDocker() {
 			printer.Infof("Please set the POSTMAN_API_KEY environment variables on the Docker command line.\n")
 		} else {
-			printer.Infof("Use the POSTMAN_API_KEY environment variables, or run 'postman-insights-agent login'.\n")
+			printer.Infof("Please set the POSTMAN_API_KEY environment variables, either in your shell session or prepend it to postman-insights-agent command.\n")
 		}
-
-		return "", AkitaErr{Err: errors.New("could not find an Postman API key to use")}
+		//lint:ignore ST1005 This is a user-facing error message
+		return "", AkitaErr{Err: errors.New("Could not find an Postman API key to use")}
 	}
 
 	return key, nil

--- a/cmd/internal/cmderr/checks.go
+++ b/cmd/internal/cmderr/checks.go
@@ -20,7 +20,7 @@ func RequirePostmanAPICredentials(explanation string) (string, error) {
 			printer.Infof("Please set the POSTMAN_API_KEY environment variables, either in your shell session or prepend it to postman-insights-agent command.\n")
 		}
 		//lint:ignore ST1005 This is a user-facing error message
-		return "", AkitaErr{Err: errors.New("Could not find an Postman API key to use")}
+		return "", AkitaErr{Err: errors.New("Could not find a Postman API key to use")}
 	}
 
 	return key, nil

--- a/cmd/internal/cmderr/checks.go
+++ b/cmd/internal/cmderr/checks.go
@@ -15,9 +15,9 @@ func RequirePostmanAPICredentials(explanation string) (string, error) {
 	if key == "" {
 		printer.Errorf("No Postman API key configured. %s\n", explanation)
 		if env.InDocker() {
-			printer.Infof("Please set the POSTMAN_API_KEY environment variables on the Docker command line.\n")
+			printer.Infof("Please set the POSTMAN_API_KEY environment variable on the Docker command line.\n")
 		} else {
-			printer.Infof("Please set the POSTMAN_API_KEY environment variables, either in your shell session or prepend it to postman-insights-agent command.\n")
+			printer.Infof("Please set the POSTMAN_API_KEY environment variable, either in your shell session or prepend it to postman-insights-agent command.\n")
 		}
 		//lint:ignore ST1005 This is a user-facing error message
 		return "", AkitaErr{Err: errors.New("Could not find a Postman API key to use")}

--- a/cmd/internal/ecs/ecs.go
+++ b/cmd/internal/ecs/ecs.go
@@ -150,7 +150,7 @@ func checkAPIKeyAndProjectID() error {
 		return err
 	}
 
-	// Check that a collection or project is provided.
+	// Check that project ID is provided.
 	if projectId == "" {
 		return errors.New("--project must be specified")
 	}

--- a/rest/http.go
+++ b/rest/http.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/akitasoftware/akita-cli/cfg"
+	"github.com/akitasoftware/akita-cli/consts"
 	"github.com/akitasoftware/akita-cli/printer"
 	"github.com/akitasoftware/akita-cli/version"
 	"github.com/akitasoftware/akita-libs/spec_util"
@@ -22,6 +23,9 @@ import (
 const (
 	// TODO: Make this tunable.
 	defaultClientTimeout = 5 * time.Second
+	unexpectedErrMsg     = "Unexpected error occured while making request, status code: %d. " +
+		"If the issue persists, run the agent with debug logs enabled (--debug), and " +
+		"contact Postman support (" + consts.SupportEmail + ") with the error logs."
 )
 
 var (
@@ -40,7 +44,8 @@ func (he HTTPError) Error() string {
 	if he.StatusCode == 401 {
 		return `Invalid credentials. Ensure the POSTMAN_API_KEY environment variable has a valid API key for Postman.`
 	}
-	return fmt.Sprintf("received status code %d, body: %s", he.StatusCode, string(he.Body))
+	printer.Debugln("Unexpected error, received status code", he.StatusCode, "body:", string(he.Body))
+	return fmt.Sprintf(unexpectedErrMsg, he.StatusCode)
 }
 
 // Implements retryablehttp LeveledLogger interface using printer.

--- a/rest/http.go
+++ b/rest/http.go
@@ -44,7 +44,7 @@ func (he HTTPError) Error() string {
 	if he.StatusCode == 401 {
 		return `Invalid credentials. Ensure the POSTMAN_API_KEY environment variable has a valid API key for Postman.`
 	}
-	printer.Debugln("Unexpected error, received status code", he.StatusCode, "body:", string(he.Body))
+	printer.Debugln("Unexpected error, received status code:", he.StatusCode, "body:", string(he.Body))
 	return fmt.Sprintf(unexpectedErrMsg, he.StatusCode)
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -98,7 +98,7 @@ func GetServiceIDByName(c rest.FrontClient, name string) (akid.ServiceID, error)
 }
 
 func GetServiceNameByServiceID(c rest.FrontClient, serviceID akid.ServiceID) (string, error) {
-	unexpectedErrMsg := "Something went wrong while starting the Agent. " +
+	unexpectedErrMsg := "Something went wrong while starting the agent. " +
 		"Please contact Postman support (" + consts.SupportEmail + ") with the error details"
 	failedToGetProjectErrMsg := "Failed to get project for given projectID: %s\n"
 
@@ -173,8 +173,7 @@ func GetServiceIDByPostmanCollectionID(c rest.FrontClient, ctx context.Context, 
 func GetOrCreateServiceIDByPostmanCollectionID(c rest.FrontClient, collectionID string) (akid.ServiceID, error) {
 	// Normalize the collectionID.
 	collectionID = strings.ToLower(collectionID)
-	unexpectedErrMsg := "Something went wrong while starting the Agent. " +
-		"Please contact Postman support (" + consts.SupportEmail + ") with the error details"
+	unexpectedErrMsg := "Something went wrong while starting the agent."
 	failedToCreateProjectErrMsg := "Failed to create project for given collectionID: %s\n"
 
 	if id, found := postmanCollectionIDCache.Get(collectionID); found {


### PR DESCRIPTION
In this PR, we have updated some of the error messages shown to users in case of errors.
* Remove mention of login command with postman-insights-agent
* Remove mention of contacting the postman support team if a user is using --collection flag
* The 3rd message mentioned in the JIRA ticket has already been fixed in earlier releases.
* Don't show the raw response body to the user for external API call errors; instead, show a generic message for unhandled cases.


**PS**: To show the user the proper message, we will need to follow a standard error response model, which will involve changes in both the Agent and Superstar services. Otherwise, we will face issues in mapping the response to the proper Golang object.
